### PR TITLE
support jmx metrics based on pod label 'cw_metrics_enabled'

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
@@ -309,15 +309,19 @@ data:
 
     - job_name: 'kubernetes-pod-jmx'
       sample_limit: 10000
+      scrape_interval: 10s
       metrics_path: /metrics
       kubernetes_sd_configs:
       - role: pod
       relabel_configs:
       - source_labels: [__address__]
+        action: replace
+        regex: ([^:]+)(?::\d+)?
+        replacement: ${1}:9404
+        target_label: __address__
+      - source_labels: [__meta_kubernetes_pod_label_cw_metrics_enabled]
         action: keep
-        regex: '.*:9404$'
-      - action: labelmap
-        regex: __meta_kubernetes_pod_label_(.+)
+        regex: true
       - action: replace
         source_labels:
         - __meta_kubernetes_namespace


### PR DESCRIPTION
*Issue:*
- Currently, Scraping JMX metrics is broken for Cloud Watch agent.

*Description of changes:*
- This pull request will fix scraping JMX metrics for CloudWatch agent.
- Fixed regex,  pod label for 'kubernetes-pod-jmx' job 
- **Note**: With these changes, CloudWatch agent will scrape Prometheus metrics only from the pods with label 'cw_metrics_enabled=true'
    - `kubectl label pod <pod_id> cw_metrics_enabled=true -n <pod_namespace>`

TODO: Documentation update. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
