### PR TITLE
allow deploying to multiple stacks in the same account

### DIFF
--- a/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json
@@ -224,8 +224,7 @@
         },
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
-        ],
-        "RoleName": "CWAgentECSTaskRole"
+        ]
       }
     },
     "ECSExecutionRole": {
@@ -249,8 +248,7 @@
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
           "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
-        ],
-        "RoleName": "CWAgentECSExecutionRole"
+        ]
       }
     }
   }


### PR DESCRIPTION
Using named roles prevents this stack from being deployed to multiple clusters in the same AWS account, and requires CAPABILITY_NAMED_IAM. 

Physical role names aren't really important for the functioning here, and removing role names lets CFN auto-generate unique names, so the stack can be deployed safely multiple times in the same account to work with different clusters, and requires lower capabilities for deployment

*Description of changes:* Removed role names to let CFN automatically generate them

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
