### PR TITLE
Add Sample CloudWatch Dashboards for Prometheus Metircs

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/README.md
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/README.md
@@ -1,0 +1,7 @@
+## Sample CloudWatch Dashboards
+
+This directory contains sample CloudWatch dashboards based on the default EMF metrics configurations in [prometheus-eks.yaml](../prometheus-eks.yaml) and [prometheus-k8s.yaml](../prometheus-k8s.yaml).
+
+* [appmesh](appmesh) provides sample CloudWatch dashboard for [AWS App Mesh](https://aws.amazon.com/app-mesh/) Prometheus metrics.
+* [javajmx](javajmx) provides sample CloudWatch dashboard for [JMX_Exporter](https://github.com/prometheus/jmx_exporter) Prometheus metrics.
+* [nginx-ingress](nginx-ingress) provides sample CloudWatch dashboard for [Nginx-Ingress](https://github.com/helm/charts/tree/master/stable/nginx-ingress) Prometheus metrics.

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/appmesh/README.md
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/appmesh/README.md
@@ -1,0 +1,2 @@
+## Sample CloudWatch Dashboard for AWS App Mesh Prometheus Metrics
+Please refer to [TBD](tbd.html) for the usage guide.

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/appmesh/cw_dashboard_awsappmesh.json
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/appmesh/cw_dashboard_awsappmesh.json
@@ -1,0 +1,352 @@
+{
+    "widgets": [
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 1,
+            "width": 3,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName, Namespace} envoy_server_live', 'Sum', 60))", "label": "Count", "id": "e2", "region": "us-east-1" } ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Sum",
+                "period": 60,
+                "title": "Meshed Pods"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 4,
+            "width": 3,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "AVG(REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_server_uptime', 'Average', 60)/3600))", "label": "hour", "id": "e1", "region": "us-east-1" } ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Sum",
+                "period": 300,
+                "setPeriodToTimeRange": false,
+                "title": "Average Uptime"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 12,
+            "y": 4,
+            "width": 6,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "AVG(REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_cx_connect_timeout', 'Average', 60)))", "id": "e2" } ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Sum",
+                "period": 300,
+                "start": "-PT1H",
+                "end": "P0D",
+                "setPeriodToTimeRange": false,
+                "title": "Connection Timeouts"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 7,
+            "width": 18,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "SUM(REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_cx_rx_bytes_total', 'Sum', 60)))/60", "id": "e1", "label": "InBound (TX)", "region": "us-east-1" } ],
+                    [ { "expression": "SUM(REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_cx_tx_bytes_total', 'Sum', 60)))/60", "id": "e2", "label": "OutBound (RX)", "region": "us-east-1" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Sum",
+                "period": 300,
+                "setPeriodToTimeRange": false,
+                "title": "Total Traffic (inbound & outbound) "
+            }
+        },
+        {
+            "type": "metric",
+            "x": 3,
+            "y": 4,
+            "width": 3,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "SUM(REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_cx_rx_bytes_total', 'Sum', 60)))/60", "id": "e1", "region": "us-east-1", "label": "kbps" } ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Sum",
+                "period": 60,
+                "setPeriodToTimeRange": false,
+                "title": "Inbound Traffic"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 6,
+            "y": 4,
+            "width": 3,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "SUM(REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_cx_tx_bytes_total', 'Sum', 60)))/60", "id": "e1", "region": "us-east-1", "label": "kbps" } ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Sum",
+                "period": 60,
+                "setPeriodToTimeRange": false,
+                "title": "Outbound Traffic"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 9,
+            "y": 4,
+            "width": 3,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "SUM(REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_membership_total', 'Sum', 60))) - SUM(REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_membership_healthy', 'Sum', 60)))", "id": "e1", "region": "us-east-1", "label": "" } ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Sum",
+                "period": 300,
+                "setPeriodToTimeRange": false,
+                "title": "Unhealthy Pods"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 9,
+            "y": 1,
+            "width": 3,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_server_memory_heap_size', 'Sum', 60))", "id": "e2", "period": 300, "region": "us-east-1", "label": "" } ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Sum",
+                "period": 300,
+                "setPeriodToTimeRange": false,
+                "title": "Total Envoy Heap"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 12,
+            "y": 1,
+            "width": 6,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_server_memory_allocated', 'Sum', 60))", "id": "e2", "period": 300, "region": "us-east-1", "label": "" } ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Sum",
+                "period": 300,
+                "setPeriodToTimeRange": false,
+                "title": "Total Envoy Memory Usage"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 3,
+            "y": 1,
+            "width": 3,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_http_downstream_rq_total', 'Sum', 60))/60", "id": "e1", "label": "rps" } ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Sum",
+                "period": 300,
+                "start": "-PT1H",
+                "end": "P0D",
+                "setPeriodToTimeRange": false,
+                "title": "Requests/Second"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 6,
+            "y": 1,
+            "width": 3,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "(SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx$ (envoy_http_conn_manager_prefix=\"ingress\" OR envoy_http_conn_manager_prefix=\"egress\") envoy_response_code_class=\"4\"', 'Sum', 60)) + SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx$ (envoy_http_conn_manager_prefix=\"ingress\" OR envoy_http_conn_manager_prefix=\"egress\") envoy_response_code_class=\"5\"', 'Sum', 60)))/60", "id": "e2", "period": 60, "label": "" } ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Sum",
+                "period": 60,
+                "setPeriodToTimeRange": false,
+                "title": "Failures/Second"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 13,
+            "width": 9,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"ingress\" envoy_response_code_class=\"2\"', 'Sum', 60))/60", "id": "e3", "label": "[avg: ${AVG}] HTTP 2XX" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"ingress\" envoy_response_code_class=\"1\"', 'Sum', 60))/60", "id": "e2", "label": "[avg: ${AVG}] HTTP 1XX" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"ingress\" envoy_response_code_class=\"3\"', 'Sum', 60))/60", "id": "e4", "label": "[avg: ${AVG}] HTTP 3XX" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"ingress\" envoy_response_code_class=\"4\"', 'Sum', 60))/60", "id": "e5", "label": "[avg: ${AVG}] HTTP 4XX" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"ingress\" envoy_response_code_class=\"5\"', 'Sum', 60))/60", "id": "e1", "label": "[avg: ${AVG}] HTTP 5XX" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 300,
+                "title": "Ingress HTTP Requests/sec"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 9,
+            "y": 13,
+            "width": 9,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"egress\" envoy_response_code_class=\"2\"', 'Sum', 60))/60", "id": "e3", "label": "[avg: ${AVG}] HTTP 2XX", "region": "us-east-1" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"egress\" envoy_response_code_class=\"1\"', 'Sum', 60))/60", "id": "e2", "label": "[avg: ${AVG}] HTTP 1XX", "region": "us-east-1" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"egress\" envoy_response_code_class=\"3\"', 'Sum', 60))/60", "id": "e4", "label": "[avg: ${AVG}] HTTP 3XX", "region": "us-east-1" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"egress\" envoy_response_code_class=\"4\"', 'Sum', 60))/60", "id": "e5", "label": "[avg: ${AVG}] HTTP 4XX", "region": "us-east-1" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"egress\" envoy_response_code_class=\"5\"', 'Sum', 60))/60", "id": "e1", "label": "[avg: ${AVG}] HTTP 5XX", "region": "us-east-1" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 300,
+                "title": "Egress HTTP Requests/sec"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 19,
+            "width": 9,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_pending_failure_eject', 'Sum', 60))/60", "id": "e2", "label": "[min: ${MIN}, max: ${MAX}, avg: ${AVG}, last: ${LAST}] pending failure ejection" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_pending_overflow', 'Sum', 60))/60", "id": "e3", "label": "[min: ${MIN}, max: ${MAX}, avg: ${AVG}, last: ${LAST}] pending overflow" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_cx_connect_timeout', 'Sum', 60))/60", "id": "e1", "label": "[min: ${MIN}, max: ${MAX}, avg: ${AVG}, last: ${LAST}] connect timeout" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_timeout', 'Sum', 60))/60", "id": "e4", "label": "[min: ${MIN}, max: ${MAX}, avg: ${AVG}, last: ${LAST}] request timeout" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_per_try_timeout', 'Sum', 60))/60", "id": "e5", "label": "[min: ${MIN}, max: ${MAX}, avg: ${AVG}, last: ${LAST}] per try request timeout" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_rx_reset', 'Sum', 60))/60", "id": "e6", "label": "[min: ${MIN}, max: ${MAX}, avg: ${AVG}, last: ${LAST}] request reset" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_cx_destroy_local_with_active_rq', 'Sum', 60))/60", "id": "e7", "label": "[min: ${MIN}, max: ${MAX}, avg: ${AVG}, last: ${LAST}] destroy initialized from originating service" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_http_downstream_cx_destroy_remote_active_rq', 'Sum', 60))/60", "id": "e8", "label": "[min: ${MIN}, max: ${MAX}, avg: ${AVG}, last: ${LAST}] destroy initialized from remote service" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_maintenance_mode', 'Sum', 60))/60", "id": "e9", "label": "[min: ${MIN}, max: ${MAX}, avg: ${AVG}, last: ${LAST}] request failed maintenance mode" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 300,
+                "title": "Upstream Request Errors"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 9,
+            "y": 19,
+            "width": 9,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_flow_control_paused_reading_total', 'Sum', 60))/60", "id": "e1", "label": "[avg: ${AVG}] paused reading from destination service", "region": "us-east-1" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_flow_control_resumed_reading_total', 'Sum', 60))/60", "id": "e2", "label": "[avg: ${AVG}] resumed reading from destination service", "region": "us-east-1" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_flow_control_backed_up_total', 'Sum', 60))/60", "id": "e3", "label": "[avg: ${AVG}] paused reading from originating service", "region": "us-east-1" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_flow_control_drained_total', 'Sum', 60))/60", "id": "e4", "label": "[avg: ${AVG}] resumed reading from originating service", "region": "us-east-1" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 300,
+                "title": "Upstream Flow Control"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 25,
+            "width": 18,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_flow_control_resumed_reading_total', 'Sum', 60))/60", "id": "e2", "label": "[avg: ${AVG}] request retry", "region": "us-east-1" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_retry_success', 'Sum', 60))/60", "id": "e1", "label": "[avg: ${AVG}] request retry success", "region": "us-east-1" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_retry_overflow', 'Sum', 60))/60", "id": "e3", "label": "[avg: ${AVG}] request retry overflow", "region": "us-east-1" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 300,
+                "title": "Upstream Request Retry"
+            }
+        },
+        {
+            "type": "text",
+            "x": 0,
+            "y": 0,
+            "width": 18,
+            "height": 1,
+            "properties": {
+                "markdown": "\n# AWS App Mesh\n"
+            }
+        },
+        {
+            "type": "log",
+            "x": 0,
+            "y": 31,
+            "width": 18,
+            "height": 6,
+            "properties": {
+                "query": "SOURCE '/aws/containerinsights/<CLUSTER-NAME>/prometheus' | fields Namespace, app, pod_name, @message\n| limit 50\n| filter CloudWatchMetrics.0.Namespace=\"ContainerInsights/Prometheus\"\n| filter CloudWatchMetrics.0.Metrics.0.Name like /envoy_/\n| stats sum(envoy_cluster_upstream_cx_rx_bytes_buffered) as bytes_rx_buffered, sum(envoy_cluster_upstream_cx_tx_bytes_buffered) as bytes_tx_buffered, sum(envoy_http_downstream_rq_xx) as http_downstream_rq_xx by app, pod_name\n| sort bytes_rx_buffered desc \n",
+                "region": "us-east-1",
+                "stacked": false,
+                "title": "Summary by App",
+                "view": "table"
+            }
+        }
+    ]
+}

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/javajmx/README.md
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/javajmx/README.md
@@ -1,0 +1,2 @@
+## Sample CloudWatch Dashboard for Java JMX Prometheus Metrics
+Please refer to [TBD](tbd.html) for the usage guide.

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/javajmx/cw_dashboard_javajmx.json
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/javajmx/cw_dashboard_javajmx.json
@@ -1,0 +1,282 @@
+{
+    "widgets": [
+        {
+            "type": "metric",
+            "x": 12,
+            "y": 1,
+            "width": 12,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} java_lang_operatingsystem_totalphysicalmemorysize', 'Average', 60))", "id": "e1", "region": "us-east-1" } ]
+                ],
+                "view": "singleValue",
+                "stacked": true,
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 60,
+                "title": "Total RAM",
+                "setPeriodToTimeRange": false
+            }
+        },
+        {
+            "type": "metric",
+            "x": 12,
+            "y": 4,
+            "width": 12,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} java_lang_operatingsystem_totalswapspacesize', 'Average', 60))", "id": "e1", "region": "us-east-1", "label": "" } ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 60,
+                "title": "Total SWAP"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 1,
+            "width": 12,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} java_lang_operatingsystem_systemcpuload', 'Average', 60)) * 100", "id": "e1", "region": "us-east-1", "label": "" } ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 60,
+                "title": "CPU System Load"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 7,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} java_lang_operatingsystem_systemcpuload', 'Average', 60)) * 100", "id": "e1", "region": "us-east-1", "label": "System" } ],
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} java_lang_operatingsystem_processcpuload', 'Average', 60)) * 100", "id": "e2", "region": "us-east-1", "label": "Process" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 60,
+                "title": "CPU Usage"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 12,
+            "y": 13,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace, area} jvm_memory_bytes_used', 'Average', 60))/AVG(REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} java_lang_operatingsystem_totalphysicalmemorysize', 'Average', 60))) * 100", "id": "e1", "region": "us-east-1", "label": "" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 60,
+                "title": "Memory Heap / Non Heap"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 13,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace, pool} jvm_memory_pool_bytes_used', 'Average', 60))", "id": "e1", "region": "us-east-1", "label": "" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 60,
+                "title": "Memory Pool Used "
+            }
+        },
+        {
+            "type": "metric",
+            "x": 12,
+            "y": 7,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} jvm_threads_daemon', 'Average', 60))", "id": "e2", "region": "us-east-1", "label": "" } ],
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} jvm_threads_current', 'Average', 60))", "id": "e1", "region": "us-east-1", "label": "" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 60,
+                "title": "Threads Used"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 19,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} java_lang_operatingsystem_openfiledescriptorcount', 'Average', 60))", "id": "e1", "region": "us-east-1", "label": "System" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 60,
+                "title": "Open File Descriptors "
+            }
+        },
+        {
+            "type": "metric",
+            "x": 12,
+            "y": 19,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} jvm_classes_loaded', 'Average', 60)) * 100", "id": "e1", "region": "us-east-1", "label": "System" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 60,
+                "title": "Class Loading"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 4,
+            "width": 12,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} java_lang_operatingsystem_availableprocessors', 'Average', 60))", "id": "e1", "region": "us-east-1" } ]
+                ],
+                "view": "singleValue",
+                "stacked": true,
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 60,
+                "title": "CPU Cores",
+                "setPeriodToTimeRange": false
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 25,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} catalina_manager_activesessions', 'Average', 60))", "id": "e1", "region": "us-east-1", "label": "active" } ],
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} catalina_manager_rejectedsessions', 'Average', 60))", "id": "e2", "region": "us-east-1", "label": "rejected" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 60,
+                "title": "Catalina Manager Sessions"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 12,
+            "y": 25,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} catalina_globalrequestprocessor_bytesreceived', 'Average', 60))", "id": "e1", "region": "us-east-1", "label": "recv" } ],
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} catalina_globalrequestprocessor_bytessent', 'Average', 60))", "id": "e2", "region": "us-east-1", "label": "sent" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 60,
+                "title": "Catalina Request Processor bytes"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 31,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} catalina_globalrequestprocessor_requestcount', 'Average', 60))", "id": "e1", "region": "us-east-1", "label": "count" } ],
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} catalina_globalrequestprocessor_errorcount', 'Average', 60))", "id": "e2", "region": "us-east-1", "label": "error" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 60,
+                "title": "Catalina Request Processor requests"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 12,
+            "y": 31,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} catalina_globalrequestprocessor_processingtime', 'Average', 60))", "id": "e1", "region": "us-east-1", "label": "count" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 60,
+                "title": "Catalina Request Processor Time",
+                "yAxis": {
+                    "left": {
+                        "label": "ms",
+                        "showUnits": false
+                    },
+                    "right": {
+                        "showUnits": false
+                    }
+                }
+            }
+        },
+        {
+            "type": "text",
+            "x": 0,
+            "y": 0,
+            "width": 24,
+            "height": 1,
+            "properties": {
+                "markdown": "\n# Prometheus metrics: Java/JMX\n"
+            }
+        }
+    ]
+}

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/nginx-ingress/README.md
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/nginx-ingress/README.md
@@ -1,0 +1,2 @@
+## Sample CloudWatch Dashboard for Nginx-Igress Prometheus Metrics
+Please refer to [TBD](tbd.html) for the usage guide.

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/nginx-ingress/cw_dashboard_nginx_ingress_controller.json
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/nginx-ingress/cw_dashboard_nginx_ingress_controller.json
@@ -1,0 +1,169 @@
+{
+    "widgets": [
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 1,
+            "width": 6,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "AVG(METRICS())/10", "label": "ops", "id": "e1", "region": "us-east-1", "visible": false } ],
+                    [ { "expression": "REMOVE_EMPTY(SEARCH ('{ContainerInsights/Prometheus, ClusterName, Service, Namespace} MetricName=\"nginx_ingress_controller_requests\"', 'Sum', 300))/300", "label": "", "id": "e2", "region": "us-east-1" } ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 300,
+                "title": "Controller Request Volume",
+                "setPeriodToTimeRange": true
+            }
+        },
+        {
+            "type": "metric",
+            "x": 6,
+            "y": 1,
+            "width": 6,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "AVG(METRICS())", "label": "", "id": "e1", "region": "us-east-1", "visible": false } ],
+                    [ { "expression": "REMOVE_EMPTY(SEARCH ('{ContainerInsights/Prometheus, ClusterName, Service, Namespace} MetricName=\"nginx_ingress_controller_nginx_process_connections\"', 'Average', 300))", "label": "", "id": "e2", "region": "us-east-1" } ]
+                ],
+                "view": "timeSeries",
+                "region": "us-east-1",
+                "stat": "Average",
+                "period": 300,
+                "title": "Controller Connections",
+                "stacked": false,
+                "yAxis": {
+                    "left": {
+                        "min": 0
+                    }
+                }
+            }
+        },
+        {
+            "type": "metric",
+            "x": 12,
+            "y": 1,
+            "width": 12,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH ('{ContainerInsights/Prometheus, ClusterName, Service, Namespace, status} MetricName=\"nginx_ingress_controller_requests\"', 'Sum', 300))", "label": "", "id": "e1", "region": "us-east-1" } ]
+                ],
+                "view": "timeSeries",
+                "title": "Controller Success Rate (non-4|5xx responses)",
+                "region": "us-east-1",
+                "stat": "Sum",
+                "period": 300,
+                "stacked": false,
+                "yAxis": {
+                    "left": {
+                        "min": 0
+                    }
+                }
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 4,
+            "width": 6,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH ('{ContainerInsights/Prometheus, ingress, ClusterName, Service, Namespace} MetricName=\"nginx_ingress_controller_requests\"', 'Average', 300))", "label": "", "id": "e1", "region": "us-east-1" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "yAxis": {
+                    "left": {
+                        "min": 0,
+                        "label": ""
+                    }
+                },
+                "stat": "Average",
+                "period": 300,
+                "title": "Ingress Request Volume"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 12,
+            "y": 4,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH ('{ContainerInsights/Prometheus, ClusterName, Service, Namespace} MetricName=\"nginx_ingress_controller_nginx_process_cpu_seconds_total\"', 'Average', 60))", "label": "", "id": "e1", "region": "us-east-1" } ],
+                    [ { "expression": "REMOVE_EMPTY(SEARCH ('{ContainerInsights/Prometheus, ClusterName, Service, Namespace} MetricName=\"nginx_ingress_controller_nginx_process_cpu_seconds_total\"', 'p90', 60))", "label": "p90", "id": "e2", "region": "us-east-1", "visible": false } ],
+                    [ { "expression": "REMOVE_EMPTY(SEARCH ('{ContainerInsights/Prometheus, ClusterName, Service, Namespace} MetricName=\"nginx_ingress_controller_nginx_process_cpu_seconds_total\"', 'p10', 60))", "label": "p10", "id": "e3", "region": "us-east-1", "visible": false } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "title": "Average CPU Usage",
+                "region": "us-east-1",
+                "yAxis": {
+                    "left": {
+                        "min": 0
+                    }
+                },
+                "period": 300,
+                "stat": "Average"
+            }
+        },
+        {
+            "type": "text",
+            "x": 0,
+            "y": 0,
+            "width": 24,
+            "height": 1,
+            "properties": {
+                "markdown": "\n# NGINX Ingress controller\n"
+            }
+        },
+        {
+            "type": "log",
+            "x": 0,
+            "y": 10,
+            "width": 24,
+            "height": 6,
+            "properties": {
+                "query": "SOURCE '/aws/containerinsights/<CLUSTER-NAME>/prometheus' | fields controller_class, controller_namespace, controller_pod\n| limit 50\n| filter CloudWatchMetrics.0.Namespace=\"ContainerInsights/Prometheus\"\n| filter CloudWatchMetrics.0.Metrics.0.Name=\"nginx_ingress_controller_requests\" or CloudWatchMetrics.0.Metrics.0.Name=\"nginx_ingress_controller_requests\"\n| stats sum(nginx_ingress_controller_requests) as controller_request_volume by controller_class, controller_namespace, controller_pod, status\n",
+                "region": "us-east-1",
+                "stacked": false,
+                "title": "Summary by Pods",
+                "view": "table"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 6,
+            "y": 4,
+            "width": 6,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH ('{ContainerInsights/Prometheus, ClusterName, Service, Namespace} MetricName=\"nginx_ingress_controller_nginx_process_resident_memory_bytes\"', 'Average', 60))", "label": "Average", "id": "e1", "region": "us-east-1" } ],
+                    [ { "expression": "REMOVE_EMPTY(SEARCH ('{ContainerInsights/Prometheus, ClusterName, Service, Namespace} MetricName=\"nginx_ingress_controller_nginx_process_resident_memory_bytes\"', 'p90', 60))", "label": "p90", "id": "e2", "region": "us-east-1", "visible": false } ],
+                    [ { "expression": "REMOVE_EMPTY(SEARCH ('{ContainerInsights/Prometheus, ClusterName, Service, Namespace} MetricName=\"nginx_ingress_controller_nginx_process_resident_memory_bytes\"', 'p10', 60))", "label": "p10", "id": "e3", "region": "us-east-1", "visible": false } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "us-east-1",
+                "title": "Average Memory Usage",
+                "stat": "Average",
+                "period": 300,
+                "yAxis": {
+                    "left": {
+                        "label": "MiB"
+                    }
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: Add Sample CloudWatch Dashboards for Prometheus Metircs configured in the CWAgent installation yaml files*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
