### PR TITLE
Update Kubernetes API Server CW Dashboard to use non-deprecated metrics

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/kubernetes_api_server/kubernetes_kpi_server.json
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/kubernetes_api_server/kubernetes_kpi_server.json
@@ -7,102 +7,84 @@
       "width": 18,
       "height": 1,
       "properties": {
-        "markdown": "\n# Kubernetes APIService\n"
+        "markdown": "\n# Kubernetes API Server\n"
       }
     },
     {
       "type": "metric",
       "x": 0,
       "y": 1,
-      "width": 6,
+      "width": 9,
       "height": 6,
       "properties": {
         "metrics": [
-          [ { "expression": "SUM(REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Service,code} ClusterName=\"{{YOUR_CLUSTER_NAME}}\" Service=\"kubernetes\" MetricName=\"apiserver_request_count\"', 'Sum', 60)))", "id": "e1", "period": 60, "label": "[avg: ${AVG}, max: ${MAX}] apiserver_request_count (2XX)", "region": "{{YOUR_AWS_REGION}}" } ],
-          [ "ContainerInsights/Prometheus", "apiserver_request_count", "Service", "kubernetes", "ClusterName", "{{YOUR_CLUSTER_NAME}}", { "id": "m1", "label": "[avg: ${AVG}, max: ${MAX}] apiserver_request_count (Total)" } ]
+          [ { "expression": "SUM(REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Service,code} ClusterName=\"{{YOUR_CLUSTER_NAME}}\" Service=\"kubernetes\" MetricName=\"apiserver_request_total\"', 'Sum', 60)))", "id": "e1", "period": 60, "label": "[avg: ${AVG}, max: ${MAX}] apiserver_request_total (2XX)", "region": "{{YOUR_AWS_REGION}}" } ],
+          [ "ContainerInsights/Prometheus", "apiserver_request_total", "Service", "kubernetes", "ClusterName", "{{YOUR_CLUSTER_NAME}}", { "id": "m1", "label": "[avg: ${AVG}, max: ${MAX}] apiserver_request_total (Total)" } ]
         ],
         "view": "timeSeries",
         "stacked": false,
         "region": "{{YOUR_AWS_REGION}}",
         "stat": "Sum",
         "period": 60,
-        "title": "apiserver_request_count"
+        "title": "API Server Request Count"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 9,
+      "y": 1,
+      "width": 9,
+      "height": 6,
+      "properties": {
+        "metrics": [
+          [ { "expression": "SUM(REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Service,code} ClusterName=\"{{YOUR_CLUSTER_NAME}}\" Service=\"kubernetes\" MetricName=\"apiserver_request_total\"', 'Sum', 60)))", "id": "e1", "period": 60, "label": "apiserver_request_total (2XX)", "visible": false, "region": "{{YOUR_AWS_REGION}}" } ],
+          [ { "expression": "e1/m3*100", "label": "[avg: ${AVG}, max: ${MAX}] apiserver_request_total Success Ratio", "id": "e2", "region": "{{YOUR_AWS_REGION}}" } ],
+          [ "ContainerInsights/Prometheus", "apiserver_request_total", "Service", "kubernetes", "ClusterName", "{{YOUR_CLUSTER_NAME}}", { "id": "m3", "visible": false } ]
+        ],
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Sum",
+        "period": 60,
+        "title": "APIServer Request Success Ratio"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 9,
+      "y": 7,
+      "width": 9,
+      "height": 6,
+      "properties": {
+        "metrics": [
+          [ "ContainerInsights/Prometheus", "workqueue_adds_total", "name", "APIServiceRegistrationController", "Service", "kubernetes", "ClusterName", "{{YOUR_CLUSTER_NAME}}", { "label": "[max: ${MAX}, avg: ${AVG}] workqueue_adds" } ],
+          [ ".", "workqueue_retries_total", ".", ".", ".", ".", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] workqueue_retries" } ],
+          [ ".", "workqueue_depth", ".", ".", ".", ".", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] workqueue_depth" } ]
+        ],
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Maximum",
+        "period": 60,
+        "title": "API Service Registration Controller WorkQueue"
       }
     },
     {
       "type": "metric",
       "x": 0,
       "y": 7,
-      "width": 6,
+      "width": 9,
       "height": 6,
       "properties": {
         "metrics": [
-          [ { "expression": "SUM(REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Service,code} ClusterName=\"{{YOUR_CLUSTER_NAME}}\" Service=\"kubernetes\" MetricName=\"apiserver_request_count\"', 'Sum', 60)))", "id": "e1", "period": 60, "label": "apiserver_request_count (2XX)", "visible": false, "region": "{{YOUR_AWS_REGION}}" } ],
-          [ { "expression": "e1/m3*100", "label": "[avg: ${AVG}, max: ${MAX}] apiserver_request_count Success Ratio", "id": "e2", "region": "{{YOUR_AWS_REGION}}" } ],
-          [ "ContainerInsights/Prometheus", "apiserver_request_count", "Service", "kubernetes", "ClusterName", "{{YOUR_CLUSTER_NAME}}", { "id": "m3", "visible": false } ]
+          [ { "expression": "SEARCH('{ContainerInsights/Prometheus,ClusterName,Service,resource} Service=\"kubernetes\" ClusterName=\"{{YOUR_CLUSTER_NAME}}\" ClusterName=\"{{YOUR_CLUSTER_NAME}}\" MetricName=\"etcd_object_counts\"', 'Maximum', 60)", "id": "e1", "region": "{{YOUR_AWS_REGION}}", "label": "[max: ${MAX}, avg: ${AVG}] " } ]
         ],
         "view": "timeSeries",
         "stacked": false,
         "region": "{{YOUR_AWS_REGION}}",
-        "stat": "Sum",
+        "stat": "Maximum",
         "period": 60,
-        "title": "apiserver_request_count Success Ratio"
-      }
-    },
-    {
-      "type": "metric",
-      "x": 12,
-      "y": 1,
-      "width": 6,
-      "height": 12,
-      "properties": {
-        "view": "timeSeries",
-        "stacked": false,
-        "region": "{{YOUR_AWS_REGION}}",
-        "stat": "Sum",
-        "period": 60,
-        "title": " Etcd Helper Cache",
-        "metrics": [
-          [ "ContainerInsights/Prometheus", "etcd_helper_cache_entry_total", "Service", "kubernetes", "ClusterName", "{{YOUR_CLUSTER_NAME}}", { "label": "[avg: ${AVG}, max: ${MAX}] etcd_helper_cache_entry_total" } ],
-          [ ".", "etcd_helper_cache_miss_total", ".", ".", ".", ".", { "label": "[avg: ${AVG}, max: ${MAX}] etcd_helper_cache_miss_total" } ],
-          [ ".", "etcd_helper_cache_hit_total", ".", ".", ".", ".", { "label": "[avg: ${AVG}, max: ${MAX}] etcd_helper_cache_hit_total" } ]
-        ]
-      }
-    },
-    {
-      "type": "metric",
-      "x": 6,
-      "y": 1,
-      "width": 6,
-      "height": 6,
-      "properties": {
-        "view": "timeSeries",
-        "stacked": false,
-        "region": "{{YOUR_AWS_REGION}}",
-        "stat": "Sum",
-        "period": 60,
-        "title": "APIServiceRegistrationController Adds",
-        "metrics": [
-          [ "ContainerInsights/Prometheus", "APIServiceRegistrationController_adds", "Service", "kubernetes", "ClusterName", "{{YOUR_CLUSTER_NAME}}", { "label": "[avg: ${AVG}, max: ${MAX}] APIServiceRegistrationController_adds" } ]
-        ]
-      }
-    },
-    {
-      "type": "metric",
-      "x": 6,
-      "y": 7,
-      "width": 6,
-      "height": 6,
-      "properties": {
-        "view": "timeSeries",
-        "stacked": false,
-        "region": "{{YOUR_AWS_REGION}}",
-        "stat": "Sum",
-        "period": 60,
-        "title": "APIServiceRegistrationController Depth",
-        "metrics": [
-          [ "ContainerInsights/Prometheus", "APIServiceRegistrationController_depth", "Service", "kubernetes", "ClusterName", "{{YOUR_CLUSTER_NAME}}", { "label": "[avg: ${AVG}, max: ${MAX}] APIServiceRegistrationController_depth" } ]
-        ]
+        "title": "etcd Object Count per Resource Type"
       }
     }
   ]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:
Kubernetes 1.16 deprecated ectd_helper_* metrics by https://github.com/kubernetes/kubernetes/pull/79520
These metrics were used in the Cloudwatch Dashboard for KPI Server. 
This pull request is to update the CW Dashboard to avoid using deprecated metrics.
*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
