### PR TITLE
Update ContainerInsights setup script envname "REGION" into "AWS_REGION"

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
@@ -171,7 +171,7 @@ data:
       <match **>
         @type cloudwatch_logs
         @id out_cloudwatch_logs_containers
-        region "#{ENV.fetch('REGION')}"
+        region "#{ENV.fetch('AWS_REGION')}"
         log_group_name "/aws/containerinsights/#{ENV.fetch('CLUSTER_NAME')}/application"
         log_stream_name_key stream_name
         remove_log_stream_name_key true
@@ -259,7 +259,7 @@ data:
       <match **>
         @type cloudwatch_logs
         @id out_cloudwatch_logs_systemd
-        region "#{ENV.fetch('REGION')}"
+        region "#{ENV.fetch('AWS_REGION')}"
         log_group_name "/aws/containerinsights/#{ENV.fetch('CLUSTER_NAME')}/dataplane"
         log_stream_name_key stream_name
         auto_create_stream true
@@ -329,7 +329,7 @@ data:
       <match host.**>
         @type cloudwatch_logs
         @id out_cloudwatch_logs_host_logs
-        region "#{ENV.fetch('REGION')}"
+        region "#{ENV.fetch('AWS_REGION')}"
         log_group_name "/aws/containerinsights/#{ENV.fetch('CLUSTER_NAME')}/host"
         log_stream_name_key stream_name
         remove_log_stream_name_key true
@@ -380,7 +380,7 @@ spec:
         - name: fluentd-cloudwatch
           image: fluent/fluentd-kubernetes-daemonset:v1.7.3-debian-cloudwatch-1.0
           env:
-            - name: REGION
+            - name: AWS_REGION
               valueFrom:
                 configMapKeyRef:
                   name: cluster-info

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
@@ -355,7 +355,7 @@ data:
       <match **>
         @type cloudwatch_logs
         @id out_cloudwatch_logs_containers
-        region "#{ENV.fetch('REGION')}"
+        region "#{ENV.fetch('AWS_REGION')}"
         log_group_name "/aws/containerinsights/#{ENV.fetch('CLUSTER_NAME')}/application"
         log_stream_name_key stream_name
         remove_log_stream_name_key true
@@ -443,7 +443,7 @@ data:
       <match **>
         @type cloudwatch_logs
         @id out_cloudwatch_logs_systemd
-        region "#{ENV.fetch('REGION')}"
+        region "#{ENV.fetch('AWS_REGION')}"
         log_group_name "/aws/containerinsights/#{ENV.fetch('CLUSTER_NAME')}/dataplane"
         log_stream_name_key stream_name
         auto_create_stream true
@@ -513,7 +513,7 @@ data:
       <match host.**>
         @type cloudwatch_logs
         @id out_cloudwatch_logs_host_logs
-        region "#{ENV.fetch('REGION')}"
+        region "#{ENV.fetch('AWS_REGION')}"
         log_group_name "/aws/containerinsights/#{ENV.fetch('CLUSTER_NAME')}/host"
         log_stream_name_key stream_name
         remove_log_stream_name_key true
@@ -564,7 +564,7 @@ spec:
         - name: fluentd-cloudwatch
           image: fluent/fluentd-kubernetes-daemonset:v1.7.3-debian-cloudwatch-1.0
           env:
-            - name: REGION
+            - name: AWS_REGION
               valueFrom:
                 configMapKeyRef:
                   name: cluster-info


### PR DESCRIPTION
*Issue #, if available:*
#5
*Description of changes:*
Hi,
As https://github.com/aws-samples/amazon-cloudwatch-container-insights/issues/5#issuecomment-546036182 and https://github.com/aws-samples/amazon-cloudwatch-container-insights/issues/5#issuecomment-535908319  shown, we still need to rename REGION to AWS_REGION for fluentd 1.7 when install ContainerInsights by [quickstart.yaml](https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml) into EKScluster using [EKS IAM Roles for Service Accounts](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-EKS-quickstart.html) over EKS1.14.
[fluentd.yaml](https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/latest/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml) also has same problem written on [Set Up FluentD as a DaemonSet to Send Logs to CloudWatch Logs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-logs.html) document.

I think we can update manifest and fluentd-conf envname REGION into AWS_REGION for now.
How do you think?


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
