### PR TITLE
Add Sample CWAgent Installation file for Amazon ECS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## k8s/1.2.0-prometheus
+- Upgrade cloudwatch-agent image version to amazon/cloudwatch-agent:1.248913.0-prometheus
+
 ## k8s/1.1.0-prometheus-beta
 - Upgrade cloudwatch-agent image version to amazon/cloudwatch-agent:1.243835.0-prometheus-beta
 

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/README.md
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/README.md
@@ -1,0 +1,163 @@
+## CloudWatch Agent for ECS Prometheus Monitoring
+
+The sample ECS task definitions in this folder deploy the CloudWatch Agent as a Replica Service. For more information, see [AWS Public Link TBD](link to be do).
+
+* [cwagent-prometheus-task-definition.json](cwagent-prometheus-task-definition.json): sample ECS task definition
+
+You must replace all the placeholders (with ```{{ }}```) in the above task definitions with your information:
+* ```{{task-role-arn}}```: ECS task role ARN.
+  * This is the role that your CloudWatch Agent container will use. The required permissions:
+    * ```CloudWatchAgentServerPolicy``` policy
+    * A customer managed policy with the following readonly permissions for ECS Prometheus target discovery:
+        ```
+        ECS:ListTasks,
+        ECS:DescribeContainerInstances,
+        ECS:DescribeTasks,
+        ECS:DescribeTaskDefinition
+        EC2:DescribeInstances
+        ```
+
+* ```{{execution-role-arn}}```: ECS task execution role ARN.
+  * This is the role that Amazon ECS requires to launch/execute your containers, e.g. get the parameters from SSM parameter store.
+  * Ensure that the ```AmazonSSMReadOnlyAccess```, ```AmazonECSTaskExecutionRolePolicy``` and ```CloudWatchAgentServerPolicy``` policies are attached to your ECS Task execution role.
+  * If you would like to store more sensitive data for ECS to use, refer to https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html.    
+
+* ```{{awslogs-region}}```: The AWS region where the container logs should be published: e.g. ```us-west-2```
+
+* ```{{launchtype}}```: [Amazon ECS launch type](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#requires_compatibilities)
+
+* ```{{networkmode}}```: [Amazon ECS network mode](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#network_mode)
+
+* ```{{ssm-prometheus-config}}```: AWS Systems Manager Parameter name for Prometheus Scraping Config
+
+* ```{{ssm-cwagent-config}}```: AWS Systems Manager Parameter name for CloudWatch Agent Config
+
+You can also adjust the resource limit (e.g. cpu and memory) based on your particular use cases.
+
+## Supported Matrix
+CloudWatch Agent with Prometheus Monitoring can be deployed in the following modes
+
+|ECS Launch Type         | ECS Network Mode    |
+|------------------------|---------------------|
+|FARGATE                 | awsvpc              |
+|EC2 (Linux)             | awsvpc              |
+|EC2 (Linux)             | bridge              |
+|EC2 (Linux)             | host                |
+
+
+## Examples
+
+**Sample Prometheus Config SSM Parameter**
+
+For more information, see [Prometheus Scraping Config](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config)
+```
+global:
+  scrape_interval: 1m
+  scrape_timeout: 10s
+scrape_configs:
+  - job_name: cwagent-ecs-file-sd-config
+    sample_limit: 10000
+    file_sd_configs:
+      - files: [ "/tmp/cwagent_ecs_auto_sd.yaml" ]
+```
+
+**Sample CWAgent Config**
+
+For more information, see [CWAgent Prometheus Monitoring Config for ECS](TBD)
+```
+{
+  "agent": {
+    "debug": true
+  },
+  "logs": {
+    "metrics_collected": {
+      "prometheus": {
+        "prometheus_config_path": "env:PROMETHEUS_CONFIG_CONTENT",
+        "ecs_service_discovery": {
+          "sd_frequency": "1m",
+          "sd_result_file": "/tmp/cwagent_ecs_auto_sd.yaml",
+          "docker_label": {
+            "sd_port_label": "ECS_PROMETHEUS_EXPORTER_PORT",
+            "sd_job_name_label": "ECS_PROMETHEUS_JOB_NAME"
+          },
+          "task_definition_list": [
+            {
+              "sd_job_name": "bugbash-workload-java-ec2-awsvpc-task-def-sd",
+              "sd_metrics_ports": "9404;9406",
+              "sd_task_definition_arn_pattern": ".*:task-definition/targets-workload-java-ec2-awsvpc:[0-9]+"
+            }
+          ]
+        },
+        "emf_processor": {
+          "metric_declaration_dedup": true,
+          "metric_declaration": [
+            {
+              "source_labels": ["Java_EMF_Metrics"],
+              "label_matcher": "^true$",
+              "dimensions": [["ClusterName","TaskDefinitionFamily"]],
+              "metric_selectors": [
+                "^jvm_threads_current$",
+                "^jvm_threads_daemon$",
+                "^catalina_globalrequestprocessor_requestcount$",
+                "^catalina_globalrequestprocessor_errorcount$",
+                "^catalina_globalrequestprocessor_processingtime$"
+              ]
+            },
+            {
+              "source_labels": ["Java_EMF_Metrics"],
+              "label_matcher": "^true$",
+              "dimensions": [["ClusterName","TaskDefinitionFamily","pool"]],
+              "metric_selectors": [
+                "^jvm_memory_pool_bytes_used$"
+              ]
+            }
+          ]
+        }
+      }
+    },
+    "force_flush_interval": 5
+  }
+}
+
+```
+
+**Creating CWAgent ECS Task Definition**
+
+Create the CWAgent ECS Task definition for the ECS `EC2` Cluster with `bridge` network mode in region `ca-central-1`. 
+```
+ECSTaskRoleName=CWAgentPrometheusECSTaskRole
+ECSExecutionRoleName=CWAgentPrometheusECSExecutionRole
+AWSRegion=ca-central-1
+PrometheusSSMConfigName=AmazonCloudWatch-prometheus-yaml-config
+CWAgentSSMConfigName=AmazonCloudWatch-prometheus-appmesh-config
+ECSLaunchType=EC2
+ECSNetworkMode=bridge
+
+cat cwagent-prometheus-task-definition.json \
+| sed "s/{{task-role-arn}}/${ECSTaskRoleName}/g" \
+| sed "s/{{execution-role-arn}}/${ECSExecutionRoleName}/g" \
+| sed "s/{{launchtype}}/${ECSLaunchType}/g" \
+| sed "s/{{networkmode}}/${ECSNetworkMode}/g" \
+| sed "s/{{awslogs-region}}/${AWSRegion}/g" \
+| sed "s/{{ssm-prometheus-config}}/${PrometheusSSMConfigName}/g" \
+| sed "s/{{ssm-cwagent-config}}/${CWAgentSSMConfigName}/g" \
+| xargs -0 aws ecs register-task-definition --region ${AWSRegion} --cli-input-json
+```
+
+**Creating CWAgent ECS Replica Service**
+
+Run the CWAgent with Prometheus Monitoring as replica service (with replica=1).
+
+```
+ECSClusterName=sample-ecs-ec2-cluster
+AWSRegion=ca-central-1
+
+aws ecs create-service \
+--cluster ${ECSClusterName} \
+--service-name sample-prometheus-cwagent-service-EC2-bridge \
+--task-definition ecs-cwagent-prometheus-replica-service-EC2-bridge \
+--launch-type EC2 \
+--scheduling-strategy REPLICA \
+--desired-count 1 \
+--region ${AWSRegion}
+```

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/README.md
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/README.md
@@ -1,0 +1,130 @@
+## CloudWatch Agent for Prometheus Metrics Quick Start
+
+The cloud formation templates in this folder help you to quickly deploy CloudWatch Agent as replica-service to discover and collect Prometheus metrics.
+
+### Supported Matrix
+CloudWatch Agent with Prometheus Monitoring can be deployed in the following modes
+
+|ECS Launch Type         | ECS Network Mode    |
+|------------------------|---------------------|
+|EC2 (Linux)             | bridge              |
+|EC2 (Linux)             | host                |
+|EC2 (Linux)             | awsvpc              |
+|FARGATE                 | awsvpc              |
+
+### CloudFormation Template Parameters
+* **ECSClusterName**: specify the target ECS cluster for the installation
+* **CreateIAMRoles**: whether to create ECS task role and ECS execution role or reusing existing ones. Either `True` or `False`
+* **TaskRoleName**: the ECS task role name to be created when `CreateIAMRoles=True` or the ECS task role name to be reused when `CreateIAMRoles=False`
+* **ExecutionRoleName**: the ECS execution role name to be created when `CreateIAMRoles=True` or the ECS execution role name to be reused when `CreateIAMRoles=False`
+* **ECSNetworkMode**: specify the ECS task network mode when the ECS cluster launch type is `EC2`, either `bridge` or `host`
+* **ECSLaunchType**: specify the ECS cluster launch type when the network mode is `awsvpc`, either `FARGATE` or `EC2`
+* **SecurityGroupID**: specify the security group ID when ECS task network mode is `awsvpc`
+* **SubnetID**: specify the subnet ID when ECS task network mode is `awsvpc`
+
+### Samples Commands
+##### Create AWS CloudFormation Stack for `EC2` ECS Cluster with `bridge` network mode
+
+```
+export AWS_PROFILE=your_aws_config_profile_eg_default
+export AWS_DEFAULT_REGION=your_aws_region_eg_ap-southeast-1
+export ECS_CLUSTER_NAME=your_ec2_ecs_cluster_name
+export ECS_NETWORK_MODE=bridge
+export CREATE_IAM_ROLES=True
+
+aws cloudformation create-stack --stack-name CWAgent-Prometheus-ECS-${ECS_CLUSTER_NAME}-EC2-${ECS_NETWORK_MODE} \
+    --template-body file://cwagent-ecs-prometheus-metric-for-bridge-host.yaml \
+    --parameters ParameterKey=ECSClusterName,ParameterValue=${ECS_CLUSTER_NAME} \
+                 ParameterKey=CreateIAMRoles,ParameterValue=${CREATE_IAM_ROLES} \
+                 ParameterKey=ECSNetworkMode,ParameterValue=${ECS_NETWORK_MODE} \
+                 ParameterKey=TaskRoleName,ParameterValue=CWAgent-Prometheus-TaskRole-${ECS_CLUSTER_NAME} \
+                 ParameterKey=ExecutionRoleName,ParameterValue=CWAgent-Prometheus-ExecutionRole-${ECS_CLUSTER_NAME} \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --region ${AWS_DEFAULT_REGION} \
+    --profile ${AWS_PROFILE}
+```
+
+##### Create AWS CloudFormation Stack for `EC2` ECS Cluster with `host` network type
+
+```
+export AWS_PROFILE=your_aws_config_profile_eg_default
+export AWS_DEFAULT_REGION=your_aws_region_eg_ap-southeast-1
+export ECS_CLUSTER_NAME=your_ec2_ecs_cluster_name
+export ECS_NETWORK_MODE=host
+export CREATE_IAM_ROLES=True
+
+aws cloudformation create-stack --stack-name CWAgent-Prometheus-ECS-${ECS_CLUSTER_NAME}-EC2-${ECS_NETWORK_MODE} \
+    --template-body file://cwagent-ecs-prometheus-metric-for-bridge-host.yaml \
+    --parameters ParameterKey=ECSClusterName,ParameterValue=${ECS_CLUSTER_NAME} \
+                 ParameterKey=CreateIAMRoles,ParameterValue=${CREATE_IAM_ROLES} \
+                 ParameterKey=ECSNetworkMode,ParameterValue=${ECS_NETWORK_MODE} \
+                 ParameterKey=TaskRoleName,ParameterValue=CWAgent-Prometheus-TaskRole-${ECS_CLUSTER_NAME} \
+                 ParameterKey=ExecutionRoleName,ParameterValue=CWAgent-Prometheus-ExecutionRole-${ECS_CLUSTER_NAME} \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --region ${AWS_DEFAULT_REGION} \
+    --profile ${AWS_PROFILE}
+```
+
+##### Create AWS CloudFormation Stack for `EC2` ECS Cluster with `awsvpc` network type
+
+```
+export AWS_PROFILE=your_aws_config_profile_eg_default
+export AWS_DEFAULT_REGION=your_aws_region_eg_ap-southeast-1
+export ECS_CLUSTER_NAME=your_ec2_ecs_cluster_name
+export ECS_LAUNCH_TYPE=EC2
+export CREATE_IAM_ROLES=True
+export ECS_CLASTER_SECURITY_GROUP=your_security_group_eg_sg-xxxxxxxxxx
+export ECS_CLUSTER_SUBNET=your_subnet_eg_subnet-xxxxxxxxxx
+
+aws cloudformation create-stack --stack-name CWAgent-Prometheus-ECS-${ECS_CLUSTER_NAME}-${ECS_LAUNCH_TYPE}-awsvpc \
+    --template-body file://cwagent-ecs-prometheus-metric-for-awsvpc.yaml \
+    --parameters ParameterKey=ECSClusterName,ParameterValue=${ECS_CLUSTER_NAME} \
+                 ParameterKey=CreateIAMRoles,ParameterValue=${CREATE_IAM_ROLES} \
+                 ParameterKey=ECSLaunchType,ParameterValue=${ECS_LAUNCH_TYPE} \
+                 ParameterKey=SecurityGroupID,ParameterValue=${ECS_CLASTER_SECURITY_GROUP} \
+                 ParameterKey=SubnetID,ParameterValue=${ECS_CLUSTER_SUBNET} \
+                 ParameterKey=TaskRoleName,ParameterValue=CWAgent-Prometheus-TaskRole-${ECS_CLUSTER_NAME} \
+                 ParameterKey=ExecutionRoleName,ParameterValue=CWAgent-Prometheus-ExecutionRole-${ECS_CLUSTER_NAME} \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --region ${AWS_DEFAULT_REGION} \
+    --profile ${AWS_PROFILE}
+```
+
+##### Create AWS CloudFormation Stack for `FARGATE` ECS Cluster with `awsvpc` network type
+
+```
+export AWS_PROFILE=your_aws_config_profile_eg_default
+export AWS_DEFAULT_REGION=your_aws_region_eg_ap-southeast-1
+export ECS_CLUSTER_NAME=your_ec2_ecs_cluster_name
+export ECS_LAUNCH_TYPE=FARGATE
+export CREATE_IAM_ROLES=True
+export ECS_CLASTER_SECURITY_GROUP=your_security_group_eg_sg-xxxxxxxxxx
+export ECS_CLUSTER_SUBNET=your_subnet_eg_subnet-xxxxxxxxxx
+
+aws cloudformation create-stack --stack-name CWAgent-Prometheus-ECS-${ECS_CLUSTER_NAME}-${ECS_LAUNCH_TYPE}-awsvpc \
+    --template-body file://cwagent-ecs-prometheus-metric-for-awsvpc.yaml \
+    --parameters ParameterKey=ECSClusterName,ParameterValue=${ECS_CLUSTER_NAME} \
+                 ParameterKey=CreateIAMRoles,ParameterValue=${CREATE_IAM_ROLES} \
+                 ParameterKey=ECSLaunchType,ParameterValue=${ECS_LAUNCH_TYPE} \
+                 ParameterKey=SecurityGroupID,ParameterValue=${ECS_CLASTER_SECURITY_GROUP} \
+                 ParameterKey=SubnetID,ParameterValue=${ECS_CLUSTER_SUBNET} \
+                 ParameterKey=TaskRoleName,ParameterValue=CWAgent-Prometheus-TaskRole-${ECS_CLUSTER_NAME} \
+                 ParameterKey=ExecutionRoleName,ParameterValue=CWAgent-Prometheus-ExecutionRole-${ECS_CLUSTER_NAME} \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --region ${AWS_DEFAULT_REGION} \
+    --profile ${AWS_PROFILE}
+```
+
+### AWS CloudFormation Resources Created
+
+The following resources will be created by the cloud formation stack
+
+|Resource Type           | Resource Name                                                                                | Comments                               |
+|------------------------|----------------------------------------------------------------------------------------------|----------------------------------------|
+|AWS::SSM::Parameter     | AmazonCloudWatch-CWAgentConfig-${ECSClusterName}-${ECSLaunchType}-${ECS_NETWORK_MODE}        |CloudWatch Agent with default AWS App Mesh and Java/Jmx EMF definition  |
+|AWS::SSM::Parameter     | AmazonCloudWatch-PrometheusConfigName-${ECSClusterName}-${ECSLaunchType}-${ECS_NETWORK_MODE} |Prometheus scraping configuration       |
+|AWS::IAM::Role          | CWAgent-Prometheus-TaskRole-${ECS_CLUSTER_NAME}                                              |created when CREATE_IAM_ROLES=True      |
+|AWS::IAM::Role          | CWAgent-Prometheus-ExecutionRole-${ECS_CLUSTER_NAME}                                         |created when CREATE_IAM_ROLES=True      |
+|AWS::ECS::Service       | cwagent-prometheus-replica-service-${ECSLaunchType}-${ECSNetworkMode}                        |                                        |
+|AWS::ECS::TaskDefinition| cwagent-prometheus-${ECSClusterName}-${ECSLaunchType}-${ECS_NETWORK_MODE}                    |                                        |
+

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
@@ -1,0 +1,263 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  ECSClusterName:
+    Type: String
+    Description: Enter the name of your ECS cluster from which you want to collect Prometheus metrics
+  CreateIAMRoles:
+    Type: String
+    AllowedValues:
+      - 'True'
+      - 'False'
+    Description: Whether to create new IAM roles or using existing IAM roles for the ECS tasks
+    ConstraintDescription: must specifid, either True or False
+  ECSLaunchType:
+    Type: String
+    AllowedValues:
+      - 'EC2'
+      - 'FARGATE'
+    Description: ECS Launch Type for the ECS cluster
+    ConstraintDescription: must specifid, either EC2 or FARGATE
+  TaskRoleName:
+    Type: String
+    Description: Enter the CloudWatch Agent ECS task role name
+  ExecutionRoleName:
+    Type: String
+    Description: Enter the CloudWatch Agent ECS execution role name
+  SecurityGroupID:
+    Type: String
+    Description: Enter the Security Group ID for running the CloudWatch Agent ECS Task
+  SubnetID:
+    Type: String
+    Description: Enter the Subnet ID for running the CloudWatch Agent ECS Task
+Conditions:
+  CreateRoles:
+    !Equals [!Ref CreateIAMRoles, 'True']
+  AssignPublicIp:
+    !Equals [!Ref ECSLaunchType, 'FARGATE']
+Resources:
+  PrometheusConfigSSMParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub 'AmazonCloudWatch-PrometheusConfigName-${ECSClusterName}-${ECSLaunchType}-awsvpc'
+      Type: String
+      Tier: Standard
+      Description: !Sub 'Prometheus Scraping SSM Parameter for ECS Cluster: ${ECSClusterName}'
+      Value: |-
+        global:
+          scrape_interval: 1m
+          scrape_timeout: 10s
+        scrape_configs:
+          - job_name: cwagent-ecs-file-sd-config
+            sample_limit: 10000
+            file_sd_configs:
+              - files: [ "/tmp/cwagent_ecs_auto_sd.yaml" ]
+  CWAgentConfigSSMParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub 'AmazonCloudWatch-CWAgentConfig-${ECSClusterName}-${ECSLaunchType}-awsvpc'
+      Type: String
+      Tier: Intelligent-Tiering
+      Description: !Sub 'CWAgent SSM Parameter with App Mesh and Java EMF Definition for ECS Cluster: ${ECSClusterName}'
+      Value: |-
+        {
+          "logs": {
+            "metrics_collected": {
+              "prometheus": {
+                "prometheus_config_path": "env:PROMETHEUS_CONFIG_CONTENT",
+                "ecs_service_discovery": {
+                  "sd_frequency": "1m",
+                  "sd_result_file": "/tmp/cwagent_ecs_auto_sd.yaml",
+                  "docker_label": {
+                  },
+                  "task_definition_list": [
+                    {
+                      "sd_job_name": "ecs-appmesh-colors",
+                      "sd_metrics_ports": "9901",
+                      "sd_task_definition_arn_pattern": ".*:task-definition/.*-ColorTeller-(white|red):[0-9]+",
+                      "sd_metrics_path": "/stats/prometheus"
+                    },
+                    {
+                      "sd_job_name": "ecs-appmesh-gateway",
+                      "sd_metrics_ports": "9901",
+                      "sd_task_definition_arn_pattern": ".*:task-definition/.*-ColorGateway:[0-9]+",
+                      "sd_metrics_path": "/stats/prometheus"
+                    }
+                  ]
+                },
+                "emf_processor": {
+                  "metric_declaration_dedup": true,
+                  "metric_declaration": [
+                    {
+                      "source_labels": ["container_name"],
+                      "label_matcher": "^envoy$",
+                      "dimensions": [["ClusterName","TaskDefinitionFamily"]],
+                      "metric_selectors": [
+                        "^envoy_http_downstream_rq_(total|xx)$",
+                        "^envoy_cluster_upstream_cx_(r|t)x_bytes_total$",
+                        "^envoy_cluster_membership_(healthy|total)$",
+                        "^envoy_server_memory_(allocated|heap_size)$",
+                        "^envoy_cluster_upstream_cx_(connect_timeout|destroy_local_with_active_rq)$",
+                        "^envoy_cluster_upstream_rq_(pending_failure_eject|pending_overflow|timeout|per_try_timeout|rx_reset|maintenance_mode)$",
+                        "^envoy_http_downstream_cx_destroy_remote_active_rq$",
+                        "^envoy_cluster_upstream_flow_control_(paused_reading_total|resumed_reading_total|backed_up_total|drained_total)$",
+                        "^envoy_cluster_upstream_rq_retry$",
+                        "^envoy_cluster_upstream_rq_retry_(success|overflow)$",
+                        "^envoy_server_(version|uptime|live)$"
+                      ]
+                    },
+                    {
+                      "source_labels": ["container_name"],
+                      "label_matcher": "^envoy$",
+                      "dimensions": [["ClusterName","TaskDefinitionFamily","envoy_http_conn_manager_prefix","envoy_response_code_class"]],
+                      "metric_selectors": [
+                        "^envoy_http_downstream_rq_xx$"
+                      ]
+                    },
+                    {
+                      "source_labels": ["Java_EMF_Metrics"],
+                      "label_matcher": "^true$",
+                      "dimensions": [["ClusterName","TaskDefinitionFamily"]],
+                      "metric_selectors": [
+                        "^jvm_threads_(current|daemon)$",
+                        "^jvm_classes_loaded$",
+                        "^java_lang_operatingsystem_(freephysicalmemorysize|totalphysicalmemorysize|freeswapspacesize|totalswapspacesize|systemcpuload|processcpuload|availableprocessors|openfiledescriptorcount)$",
+                        "^catalina_manager_(rejectedsessions|activesessions)$",
+                        "^jvm_gc_collection_seconds_(count|sum)$",
+                        "^catalina_globalrequestprocessor_(bytesreceived|bytessent|requestcount|errorcount|processingtime)$"
+                      ]
+                    },
+                    {
+                      "source_labels": ["Java_EMF_Metrics"],
+                      "label_matcher": "^true$",
+                      "dimensions": [["ClusterName","TaskDefinitionFamily","area"]],
+                      "metric_selectors": [
+                        "^jvm_memory_bytes_used$"
+                      ]
+                    },
+                    {
+                      "source_labels": ["Java_EMF_Metrics"],
+                      "label_matcher": "^true$",
+                      "dimensions": [["ClusterName","TaskDefinitionFamily","pool"]],
+                      "metric_selectors": [
+                        "^jvm_memory_pool_bytes_used$"
+                      ]
+                    }
+                  ]
+                }
+              }
+            },
+            "force_flush_interval": 5
+          }
+        }
+  CWAgentECSExecutionRole:
+    Type: AWS::IAM::Role
+    Condition: CreateRoles
+    Properties:
+      RoleName: !Ref ExecutionRoleName
+      Description: Allows ECS container agent makes calls to the Amazon ECS API on your behalf.
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+      Policies:
+        - PolicyName: ECSSSMInlinePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameters
+                Resource: arn:aws:ssm:*:*:parameter/AmazonCloudWatch-*
+  CWAgentECSTaskRole:
+    Type: AWS::IAM::Role
+    Condition: CreateRoles
+    DependsOn: CWAgentECSExecutionRole
+    Properties:
+      RoleName: !Ref TaskRoleName
+      Description: Allows ECS tasks to call AWS services on your behalf.
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+      Policies:
+        - PolicyName: ECSServiceDiscoveryInlinePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ecs:DescribeTasks
+                  - ecs:ListTasks
+                  - ecs:DescribeContainerInstances
+                Resource: "*"
+                Condition:
+                  ArnEquals:
+                    ecs:cluster:
+                      !Sub 'arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ECSClusterName}'
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeInstances
+                  - ecs:DescribeTaskDefinition
+                Resource: "*"
+  ECSCWAgentTaskDefinition:
+    Type: 'AWS::ECS::TaskDefinition'
+    DependsOn:
+      - PrometheusConfigSSMParameter
+      - CWAgentConfigSSMParameter
+    Properties:
+      family: !Sub 'cwagent-prometheus-${ECSClusterName}-${ECSLaunchType}-awsvpc'
+      taskRoleArn: !If [CreateRoles, !Ref CWAgentECSTaskRole, !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${TaskRoleName}']
+      executionRoleArn: !If [CreateRoles, !Ref CWAgentECSExecutionRole, !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${ExecutionRoleName}']
+      networkMode: awsvpc
+      containerDefinitions:
+        - name: cloudwatch-agent-prometheus
+          image: amazon/cloudwatch-agent:1.248913.0-prometheus
+          essential: true
+          mountPoints: []
+          portMappings: []
+          environment: []
+          secrets:
+            - name: PROMETHEUS_CONFIG_CONTENT
+              valueFrom: !Sub 'AmazonCloudWatch-PrometheusConfigName-${ECSClusterName}-${ECSLaunchType}-awsvpc'
+            - name: CW_CONFIG_CONTENT
+              valueFrom: !Sub 'AmazonCloudWatch-CWAgentConfig-${ECSClusterName}-${ECSLaunchType}-awsvpc'
+          logConfiguration:
+            logDriver: awslogs
+            options:
+              awslogs-create-group: 'True'
+              awslogs-group: "/ecs/ecs-cwagent-prometheus"
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: !Sub 'ecs-${ECSLaunchType}-awsvpc'
+      requiresCompatibilities:
+        - !Ref ECSLaunchType
+      cpu: '512'
+      memory: '1024'
+  ECSCWAgentService:
+    Type: AWS::ECS::Service
+    DependsOn: ECSCWAgentTaskDefinition
+    Properties:
+      Cluster: !Ref ECSClusterName
+      DesiredCount: 1
+      LaunchType: !Ref ECSLaunchType
+      SchedulingStrategy: REPLICA
+      ServiceName: !Sub 'cwagent-prometheus-replica-service-${ECSLaunchType}-awsvpc'
+      TaskDefinition: !Ref ECSCWAgentTaskDefinition
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: !If [AssignPublicIp, ENABLED, DISABLED]
+          SecurityGroups:
+            - !Ref SecurityGroupID
+          Subnets:
+            - !Ref SubnetID

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
@@ -1,0 +1,251 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  ECSClusterName:
+    Type: String
+    Description: Enter the name of your ECS cluster from which you want to collect Prometheus metrics
+  CreateIAMRoles:
+    Type: String
+    AllowedValues:
+      - 'True'
+      - 'False'
+    Description: Whether to create new IAM roles or using existing IAM roles for the ECS tasks
+    ConstraintDescription: must specifid, either True or False
+  ECSNetworkMode:
+    Type: String
+    AllowedValues:
+      - 'bridge'
+      - 'host'
+    Default: bridge
+    Description: ECS Network Mode for the Task
+  TaskRoleName:
+    Type: String
+    Description: Enter the CloudWatch Agent ECS task role name
+  ExecutionRoleName:
+    Type: String
+    Description: Enter the CloudWatch Agent ECS execution role name
+Conditions:
+  CreateRoles:
+    Fn::Equals:
+      - Ref: CreateIAMRoles
+      - 'True'
+Resources:
+  PrometheusConfigSSMParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub 'AmazonCloudWatch-PrometheusConfigName-${ECSClusterName}-EC2-${ECSNetworkMode}'
+      Type: String
+      Tier: Standard
+      Description: !Sub 'Prometheus Scraping SSM Parameter for ECS Cluster: ${ECSClusterName}'
+      Value: |-
+        global:
+          scrape_interval: 1m
+          scrape_timeout: 10s
+        scrape_configs:
+          - job_name: cwagent-ecs-file-sd-config
+            sample_limit: 10000
+            file_sd_configs:
+              - files: [ "/tmp/cwagent_ecs_auto_sd.yaml" ]
+  CWAgentConfigSSMParameter:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub 'AmazonCloudWatch-CWAgentConfig-${ECSClusterName}-EC2-${ECSNetworkMode}'
+      Type: String
+      Tier: Intelligent-Tiering
+      Description: !Sub 'CWAgent SSM Parameter with App Mesh and Java EMF Definition for ECS Cluster: ${ECSClusterName}'
+      Value: |-
+        {
+          "logs": {
+            "metrics_collected": {
+              "prometheus": {
+                "prometheus_config_path": "env:PROMETHEUS_CONFIG_CONTENT",
+                "ecs_service_discovery": {
+                  "sd_frequency": "1m",
+                  "sd_result_file": "/tmp/cwagent_ecs_auto_sd.yaml",
+                  "docker_label": {
+                  },
+                  "task_definition_list": [
+                    {
+                      "sd_job_name": "ecs-appmesh-colors",
+                      "sd_metrics_ports": "9901",
+                      "sd_task_definition_arn_pattern": ".*:task-definition/.*-ColorTeller-(white):[0-9]+",
+                      "sd_metrics_path": "/stats/prometheus"
+                    },
+                    {
+                      "sd_job_name": "ecs-appmesh-gateway",
+                      "sd_metrics_ports": "9901",
+                      "sd_task_definition_arn_pattern": ".*:task-definition/.*-ColorGateway:[0-9]+",
+                      "sd_metrics_path": "/stats/prometheus"
+                    }
+                  ]
+                },
+                "emf_processor": {
+                  "metric_declaration_dedup": true,
+                  "metric_declaration": [
+                    {
+                      "source_labels": ["container_name"],
+                      "label_matcher": "^envoy$",
+                      "dimensions": [["ClusterName","TaskDefinitionFamily"]],
+                      "metric_selectors": [
+                        "^envoy_http_downstream_rq_(total|xx)$",
+                        "^envoy_cluster_upstream_cx_(r|t)x_bytes_total$",
+                        "^envoy_cluster_membership_(healthy|total)$",
+                        "^envoy_server_memory_(allocated|heap_size)$",
+                        "^envoy_cluster_upstream_cx_(connect_timeout|destroy_local_with_active_rq)$",
+                        "^envoy_cluster_upstream_rq_(pending_failure_eject|pending_overflow|timeout|per_try_timeout|rx_reset|maintenance_mode)$",
+                        "^envoy_http_downstream_cx_destroy_remote_active_rq$",
+                        "^envoy_cluster_upstream_flow_control_(paused_reading_total|resumed_reading_total|backed_up_total|drained_total)$",
+                        "^envoy_cluster_upstream_rq_retry$",
+                        "^envoy_cluster_upstream_rq_retry_(success|overflow)$",
+                        "^envoy_server_(version|uptime|live)$"
+                      ]
+                    },
+                    {
+                      "source_labels": ["container_name"],
+                      "label_matcher": "^envoy$",
+                      "dimensions": [["ClusterName","TaskDefinitionFamily","envoy_http_conn_manager_prefix","envoy_response_code_class"]],
+                      "metric_selectors": [
+                        "^envoy_http_downstream_rq_xx$"
+                      ]
+                    },
+                    {
+                      "source_labels": ["Java_EMF_Metrics"],
+                      "label_matcher": "^true$",
+                      "dimensions": [["ClusterName","TaskDefinitionFamily"]],
+                      "metric_selectors": [
+                        "^jvm_threads_(current|daemon)$",
+                        "^jvm_classes_loaded$",
+                        "^java_lang_operatingsystem_(freephysicalmemorysize|totalphysicalmemorysize|freeswapspacesize|totalswapspacesize|systemcpuload|processcpuload|availableprocessors|openfiledescriptorcount)$",
+                        "^catalina_manager_(rejectedsessions|activesessions)$",
+                        "^jvm_gc_collection_seconds_(count|sum)$",
+                        "^catalina_globalrequestprocessor_(bytesreceived|bytessent|requestcount|errorcount|processingtime)$"
+                      ]
+                    },
+                    {
+                      "source_labels": ["Java_EMF_Metrics"],
+                      "label_matcher": "^true$",
+                      "dimensions": [["ClusterName","TaskDefinitionFamily","area"]],
+                      "metric_selectors": [
+                        "^jvm_memory_bytes_used$"
+                      ]
+                    },
+                    {
+                      "source_labels": ["Java_EMF_Metrics"],
+                      "label_matcher": "^true$",
+                      "dimensions": [["ClusterName","TaskDefinitionFamily","pool"]],
+                      "metric_selectors": [
+                        "^jvm_memory_pool_bytes_used$"
+                      ]
+                    }
+                  ]
+                }
+              }
+            },
+            "force_flush_interval": 5
+          }
+        }
+  CWAgentECSExecutionRole:
+    Type: AWS::IAM::Role
+    Condition: CreateRoles
+    Properties:
+      RoleName: !Ref ExecutionRoleName
+      Description: Allows ECS container agent makes calls to the Amazon ECS API on your behalf.
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+      Policies:
+        - PolicyName: ECSSSMInlinePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameters
+                Resource: arn:aws:ssm:*:*:parameter/AmazonCloudWatch-*
+  CWAgentECSTaskRole:
+    Type: AWS::IAM::Role
+    Condition: CreateRoles
+    DependsOn: CWAgentECSExecutionRole
+    Properties:
+      RoleName: !Ref TaskRoleName
+      Description: Allows ECS tasks to call AWS services on your behalf.
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+      Policies:
+        - PolicyName: ECSServiceDiscoveryInlinePolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ecs:DescribeTasks
+                  - ecs:ListTasks
+                  - ecs:DescribeContainerInstances
+                Resource: "*"
+                Condition:
+                  ArnEquals:
+                    ecs:cluster:
+                      !Sub 'arn:${AWS::Partition}:ecs:${AWS::Region}:${AWS::AccountId}:cluster/${ECSClusterName}'
+              - Effect: Allow
+                Action:
+                  - ec2:DescribeInstances
+                  - ecs:DescribeTaskDefinition
+                Resource: "*"
+  ECSCWAgentTaskDefinition:
+    Type: 'AWS::ECS::TaskDefinition'
+    DependsOn:
+      - PrometheusConfigSSMParameter
+      - CWAgentConfigSSMParameter
+    Properties:
+      family: !Sub 'cwagent-prometheus-${ECSClusterName}-EC2-${ECSNetworkMode}'
+      taskRoleArn: !If [CreateRoles, !Ref CWAgentECSTaskRole, !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${TaskRoleName}']
+      executionRoleArn: !If [CreateRoles, !Ref CWAgentECSExecutionRole, !Sub 'arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${ExecutionRoleName}']
+      networkMode: !Ref ECSNetworkMode
+      containerDefinitions:
+        - name: cloudwatch-agent-prometheus
+          image: amazon/cloudwatch-agent:1.248913.0-prometheus
+          essential: true
+          mountPoints: []
+          portMappings: []
+          environment: []
+          secrets:
+            - name: PROMETHEUS_CONFIG_CONTENT
+              valueFrom: !Sub 'AmazonCloudWatch-PrometheusConfigName-${ECSClusterName}-EC2-${ECSNetworkMode}'
+            - name: CW_CONFIG_CONTENT
+              valueFrom: !Sub 'AmazonCloudWatch-CWAgentConfig-${ECSClusterName}-EC2-${ECSNetworkMode}'
+          logConfiguration:
+            logDriver: awslogs
+            options:
+              awslogs-create-group: 'True'
+              awslogs-group: "/ecs/ecs-cwagent-prometheus"
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: !Sub 'ecs-EC2-${ECSNetworkMode}'
+      requiresCompatibilities:
+        - EC2
+      cpu: '512'
+      memory: '1024'
+
+  ECSCWAgentService:
+    Type: AWS::ECS::Service
+    DependsOn: ECSCWAgentTaskDefinition
+    Properties:
+      Cluster: !Ref ECSClusterName
+      DesiredCount: 1
+      LaunchType: EC2
+      SchedulingStrategy: REPLICA
+      ServiceName: !Sub 'cwagent-prometheus-replica-service-EC2-${ECSNetworkMode}'
+      TaskDefinition: !Ref ECSCWAgentTaskDefinition

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cwagent-prometheus-task-definition.json
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cwagent-prometheus-task-definition.json
@@ -1,0 +1,43 @@
+{
+  "family": "ecs-cwagent-prometheus-replica-service-{{launchtype}}-{{networkmode}}",
+  "taskRoleArn": "{{task-role-arn}}",
+  "executionRoleArn": "{{execution-role-arn}}",
+  "networkMode": "{{networkmode}}",
+  "containerDefinitions": [
+    {
+      "name": "cloudwatch-agent-prometheus",
+      "image": "amazon/cloudwatch-agent:1.248913.0-prometheus",
+      "essential": true,
+      "mountPoints": [
+      ],
+      "portMappings": [
+      ],
+      "environment": [
+      ],
+      "secrets": [
+        {
+          "name": "PROMETHEUS_CONFIG_CONTENT",
+          "valueFrom": "{{ssm-prometheus-config}}"
+        },
+        {
+          "name": "CW_CONFIG_CONTENT",
+          "valueFrom": "{{ssm-cwagent-config}}"
+        }
+      ],
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-create-group": "True",
+          "awslogs-group": "/ecs/ecs-cwagent-prometheus",
+          "awslogs-region": "{{awslogs-region}}",
+          "awslogs-stream-prefix": "ecs-{{launchtype}}-{{networkmode}}"
+        }
+      }
+    }
+  ],
+  "requiresCompatibilities": [
+    "{{launchtype}}"
+  ],
+  "cpu": "512",
+  "memory": "1024"
+}

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_cloudwatch_dashboards/appmesh/README.md
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_cloudwatch_dashboards/appmesh/README.md
@@ -1,5 +1,4 @@
-## Sample CloudWatch Dashboard for Prometheus API Server Metrics
-Please refer to [Tutorial for Adding a New Prometheus Scrape Target: Prometheus KPI Server Metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-Setup-configure.html) for details.
+## Sample CloudWatch Dashboard for AWS App Mesh Prometheus Metrics
 
 ### Usage Guide
 
@@ -8,21 +7,21 @@ You need the following permission to create a dashboard or update an existing da
 ```
 cloudwatch:PutDashboard
 ```
-
-#### Setup Dashboard Variables 
+#### Setup Dashboard Variables
 Replace the values below to match your setup
 
 ```
 DASHBOARD_NAME=your_cw_dashboard_name
-REGION_NAME=us-east-1
-CLUSTER_NAME=your_k8s_cluster_name_here
+REGION_NAME=your_aws_region_eg:us-east-1
+CLUSTER_NAME=your_ecs_cluster_name_here
 ```
 
 #### Create Dashboard
 Create the CloudWatch Dashboard by the AWS CLI command as below:
 ```
-cat cw_dashboard_kubernetes_api_server.json \
+cat cw_dashboard_awsappmesh.json \
 | sed "s/{{YOUR_AWS_REGION}}/${REGION_NAME}/g" \
 | sed "s/{{YOUR_CLUSTER_NAME}}/${CLUSTER_NAME}/g" \
 | xargs -0 aws cloudwatch put-dashboard --dashboard-name ${DASHBOARD_NAME} --dashboard-body
 ```
+

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_cloudwatch_dashboards/appmesh/cw_dashboard_awsappmesh.json
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_cloudwatch_dashboards/appmesh/cw_dashboard_awsappmesh.json
@@ -1,0 +1,352 @@
+{
+  "widgets": [
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 1,
+      "width": 3,
+      "height": 3,
+      "properties": {
+        "metrics": [
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName, TaskDefinitionFamily} envoy_server_live', 'Sum', 60))", "label": "Count", "id": "e2", "region": "{{YOUR_AWS_REGION}}" } ]
+        ],
+        "view": "singleValue",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Sum",
+        "period": 60,
+        "title": "Meshed Pods"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 4,
+      "width": 3,
+      "height": 3,
+      "properties": {
+        "metrics": [
+          [ { "expression": "AVG(REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_server_uptime', 'Average', 60)/3600))", "label": "hour", "id": "e1", "region": "{{YOUR_AWS_REGION}}" } ]
+        ],
+        "view": "singleValue",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Sum",
+        "period": 300,
+        "setPeriodToTimeRange": false,
+        "title": "Average Uptime"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 12,
+      "y": 4,
+      "width": 6,
+      "height": 3,
+      "properties": {
+        "metrics": [
+          [ { "expression": "AVG(REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_upstream_cx_connect_timeout', 'Average', 60)))", "id": "e2" } ]
+        ],
+        "view": "singleValue",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Sum",
+        "period": 300,
+        "start": "-PT1H",
+        "end": "P0D",
+        "setPeriodToTimeRange": false,
+        "title": "Connection Timeouts"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 7,
+      "width": 18,
+      "height": 6,
+      "properties": {
+        "metrics": [
+          [ { "expression": "SUM(REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_upstream_cx_rx_bytes_total', 'Sum', 60)))/60", "id": "e1", "label": "[max: ${MAX}, avg: ${AVG}] InBound (TX)", "region": "{{YOUR_AWS_REGION}}" } ],
+          [ { "expression": "SUM(REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_upstream_cx_tx_bytes_total', 'Sum', 60)))/60", "id": "e2", "label": "[max: ${MAX}, avg: ${AVG}] OutBound (RX)", "region": "{{YOUR_AWS_REGION}}" } ]
+        ],
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Sum",
+        "period": 300,
+        "setPeriodToTimeRange": false,
+        "title": "Total Traffic (inbound & outbound) "
+      }
+    },
+    {
+      "type": "metric",
+      "x": 3,
+      "y": 4,
+      "width": 3,
+      "height": 3,
+      "properties": {
+        "metrics": [
+          [ { "expression": "SUM(REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_upstream_cx_rx_bytes_total', 'Sum', 60)))/60", "id": "e1", "region": "{{YOUR_AWS_REGION}}", "label": "kbps" } ]
+        ],
+        "view": "singleValue",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Sum",
+        "period": 60,
+        "setPeriodToTimeRange": false,
+        "title": "Inbound Traffic"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 6,
+      "y": 4,
+      "width": 3,
+      "height": 3,
+      "properties": {
+        "metrics": [
+          [ { "expression": "SUM(REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_upstream_cx_tx_bytes_total', 'Sum', 60)))/60", "id": "e1", "region": "{{YOUR_AWS_REGION}}", "label": "kbps" } ]
+        ],
+        "view": "singleValue",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Sum",
+        "period": 60,
+        "setPeriodToTimeRange": false,
+        "title": "Outbound Traffic"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 9,
+      "y": 4,
+      "width": 3,
+      "height": 3,
+      "properties": {
+        "metrics": [
+          [ { "expression": "SUM(REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_membership_total', 'Sum', 60))) - SUM(REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_membership_healthy', 'Sum', 60)))", "id": "e1", "region": "{{YOUR_AWS_REGION}}", "label": "" } ]
+        ],
+        "view": "singleValue",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Sum",
+        "period": 300,
+        "setPeriodToTimeRange": false,
+        "title": "Unhealthy Pods"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 9,
+      "y": 1,
+      "width": 3,
+      "height": 3,
+      "properties": {
+        "metrics": [
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_server_memory_heap_size', 'Sum', 60))", "id": "e2", "period": 300, "region": "{{YOUR_AWS_REGION}}", "label": "" } ]
+        ],
+        "view": "singleValue",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Sum",
+        "period": 300,
+        "setPeriodToTimeRange": false,
+        "title": "Total Envoy Heap"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 12,
+      "y": 1,
+      "width": 6,
+      "height": 3,
+      "properties": {
+        "metrics": [
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_server_memory_allocated', 'Sum', 60))", "id": "e2", "period": 300, "region": "{{YOUR_AWS_REGION}}", "label": "" } ]
+        ],
+        "view": "singleValue",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Sum",
+        "period": 300,
+        "setPeriodToTimeRange": false,
+        "title": "Total Envoy Memory Usage"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 3,
+      "y": 1,
+      "width": 3,
+      "height": 3,
+      "properties": {
+        "metrics": [
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_http_downstream_rq_total', 'Sum', 60))/60", "id": "e1", "label": "rps" } ]
+        ],
+        "view": "singleValue",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Sum",
+        "period": 300,
+        "start": "-PT1H",
+        "end": "P0D",
+        "setPeriodToTimeRange": false,
+        "title": "Requests/Second"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 6,
+      "y": 1,
+      "width": 3,
+      "height": 3,
+      "properties": {
+        "metrics": [
+          [ { "expression": "(SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx$ (envoy_http_conn_manager_prefix=\"ingress\" OR envoy_http_conn_manager_prefix=\"egress\") envoy_response_code_class=\"4\"', 'Sum', 60)) + SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx$ (envoy_http_conn_manager_prefix=\"ingress\" OR envoy_http_conn_manager_prefix=\"egress\") envoy_response_code_class=\"5\"', 'Sum', 60)))/60", "id": "e2", "period": 60, "label": "" } ]
+        ],
+        "view": "singleValue",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Sum",
+        "period": 60,
+        "setPeriodToTimeRange": false,
+        "title": "Failures/Second"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 13,
+      "width": 9,
+      "height": 6,
+      "properties": {
+        "metrics": [
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"ingress\" envoy_response_code_class=\"2\"', 'Sum', 60))/60", "id": "e3", "label": "[max: ${MAX}, avg: ${AVG}] HTTP 2XX" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"ingress\" envoy_response_code_class=\"1\"', 'Sum', 60))/60", "id": "e2", "label": "[max: ${MAX}, avg: ${AVG}] HTTP 1XX" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"ingress\" envoy_response_code_class=\"3\"', 'Sum', 60))/60", "id": "e4", "label": "[max: ${MAX}, avg: ${AVG}] HTTP 3XX" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"ingress\" envoy_response_code_class=\"4\"', 'Sum', 60))/60", "id": "e5", "label": "[max: ${MAX}, avg: ${AVG}] HTTP 4XX" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"ingress\" envoy_response_code_class=\"5\"', 'Sum', 60))/60", "id": "e1", "label": "[max: ${MAX}, avg: ${AVG}] HTTP 5XX" } ]
+        ],
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Average",
+        "period": 300,
+        "title": "Ingress HTTP Requests/sec"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 9,
+      "y": 13,
+      "width": 9,
+      "height": 6,
+      "properties": {
+        "metrics": [
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"egress\" envoy_response_code_class=\"2\"', 'Sum', 60))/60", "id": "e3", "label": "[max: ${MAX}, avg: ${AVG}] HTTP 2XX", "region": "{{YOUR_AWS_REGION}}" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"egress\" envoy_response_code_class=\"1\"', 'Sum', 60))/60", "id": "e2", "label": "[max: ${MAX}, avg: ${AVG}] HTTP 1XX", "region": "{{YOUR_AWS_REGION}}" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"egress\" envoy_response_code_class=\"3\"', 'Sum', 60))/60", "id": "e4", "label": "[max: ${MAX}, avg: ${AVG}] HTTP 3XX", "region": "{{YOUR_AWS_REGION}}" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"egress\" envoy_response_code_class=\"4\"', 'Sum', 60))/60", "id": "e5", "label": "[max: ${MAX}, avg: ${AVG}] HTTP 4XX", "region": "{{YOUR_AWS_REGION}}" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"egress\" envoy_response_code_class=\"5\"', 'Sum', 60))/60", "id": "e1", "label": "[max: ${MAX}, avg: ${AVG}] HTTP 5XX", "region": "{{YOUR_AWS_REGION}}" } ]
+        ],
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Average",
+        "period": 300,
+        "title": "Egress HTTP Requests/sec"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 19,
+      "width": 9,
+      "height": 6,
+      "properties": {
+        "metrics": [
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_upstream_rq_pending_failure_eject', 'Sum', 60))/60", "id": "e2", "label": "[max: ${MAX}, avg: ${AVG}] pending failure ejection" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_upstream_rq_pending_overflow', 'Sum', 60))/60", "id": "e3", "label": "[max: ${MAX}, avg: ${AVG}] pending overflow" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_upstream_cx_connect_timeout', 'Sum', 60))/60", "id": "e1", "label": "[max: ${MAX}, avg: ${AVG}] connect timeout" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_upstream_rq_timeout', 'Sum', 60))/60", "id": "e4", "label": "[max: ${MAX}, avg: ${AVG}] request timeout" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_upstream_rq_per_try_timeout', 'Sum', 60))/60", "id": "e5", "label": "[max: ${MAX}, avg: ${AVG}] per try request timeout" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_upstream_rq_rx_reset', 'Sum', 60))/60", "id": "e6", "label": "[max: ${MAX}, avg: ${AVG}] request reset" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_upstream_cx_destroy_local_with_active_rq', 'Sum', 60))/60", "id": "e7", "label": "[max: ${MAX}, avg: ${AVG}] destroy initialized from originating service" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_http_downstream_cx_destroy_remote_active_rq', 'Sum', 60))/60", "id": "e8", "label": "[max: ${MAX}, avg: ${AVG}] destroy initialized from remote service" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_upstream_rq_maintenance_mode', 'Sum', 60))/60", "id": "e9", "label": "[max: ${MAX}, avg: ${AVG}] request failed maintenance mode" } ]
+        ],
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Average",
+        "period": 300,
+        "title": "Upstream Request Errors"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 9,
+      "y": 19,
+      "width": 9,
+      "height": 6,
+      "properties": {
+        "metrics": [
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_upstream_flow_control_paused_reading_total', 'Sum', 60))/60", "id": "e1", "label": "[max: ${MAX}, avg: ${AVG}] paused reading from destination service", "region": "{{YOUR_AWS_REGION}}" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_upstream_flow_control_resumed_reading_total', 'Sum', 60))/60", "id": "e2", "label": "[max: ${MAX}, avg: ${AVG}] resumed reading from destination service", "region": "{{YOUR_AWS_REGION}}" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_upstream_flow_control_backed_up_total', 'Sum', 60))/60", "id": "e3", "label": "[max: ${MAX}, avg: ${AVG}] paused reading from originating service", "region": "{{YOUR_AWS_REGION}}" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_upstream_flow_control_drained_total', 'Sum', 60))/60", "id": "e4", "label": "[max: ${MAX}, avg: ${AVG}] resumed reading from originating service", "region": "{{YOUR_AWS_REGION}}" } ]
+        ],
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Average",
+        "period": 300,
+        "title": "Upstream Flow Control"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 25,
+      "width": 18,
+      "height": 6,
+      "properties": {
+        "metrics": [
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_upstream_flow_control_resumed_reading_total', 'Sum', 60))/60", "id": "e2", "label": "[max: ${MAX}, avg: ${AVG}] request retry", "region": "{{YOUR_AWS_REGION}}" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_upstream_rq_retry_success', 'Sum', 60))/60", "id": "e1", "label": "[max: ${MAX}, avg: ${AVG}] request retry success", "region": "{{YOUR_AWS_REGION}}" } ],
+          [ { "expression": "SUM(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} envoy_cluster_upstream_rq_retry_overflow', 'Sum', 60))/60", "id": "e3", "label": "[max: ${MAX}, avg: ${AVG}] request retry overflow", "region": "{{YOUR_AWS_REGION}}" } ]
+        ],
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Average",
+        "period": 300,
+        "title": "Upstream Request Retry"
+      }
+    },
+    {
+      "type": "text",
+      "x": 0,
+      "y": 0,
+      "width": 18,
+      "height": 1,
+      "properties": {
+        "markdown": "\n# ECS AWS App Mesh\n"
+      }
+    },
+    {
+      "type": "log",
+      "x": 0,
+      "y": 31,
+      "width": 18,
+      "height": 6,
+      "properties": {
+        "query": "SOURCE '/aws/ecs/containerinsights/{{YOUR_CLUSTER_NAME}}/prometheus' | fields TaskDefinitionFamily, @message\n| limit 50\n| filter CloudWatchMetrics.0.Namespace=\"ECS/ContainerInsights/Prometheus\"\n| filter CloudWatchMetrics.0.Metrics.0.Name like /envoy_/\n| stats sum(envoy_cluster_upstream_cx_rx_bytes_buffered) as bytes_rx_buffered, sum(envoy_cluster_upstream_cx_tx_bytes_buffered) as bytes_tx_buffered, sum(envoy_http_downstream_rq_xx) as http_downstream_rq_xx by TaskDefinitionFamily\n| sort bytes_rx_buffered desc \n\n",
+        "region": "{{YOUR_AWS_REGION}}",
+        "stacked": false,
+        "title": "Summary by TaskDefinitionFamily",
+        "view": "table"
+      }
+    }
+  ]
+}

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_cloudwatch_dashboards/javajmx/README.md
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_cloudwatch_dashboards/javajmx/README.md
@@ -1,5 +1,4 @@
-## Sample CloudWatch Dashboard for Prometheus API Server Metrics
-Please refer to [Tutorial for Adding a New Prometheus Scrape Target: Prometheus KPI Server Metrics](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-Setup-configure.html) for details.
+## Sample CloudWatch Dashboard for Java JMX Prometheus Metrics
 
 ### Usage Guide
 
@@ -9,20 +8,21 @@ You need the following permission to create a dashboard or update an existing da
 cloudwatch:PutDashboard
 ```
 
-#### Setup Dashboard Variables 
+#### Setup Dashboard Variables
 Replace the values below to match your setup
 
 ```
 DASHBOARD_NAME=your_cw_dashboard_name
-REGION_NAME=us-east-1
-CLUSTER_NAME=your_k8s_cluster_name_here
+REGION_NAME=your_aws_region_eg:us-east-1
+CLUSTER_NAME=your_ecs_cluster_name_here
 ```
 
 #### Create Dashboard
 Create the CloudWatch Dashboard by the AWS CLI command as below:
 ```
-cat cw_dashboard_kubernetes_api_server.json \
+cat cw_dashboard_javajmx.json \
 | sed "s/{{YOUR_AWS_REGION}}/${REGION_NAME}/g" \
 | sed "s/{{YOUR_CLUSTER_NAME}}/${CLUSTER_NAME}/g" \
 | xargs -0 aws cloudwatch put-dashboard --dashboard-name ${DASHBOARD_NAME} --dashboard-body
 ```
+

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_cloudwatch_dashboards/javajmx/cw_dashboard_javajmx.json
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_cloudwatch_dashboards/javajmx/cw_dashboard_javajmx.json
@@ -1,0 +1,282 @@
+{
+    "widgets": [
+        {
+            "type": "metric",
+            "x": 12,
+            "y": 1,
+            "width": 12,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} java_lang_operatingsystem_totalphysicalmemorysize', 'Average', 60))", "id": "e1", "region": "{{YOUR_AWS_REGION}}" } ]
+                ],
+                "view": "singleValue",
+                "stacked": true,
+                "region": "{{YOUR_AWS_REGION}}",
+                "stat": "Average",
+                "period": 60,
+                "title": "Total RAM",
+                "setPeriodToTimeRange": false
+            }
+        },
+        {
+            "type": "metric",
+            "x": 12,
+            "y": 4,
+            "width": 12,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} java_lang_operatingsystem_totalswapspacesize', 'Average', 60))", "id": "e1", "region": "{{YOUR_AWS_REGION}}", "label": "" } ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "{{YOUR_AWS_REGION}}",
+                "stat": "Average",
+                "period": 60,
+                "title": "Total SWAP"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 1,
+            "width": 12,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} java_lang_operatingsystem_systemcpuload', 'Average', 60)) * 100", "id": "e1", "region": "{{YOUR_AWS_REGION}}", "label": "" } ]
+                ],
+                "view": "singleValue",
+                "stacked": false,
+                "region": "{{YOUR_AWS_REGION}}",
+                "stat": "Average",
+                "period": 60,
+                "title": "CPU System Load"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 7,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} java_lang_operatingsystem_systemcpuload', 'Average', 60)) * 100", "id": "e1", "region": "{{YOUR_AWS_REGION}}", "label": "System" } ],
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} java_lang_operatingsystem_processcpuload', 'Average', 60)) * 100", "id": "e2", "region": "{{YOUR_AWS_REGION}}", "label": "Process" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "{{YOUR_AWS_REGION}}",
+                "stat": "Average",
+                "period": 60,
+                "title": "CPU Usage"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 12,
+            "y": 13,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily, area} jvm_memory_bytes_used', 'Average', 60))/AVG(REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} java_lang_operatingsystem_totalphysicalmemorysize', 'Average', 60))) * 100", "id": "e1", "region": "{{YOUR_AWS_REGION}}", "label": "" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "{{YOUR_AWS_REGION}}",
+                "stat": "Average",
+                "period": 60,
+                "title": "Memory Heap / Non Heap"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 13,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily, pool} jvm_memory_pool_bytes_used', 'Average', 60))", "id": "e1", "region": "{{YOUR_AWS_REGION}}", "label": "" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "{{YOUR_AWS_REGION}}",
+                "stat": "Average",
+                "period": 60,
+                "title": "Memory Pool Used "
+            }
+        },
+        {
+            "type": "metric",
+            "x": 12,
+            "y": 7,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} jvm_threads_daemon', 'Average', 60))", "id": "e2", "region": "{{YOUR_AWS_REGION}}", "label": "" } ],
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} jvm_threads_current', 'Average', 60))", "id": "e1", "region": "{{YOUR_AWS_REGION}}", "label": "" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "{{YOUR_AWS_REGION}}",
+                "stat": "Average",
+                "period": 60,
+                "title": "Threads Used"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 19,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} java_lang_operatingsystem_openfiledescriptorcount', 'Average', 60))", "id": "e1", "region": "{{YOUR_AWS_REGION}}", "label": "System" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "{{YOUR_AWS_REGION}}",
+                "stat": "Average",
+                "period": 60,
+                "title": "Open File Descriptors "
+            }
+        },
+        {
+            "type": "metric",
+            "x": 12,
+            "y": 19,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} jvm_classes_loaded', 'Average', 60)) * 100", "id": "e1", "region": "{{YOUR_AWS_REGION}}", "label": "System" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "{{YOUR_AWS_REGION}}",
+                "stat": "Average",
+                "period": 60,
+                "title": "Class Loading"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 4,
+            "width": 12,
+            "height": 3,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} java_lang_operatingsystem_availableprocessors', 'Average', 60))", "id": "e1", "region": "{{YOUR_AWS_REGION}}" } ]
+                ],
+                "view": "singleValue",
+                "stacked": true,
+                "region": "{{YOUR_AWS_REGION}}",
+                "stat": "Average",
+                "period": 60,
+                "title": "CPU Cores",
+                "setPeriodToTimeRange": false
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 25,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} catalina_manager_activesessions', 'Average', 60))", "id": "e1", "region": "{{YOUR_AWS_REGION}}", "label": "active" } ],
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} catalina_manager_rejectedsessions', 'Average', 60))", "id": "e2", "region": "{{YOUR_AWS_REGION}}", "label": "rejected" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "{{YOUR_AWS_REGION}}",
+                "stat": "Average",
+                "period": 60,
+                "title": "Catalina Manager Sessions"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 12,
+            "y": 25,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} catalina_globalrequestprocessor_bytesreceived', 'Average', 60))", "id": "e1", "region": "{{YOUR_AWS_REGION}}", "label": "recv" } ],
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} catalina_globalrequestprocessor_bytessent', 'Average', 60))", "id": "e2", "region": "{{YOUR_AWS_REGION}}", "label": "sent" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "{{YOUR_AWS_REGION}}",
+                "stat": "Average",
+                "period": 60,
+                "title": "Catalina Request Processor bytes"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 31,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} catalina_globalrequestprocessor_requestcount', 'Average', 60))", "id": "e1", "region": "{{YOUR_AWS_REGION}}", "label": "count" } ],
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} catalina_globalrequestprocessor_errorcount', 'Average', 60))", "id": "e2", "region": "{{YOUR_AWS_REGION}}", "label": "error" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "{{YOUR_AWS_REGION}}",
+                "stat": "Average",
+                "period": 60,
+                "title": "Catalina Request Processor requests"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 12,
+            "y": 31,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ { "expression": "REMOVE_EMPTY(SEARCH('{ECS/ContainerInsights/Prometheus,ClusterName,TaskDefinitionFamily} catalina_globalrequestprocessor_processingtime', 'Average', 60))", "id": "e1", "region": "{{YOUR_AWS_REGION}}", "label": "count" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "{{YOUR_AWS_REGION}}",
+                "stat": "Average",
+                "period": 60,
+                "title": "Catalina Request Processor Time",
+                "yAxis": {
+                    "left": {
+                        "label": "ms",
+                        "showUnits": false
+                    },
+                    "right": {
+                        "showUnits": false
+                    }
+                }
+            }
+        },
+        {
+            "type": "text",
+            "x": 0,
+            "y": 0,
+            "width": 24,
+            "height": 1,
+            "properties": {
+                "markdown": "\n# ECS Prometheus metrics: Java/JMX\n"
+            }
+        }
+    ]
+}

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
@@ -18,17 +18,15 @@ data:
           "prometheus": {
             "prometheus_config_path": "/etc/prometheusconfig/prometheus.yaml",
             "emf_processor": {
-              "metric_declaration_dedup": true,
               "metric_declaration": [
                 {
                   "source_labels": ["Service"],
                   "label_matcher": ".*nginx.*",
                   "dimensions": [["Service","Namespace","ClusterName"]],
                   "metric_selectors": [
-                    "^nginx_ingress_controller_requests$",
+                    "^nginx_ingress_controller_(requests|success)$",
                     "^nginx_ingress_controller_nginx_process_connections$",
                     "^nginx_ingress_controller_nginx_process_connections_total$",
-                    "^nginx_ingress_controller_success$",
                     "^nginx_ingress_controller_nginx_process_resident_memory_bytes$",
                     "^nginx_ingress_controller_nginx_process_cpu_seconds_total$",
                     "^nginx_ingress_controller_config_last_reload_successful$"
@@ -62,16 +60,11 @@ data:
                   "dimensions": [["Service","Namespace","ClusterName"]],
                   "metric_selectors": [
                     "^haproxy_backend_up$",
-                    "^haproxy_backend_bytes_in_total$",
-                    "^haproxy_backend_bytes_out_total$",
-
+                    "^haproxy_backend_bytes_(in|out)_total$",
                     "^haproxy_backend_connections_total$",
                     "^haproxy_backend_connection_errors_total$",
                     "^haproxy_backend_current_sessions$",
-
-
-                    "^haproxy_frontend_bytes_out_total$",
-                    "^haproxy_frontend_bytes_in_total$",
+                    "^haproxy_frontend_bytes_(in|out)_total$",
                     "^haproxy_frontend_connections_total$",
                     "^haproxy_frontend_http_requests_total$",
                     "^haproxy_frontend_request_errors_total$",
@@ -84,14 +77,10 @@ data:
                   "label_matcher": ".*memcached.*",
                   "dimensions": [["Service","Namespace","ClusterName"]],
                   "metric_selectors": [
-                    "^memcached_current_bytes$",
+                    "^memcached_current_(bytes|items|connections)$",
+                    "^memcached_items_(reclaimed|evicted)_total$",
+                    "^memcached_(written|read)_bytes_total$",
                     "^memcached_limit_bytes$",
-                    "^memcached_items_evicted_total$",
-                    "^memcached_items_reclaimed_total$",
-                    "^memcached_current_items$",
-                    "^memcached_read_bytes_total$",
-                    "^memcached_written_bytes_total$",
-                    "^memcached_current_connections$",
                     "^memcached_commands_total$"
                   ]
                 },
@@ -116,33 +105,17 @@ data:
                   "label_matcher": "^envoy$",
                   "dimensions": [["ClusterName","Namespace"]],
                   "metric_selectors": [
-                    "^envoy_http_downstream_rq_total$",
-                    "^envoy_http_downstream_rq_xx$",
-                    "^envoy_cluster_upstream_cx_rx_bytes_total$",
-                    "^envoy_cluster_upstream_cx_tx_bytes_total$",
-                    "^envoy_cluster_membership_healthy$",
-                    "^envoy_cluster_membership_total$",
-                    "^envoy_server_memory_heap_size$",
-                    "^envoy_server_memory_allocated$",
-                    "^envoy_cluster_upstream_cx_connect_timeout$",
-                    "^envoy_cluster_upstream_rq_pending_failure_eject$",
-                    "^envoy_cluster_upstream_rq_pending_overflow$",
-                    "^envoy_cluster_upstream_rq_timeout$",
-                    "^envoy_cluster_upstream_rq_per_try_timeout$",
-                    "^envoy_cluster_upstream_rq_rx_reset$",
-                    "^envoy_cluster_upstream_cx_destroy_local_with_active_rq$",
+                    "^envoy_http_downstream_rq_(total|xx)$",
+                    "^envoy_cluster_upstream_cx_(r|t)x_bytes_total$",
+                    "^envoy_cluster_membership_(healthy|total)$",
+                    "^envoy_server_memory_(allocated|heap_size)$",
+                    "^envoy_cluster_upstream_cx_(connect_timeout|destroy_local_with_active_rq)$",
+                    "^envoy_cluster_upstream_rq_(pending_failure_eject|pending_overflow|timeout|per_try_timeout|rx_reset|maintenance_mode)$",
                     "^envoy_http_downstream_cx_destroy_remote_active_rq$",
-                    "^envoy_cluster_upstream_rq_maintenance_mode$",
-                    "^envoy_cluster_upstream_flow_control_paused_reading_total$",
-                    "^envoy_cluster_upstream_flow_control_resumed_reading_total$",
-                    "^envoy_cluster_upstream_flow_control_backed_up_total$",
-                    "^envoy_cluster_upstream_flow_control_drained_total$",
+                    "^envoy_cluster_upstream_flow_control_(paused_reading_total|resumed_reading_total|backed_up_total|drained_total)$",
                     "^envoy_cluster_upstream_rq_retry$",
-                    "^envoy_cluster_upstream_rq_retry_success$",
-                    "^envoy_cluster_upstream_rq_retry_overflow$",
-                    "^envoy_server_live$",
-                    "^envoy_server_uptime$",
-                    "^envoy_server_version$"
+                    "^envoy_cluster_upstream_rq_retry_(success|overflow)$",
+                    "^envoy_server_(version|uptime|live)$"
                   ]
                 },
                 {
@@ -158,26 +131,12 @@ data:
                   "label_matcher": "^kubernetes-pod-jmx$",
                   "dimensions": [["ClusterName","Namespace"]],
                   "metric_selectors": [
-                    "^jvm_threads_current$",
-                    "^jvm_threads_daemon$",
+                    "^jvm_threads_(current|daemon)$",
                     "^jvm_classes_loaded$",
-                    "^java_lang_operatingsystem_freephysicalmemorysize$",
-                    "^java_lang_operatingsystem_totalphysicalmemorysize$",
-                    "^java_lang_operatingsystem_freeswapspacesize$",
-                    "^java_lang_operatingsystem_totalswapspacesize$",
-                    "^java_lang_operatingsystem_systemcpuload$",
-                    "^java_lang_operatingsystem_processcpuload$",
-                    "^java_lang_operatingsystem_availableprocessors$",
-                    "^java_lang_operatingsystem_openfiledescriptorcount$",
-                    "^catalina_manager_activesessions$",
-                    "^catalina_manager_rejectedsessions$",
-                    "^jvm_gc_collection_seconds_sum$",
-                    "^jvm_gc_collection_seconds_count$",
-                    "^catalina_globalrequestprocessor_bytesreceived$",
-                    "^catalina_globalrequestprocessor_bytessent$",
-                    "^catalina_globalrequestprocessor_requestcount$",
-                    "^catalina_globalrequestprocessor_errorcount$",
-                    "^catalina_globalrequestprocessor_processingtime$"
+                    "^java_lang_operatingsystem_(freephysicalmemorysize|totalphysicalmemorysize|freeswapspacesize|totalswapspacesize|systemcpuload|processcpuload|availableprocessors|openfiledescriptorcount)$",
+                    "^catalina_manager_(rejectedsessions|activesessions)$",
+                    "^jvm_gc_collection_seconds_(count|sum)$",
+                    "^catalina_globalrequestprocessor_(bytesreceived|bytessent|requestcount|errorcount|processingtime)$"
                   ]
                 },
                 {
@@ -306,6 +265,10 @@ data:
         source_labels:
         - __meta_kubernetes_pod_container_name
         target_label: container_name
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'go_gc_duration_seconds.*'
+        action: drop
 
     - job_name: 'kubernetes-pod-jmx'
       sample_limit: 10000
@@ -341,6 +304,10 @@ data:
         source_labels:
         - __meta_kubernetes_pod_phase
         target_label: pod_phase
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'jvm_gc_collection_seconds.*'
+        action: drop
 
 kind: ConfigMap
 metadata:
@@ -410,7 +377,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:1.243835.0-prometheus-beta
+          image: amazon/cloudwatch-agent:1.248913.0-prometheus
           imagePullPolicy: Always
           resources:
             limits:
@@ -422,7 +389,7 @@ spec:
           # Please don't change below envs
           env:
             - name: CI_VERSION
-              value: "k8s/1.1.0-prometheus-beta"
+              value: "k8s/1.2.0-prometheus"
           # Please don't change the mountPath
           volumeMounts:
             - name: prometheus-cwagentconfig

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-k8s.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-k8s.yaml
@@ -20,19 +20,18 @@ data:
         "metrics_collected": {
           "prometheus": {
             "cluster_name": "{{cluster_name}}",
+            "log_group_name": "/aws/containerinsights/{{cluster_name}}/prometheus",
             "prometheus_config_path": "/etc/prometheusconfig/prometheus.yaml",
             "emf_processor": {
-              "metric_declaration_dedup": true,
               "metric_declaration": [
                 {
                   "source_labels": ["Service"],
                   "label_matcher": ".*nginx.*",
                   "dimensions": [["Service","Namespace","ClusterName"]],
                   "metric_selectors": [
-                    "^nginx_ingress_controller_requests$",
+                    "^nginx_ingress_controller_(requests|success)$",
                     "^nginx_ingress_controller_nginx_process_connections$",
                     "^nginx_ingress_controller_nginx_process_connections_total$",
-                    "^nginx_ingress_controller_success$",
                     "^nginx_ingress_controller_nginx_process_resident_memory_bytes$",
                     "^nginx_ingress_controller_nginx_process_cpu_seconds_total$",
                     "^nginx_ingress_controller_config_last_reload_successful$"
@@ -66,13 +65,11 @@ data:
                   "dimensions": [["Service","Namespace","ClusterName"]],
                   "metric_selectors": [
                     "^haproxy_backend_up$",
-                    "^haproxy_backend_bytes_in_total$",
-                    "^haproxy_backend_bytes_out_total$",
+                    "^haproxy_backend_bytes_(in|out)_total$",
                     "^haproxy_backend_connections_total$",
                     "^haproxy_backend_connection_errors_total$",
                     "^haproxy_backend_current_sessions$",
-                    "^haproxy_frontend_bytes_out_total$",
-                    "^haproxy_frontend_bytes_in_total$",
+                    "^haproxy_frontend_bytes_(in|out)_total$",
                     "^haproxy_frontend_connections_total$",
                     "^haproxy_frontend_http_requests_total$",
                     "^haproxy_frontend_request_errors_total$",
@@ -85,14 +82,10 @@ data:
                   "label_matcher": ".*memcached.*",
                   "dimensions": [["Service","Namespace","ClusterName"]],
                   "metric_selectors": [
-                    "^memcached_current_bytes$",
+                    "^memcached_current_(bytes|items|connections)$",
+                    "^memcached_items_(reclaimed|evicted)_total$",
+                    "^memcached_(written|read)_bytes_total$",
                     "^memcached_limit_bytes$",
-                    "^memcached_items_evicted_total$",
-                    "^memcached_items_reclaimed_total$",
-                    "^memcached_current_items$",
-                    "^memcached_read_bytes_total$",
-                    "^memcached_written_bytes_total$",
-                    "^memcached_current_connections$",
                     "^memcached_commands_total$"
                   ]
                 },
@@ -117,33 +110,17 @@ data:
                   "label_matcher": "^envoy$",
                   "dimensions": [["ClusterName","Namespace"]],
                   "metric_selectors": [
-                    "^envoy_http_downstream_rq_total$",
-                    "^envoy_http_downstream_rq_xx$",
-                    "^envoy_cluster_upstream_cx_rx_bytes_total$",
-                    "^envoy_cluster_upstream_cx_tx_bytes_total$",
-                    "^envoy_cluster_membership_healthy$",
-                    "^envoy_cluster_membership_total$",
-                    "^envoy_server_memory_heap_size$",
-                    "^envoy_server_memory_allocated$",
-                    "^envoy_cluster_upstream_cx_connect_timeout$",
-                    "^envoy_cluster_upstream_rq_pending_failure_eject$",
-                    "^envoy_cluster_upstream_rq_pending_overflow$",
-                    "^envoy_cluster_upstream_rq_timeout$",
-                    "^envoy_cluster_upstream_rq_per_try_timeout$",
-                    "^envoy_cluster_upstream_rq_rx_reset$",
-                    "^envoy_cluster_upstream_cx_destroy_local_with_active_rq$",
+                    "^envoy_http_downstream_rq_(total|xx)$",
+                    "^envoy_cluster_upstream_cx_(r|t)x_bytes_total$",
+                    "^envoy_cluster_membership_(healthy|total)$",
+                    "^envoy_server_memory_(allocated|heap_size)$",
+                    "^envoy_cluster_upstream_cx_(connect_timeout|destroy_local_with_active_rq)$",
+                    "^envoy_cluster_upstream_rq_(pending_failure_eject|pending_overflow|timeout|per_try_timeout|rx_reset|maintenance_mode)$",
                     "^envoy_http_downstream_cx_destroy_remote_active_rq$",
-                    "^envoy_cluster_upstream_rq_maintenance_mode$",
-                    "^envoy_cluster_upstream_flow_control_paused_reading_total$",
-                    "^envoy_cluster_upstream_flow_control_resumed_reading_total$",
-                    "^envoy_cluster_upstream_flow_control_backed_up_total$",
-                    "^envoy_cluster_upstream_flow_control_drained_total$",
+                    "^envoy_cluster_upstream_flow_control_(paused_reading_total|resumed_reading_total|backed_up_total|drained_total)$",
                     "^envoy_cluster_upstream_rq_retry$",
-                    "^envoy_cluster_upstream_rq_retry_success$",
-                    "^envoy_cluster_upstream_rq_retry_overflow$",
-                    "^envoy_server_live$",
-                    "^envoy_server_uptime$",
-                    "^envoy_server_version$"
+                    "^envoy_cluster_upstream_rq_retry_(success|overflow)$",
+                    "^envoy_server_(version|uptime|live)$"
                   ]
                 },
                 {
@@ -159,26 +136,12 @@ data:
                   "label_matcher": "^kubernetes-pod-jmx$",
                   "dimensions": [["ClusterName","Namespace"]],
                   "metric_selectors": [
-                    "^jvm_threads_current$",
-                    "^jvm_threads_daemon$",
+                    "^jvm_threads_(current|daemon)$",
                     "^jvm_classes_loaded$",
-                    "^java_lang_operatingsystem_freephysicalmemorysize$",
-                    "^java_lang_operatingsystem_totalphysicalmemorysize$",
-                    "^java_lang_operatingsystem_freeswapspacesize$",
-                    "^java_lang_operatingsystem_totalswapspacesize$",
-                    "^java_lang_operatingsystem_systemcpuload$",
-                    "^java_lang_operatingsystem_processcpuload$",
-                    "^java_lang_operatingsystem_availableprocessors$",
-                    "^java_lang_operatingsystem_openfiledescriptorcount$",
-                    "^catalina_manager_activesessions$",
-                    "^catalina_manager_rejectedsessions$",
-                    "^jvm_gc_collection_seconds_sum$",
-                    "^jvm_gc_collection_seconds_count$",
-                    "^catalina_globalrequestprocessor_bytesreceived$",
-                    "^catalina_globalrequestprocessor_bytessent$",
-                    "^catalina_globalrequestprocessor_requestcount$",
-                    "^catalina_globalrequestprocessor_errorcount$",
-                    "^catalina_globalrequestprocessor_processingtime$"
+                    "^java_lang_operatingsystem_(freephysicalmemorysize|totalphysicalmemorysize|freeswapspacesize|totalswapspacesize|systemcpuload|processcpuload|availableprocessors|openfiledescriptorcount)$",
+                    "^catalina_manager_(rejectedsessions|activesessions)$",
+                    "^jvm_gc_collection_seconds_(count|sum)$",
+                    "^catalina_globalrequestprocessor_(bytesreceived|bytessent|requestcount|errorcount|processingtime)$"
                   ]
                 },
                 {
@@ -307,6 +270,10 @@ data:
         source_labels:
         - __meta_kubernetes_pod_container_name
         target_label: container_name
+      metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'go_gc_duration_seconds.*'
+        action: drop
 
     - job_name: 'kubernetes-pod-jmx'
       sample_limit: 10000
@@ -342,6 +309,9 @@ data:
         source_labels:
         - __meta_kubernetes_pod_phase
         target_label: pod_phase
+      - source_labels: [__name__]
+        regex: 'jvm_gc_collection_seconds.*'
+        action: drop
 
 kind: ConfigMap
 metadata:
@@ -411,7 +381,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:1.243835.0-prometheus-beta
+          image: amazon/cloudwatch-agent:1.248913.0-prometheus
           imagePullPolicy: Always
           resources:
             limits:
@@ -423,7 +393,7 @@ spec:
           # Please don't change below envs
           env:
             - name: CI_VERSION
-              value: "k8s/1.1.0-prometheus-beta"
+              value: "k8s/1.2.0-prometheus"
           # Please don't change the mountPath
           volumeMounts:
             - name: prometheus-cwagentconfig

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/appmesh/README.md
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/appmesh/README.md
@@ -3,6 +3,12 @@ Please refer to [Viewing Your Prometheus Metrics](https://docs.aws.amazon.com/Am
 
 ### Usage Guide
 
+#### Required Permission
+You need the following permission to create a dashboard or update an existing dashboard.
+```
+cloudwatch:PutDashboard
+```
+
 #### Setup Dashboard Variables
 Replace the values below to match your setup
 

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/appmesh/cw_dashboard_awsappmesh.json
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/appmesh/cw_dashboard_awsappmesh.json
@@ -66,8 +66,8 @@
             "height": 6,
             "properties": {
                 "metrics": [
-                    [ { "expression": "SUM(REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_cx_rx_bytes_total', 'Sum', 60)))/60", "id": "e1", "label": "InBound (TX)", "region": "{{YOUR_AWS_REGION}}" } ],
-                    [ { "expression": "SUM(REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_cx_tx_bytes_total', 'Sum', 60)))/60", "id": "e2", "label": "OutBound (RX)", "region": "{{YOUR_AWS_REGION}}" } ]
+                    [ { "expression": "SUM(REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_cx_rx_bytes_total', 'Sum', 60)))/60", "id": "e1", "label": "[max: ${MAX}, avg: ${AVG}] InBound (TX)", "region": "{{YOUR_AWS_REGION}}" } ],
+                    [ { "expression": "SUM(REMOVE_EMPTY(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_cx_tx_bytes_total', 'Sum', 60)))/60", "id": "e2", "label": "[max: ${MAX}, avg: ${AVG}] OutBound (RX)", "region": "{{YOUR_AWS_REGION}}" } ]
                 ],
                 "view": "timeSeries",
                 "stacked": false,
@@ -221,11 +221,11 @@
             "height": 6,
             "properties": {
                 "metrics": [
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"ingress\" envoy_response_code_class=\"2\"', 'Sum', 60))/60", "id": "e3", "label": "[avg: ${AVG}] HTTP 2XX" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"ingress\" envoy_response_code_class=\"1\"', 'Sum', 60))/60", "id": "e2", "label": "[avg: ${AVG}] HTTP 1XX" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"ingress\" envoy_response_code_class=\"3\"', 'Sum', 60))/60", "id": "e4", "label": "[avg: ${AVG}] HTTP 3XX" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"ingress\" envoy_response_code_class=\"4\"', 'Sum', 60))/60", "id": "e5", "label": "[avg: ${AVG}] HTTP 4XX" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"ingress\" envoy_response_code_class=\"5\"', 'Sum', 60))/60", "id": "e1", "label": "[avg: ${AVG}] HTTP 5XX" } ]
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"ingress\" envoy_response_code_class=\"2\"', 'Sum', 60))/60", "id": "e3", "label": "[max: ${MAX}, avg: ${AVG}] HTTP 2XX" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"ingress\" envoy_response_code_class=\"1\"', 'Sum', 60))/60", "id": "e2", "label": "[max: ${MAX}, avg: ${AVG}] HTTP 1XX" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"ingress\" envoy_response_code_class=\"3\"', 'Sum', 60))/60", "id": "e4", "label": "[max: ${MAX}, avg: ${AVG}] HTTP 3XX" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"ingress\" envoy_response_code_class=\"4\"', 'Sum', 60))/60", "id": "e5", "label": "[max: ${MAX}, avg: ${AVG}] HTTP 4XX" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"ingress\" envoy_response_code_class=\"5\"', 'Sum', 60))/60", "id": "e1", "label": "[max: ${MAX}, avg: ${AVG}] HTTP 5XX" } ]
                 ],
                 "view": "timeSeries",
                 "stacked": false,
@@ -243,11 +243,11 @@
             "height": 6,
             "properties": {
                 "metrics": [
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"egress\" envoy_response_code_class=\"2\"', 'Sum', 60))/60", "id": "e3", "label": "[avg: ${AVG}] HTTP 2XX", "region": "{{YOUR_AWS_REGION}}" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"egress\" envoy_response_code_class=\"1\"', 'Sum', 60))/60", "id": "e2", "label": "[avg: ${AVG}] HTTP 1XX", "region": "{{YOUR_AWS_REGION}}" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"egress\" envoy_response_code_class=\"3\"', 'Sum', 60))/60", "id": "e4", "label": "[avg: ${AVG}] HTTP 3XX", "region": "{{YOUR_AWS_REGION}}" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"egress\" envoy_response_code_class=\"4\"', 'Sum', 60))/60", "id": "e5", "label": "[avg: ${AVG}] HTTP 4XX", "region": "{{YOUR_AWS_REGION}}" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"egress\" envoy_response_code_class=\"5\"', 'Sum', 60))/60", "id": "e1", "label": "[avg: ${AVG}] HTTP 5XX", "region": "{{YOUR_AWS_REGION}}" } ]
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"egress\" envoy_response_code_class=\"2\"', 'Sum', 60))/60", "id": "e3", "label": "[max: ${MAX}, avg: ${AVG}] HTTP 2XX", "region": "{{YOUR_AWS_REGION}}" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"egress\" envoy_response_code_class=\"1\"', 'Sum', 60))/60", "id": "e2", "label": "[max: ${MAX}, avg: ${AVG}] HTTP 1XX", "region": "{{YOUR_AWS_REGION}}" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"egress\" envoy_response_code_class=\"3\"', 'Sum', 60))/60", "id": "e4", "label": "[max: ${MAX}, avg: ${AVG}] HTTP 3XX", "region": "{{YOUR_AWS_REGION}}" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"egress\" envoy_response_code_class=\"4\"', 'Sum', 60))/60", "id": "e5", "label": "[max: ${MAX}, avg: ${AVG}] HTTP 4XX", "region": "{{YOUR_AWS_REGION}}" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace,envoy_http_conn_manager_prefix,envoy_response_code_class} envoy_http_downstream_rq_xx envoy_http_conn_manager_prefix=\"egress\" envoy_response_code_class=\"5\"', 'Sum', 60))/60", "id": "e1", "label": "[max: ${MAX}, avg: ${AVG}] HTTP 5XX", "region": "{{YOUR_AWS_REGION}}" } ]
                 ],
                 "view": "timeSeries",
                 "stacked": false,
@@ -265,15 +265,15 @@
             "height": 6,
             "properties": {
                 "metrics": [
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_pending_failure_eject', 'Sum', 60))/60", "id": "e2", "label": "[min: ${MIN}, max: ${MAX}, avg: ${AVG}, last: ${LAST}] pending failure ejection" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_pending_overflow', 'Sum', 60))/60", "id": "e3", "label": "[min: ${MIN}, max: ${MAX}, avg: ${AVG}, last: ${LAST}] pending overflow" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_cx_connect_timeout', 'Sum', 60))/60", "id": "e1", "label": "[min: ${MIN}, max: ${MAX}, avg: ${AVG}, last: ${LAST}] connect timeout" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_timeout', 'Sum', 60))/60", "id": "e4", "label": "[min: ${MIN}, max: ${MAX}, avg: ${AVG}, last: ${LAST}] request timeout" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_per_try_timeout', 'Sum', 60))/60", "id": "e5", "label": "[min: ${MIN}, max: ${MAX}, avg: ${AVG}, last: ${LAST}] per try request timeout" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_rx_reset', 'Sum', 60))/60", "id": "e6", "label": "[min: ${MIN}, max: ${MAX}, avg: ${AVG}, last: ${LAST}] request reset" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_cx_destroy_local_with_active_rq', 'Sum', 60))/60", "id": "e7", "label": "[min: ${MIN}, max: ${MAX}, avg: ${AVG}, last: ${LAST}] destroy initialized from originating service" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_http_downstream_cx_destroy_remote_active_rq', 'Sum', 60))/60", "id": "e8", "label": "[min: ${MIN}, max: ${MAX}, avg: ${AVG}, last: ${LAST}] destroy initialized from remote service" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_maintenance_mode', 'Sum', 60))/60", "id": "e9", "label": "[min: ${MIN}, max: ${MAX}, avg: ${AVG}, last: ${LAST}] request failed maintenance mode" } ]
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_pending_failure_eject', 'Sum', 60))/60", "id": "e2", "label": "[max: ${MAX}, avg: ${AVG}] pending failure ejection" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_pending_overflow', 'Sum', 60))/60", "id": "e3", "label": "[max: ${MAX}, avg: ${AVG}] pending overflow" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_cx_connect_timeout', 'Sum', 60))/60", "id": "e1", "label": "[max: ${MAX}, avg: ${AVG}] connect timeout" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_timeout', 'Sum', 60))/60", "id": "e4", "label": "[max: ${MAX}, avg: ${AVG}] request timeout" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_per_try_timeout', 'Sum', 60))/60", "id": "e5", "label": "[max: ${MAX}, avg: ${AVG}] per try request timeout" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_rx_reset', 'Sum', 60))/60", "id": "e6", "label": "[max: ${MAX}, avg: ${AVG}] request reset" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_cx_destroy_local_with_active_rq', 'Sum', 60))/60", "id": "e7", "label": "[max: ${MAX}, avg: ${AVG}] destroy initialized from originating service" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_http_downstream_cx_destroy_remote_active_rq', 'Sum', 60))/60", "id": "e8", "label": "[max: ${MAX}, avg: ${AVG}] destroy initialized from remote service" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_maintenance_mode', 'Sum', 60))/60", "id": "e9", "label": "[max: ${MAX}, avg: ${AVG}] request failed maintenance mode" } ]
                 ],
                 "view": "timeSeries",
                 "stacked": false,
@@ -291,10 +291,10 @@
             "height": 6,
             "properties": {
                 "metrics": [
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_flow_control_paused_reading_total', 'Sum', 60))/60", "id": "e1", "label": "[avg: ${AVG}] paused reading from destination service", "region": "{{YOUR_AWS_REGION}}" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_flow_control_resumed_reading_total', 'Sum', 60))/60", "id": "e2", "label": "[avg: ${AVG}] resumed reading from destination service", "region": "{{YOUR_AWS_REGION}}" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_flow_control_backed_up_total', 'Sum', 60))/60", "id": "e3", "label": "[avg: ${AVG}] paused reading from originating service", "region": "{{YOUR_AWS_REGION}}" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_flow_control_drained_total', 'Sum', 60))/60", "id": "e4", "label": "[avg: ${AVG}] resumed reading from originating service", "region": "{{YOUR_AWS_REGION}}" } ]
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_flow_control_paused_reading_total', 'Sum', 60))/60", "id": "e1", "label": "[max: ${MAX}, avg: ${AVG}] paused reading from destination service", "region": "{{YOUR_AWS_REGION}}" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_flow_control_resumed_reading_total', 'Sum', 60))/60", "id": "e2", "label": "[max: ${MAX}, avg: ${AVG}] resumed reading from destination service", "region": "{{YOUR_AWS_REGION}}" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_flow_control_backed_up_total', 'Sum', 60))/60", "id": "e3", "label": "[max: ${MAX}, avg: ${AVG}] paused reading from originating service", "region": "{{YOUR_AWS_REGION}}" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_flow_control_drained_total', 'Sum', 60))/60", "id": "e4", "label": "[max: ${MAX}, avg: ${AVG}] resumed reading from originating service", "region": "{{YOUR_AWS_REGION}}" } ]
                 ],
                 "view": "timeSeries",
                 "stacked": false,
@@ -312,9 +312,9 @@
             "height": 6,
             "properties": {
                 "metrics": [
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_flow_control_resumed_reading_total', 'Sum', 60))/60", "id": "e2", "label": "[avg: ${AVG}] request retry", "region": "{{YOUR_AWS_REGION}}" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_retry_success', 'Sum', 60))/60", "id": "e1", "label": "[avg: ${AVG}] request retry success", "region": "{{YOUR_AWS_REGION}}" } ],
-                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_retry_overflow', 'Sum', 60))/60", "id": "e3", "label": "[avg: ${AVG}] request retry overflow", "region": "{{YOUR_AWS_REGION}}" } ]
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_flow_control_resumed_reading_total', 'Sum', 60))/60", "id": "e2", "label": "[max: ${MAX}, avg: ${AVG}] request retry", "region": "{{YOUR_AWS_REGION}}" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_retry_success', 'Sum', 60))/60", "id": "e1", "label": "[max: ${MAX}, avg: ${AVG}] request retry success", "region": "{{YOUR_AWS_REGION}}" } ],
+                    [ { "expression": "SUM(SEARCH('{ContainerInsights/Prometheus,ClusterName,Namespace} envoy_cluster_upstream_rq_retry_overflow', 'Sum', 60))/60", "id": "e3", "label": "[max: ${MAX}, avg: ${AVG}] request retry overflow", "region": "{{YOUR_AWS_REGION}}" } ]
                 ],
                 "view": "timeSeries",
                 "stacked": false,
@@ -331,7 +331,7 @@
             "width": 18,
             "height": 1,
             "properties": {
-                "markdown": "\n# AWS App Mesh\n"
+                "markdown": "\n# K8S AWS App Mesh\n"
             }
         },
         {

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/haproxy-ingress/README.md
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/haproxy-ingress/README.md
@@ -3,6 +3,12 @@ Please refer to [Viewing Your Prometheus Metrics](https://docs.aws.amazon.com/Am
 
 ### Usage Guide
 
+#### Required Permission
+You need the following permission to create a dashboard or update an existing dashboard.
+```
+cloudwatch:PutDashboard
+```
+
 #### Setup Dashboard Variables
 Replace the values below to match your setup
 

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/javajmx/README.md
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/javajmx/README.md
@@ -3,6 +3,12 @@ Please refer to [Viewing Your Prometheus Metrics](https://docs.aws.amazon.com/Am
 
 ### Usage Guide
 
+#### Required Permission
+You need the following permission to create a dashboard or update an existing dashboard.
+```
+cloudwatch:PutDashboard
+```
+
 #### Setup Dashboard Variables
 Replace the values below to match your setup
 

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/memcached/README.md
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/memcached/README.md
@@ -3,6 +3,12 @@ Please refer to [Viewing Your Prometheus Metrics](https://docs.aws.amazon.com/Am
 
 ### Usage Guide
 
+#### Required Permission
+You need the following permission to create a dashboard or update an existing dashboard.
+```
+cloudwatch:PutDashboard
+```
+
 #### Setup Dashboard Variables
 Replace the values below to match your setup
 

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/nginx-ingress/README.md
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/nginx-ingress/README.md
@@ -3,6 +3,12 @@ Please refer to [Viewing Your Prometheus Metrics](https://docs.aws.amazon.com/Am
 
 ### Usage Guide
 
+#### Required Permission
+You need the following permission to create a dashboard or update an existing dashboard.
+```
+cloudwatch:PutDashboard
+```
+
 #### Setup Dashboard Variables
 Replace the values below to match your setup
 


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
* Add Sample CWAgent Installation file for Amazon ECS
* Upgrade docker image to amazon/cloudwatch-agent:1.248913.0-prometheus
* Add required permission for creating sample CloudWatch Dashboard in README.md
* Condense the metric_definition for prometheus-eks.yaml and prometheus-k8s.yaml


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
