### PR TITLE
Added NodeSelector to prevent it from running on windows Nodes

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
@@ -146,6 +146,8 @@ spec:
             - name: devdisk
               mountPath: /dev/disk
               readOnly: true
+      nodeSelector:
+        kubernetes.io/os: linux
       volumes:
         - name: cwagentconfig
           configMap:
@@ -598,6 +600,8 @@ spec:
             - name: dmesg
               mountPath: /var/log/dmesg
               readOnly: true
+      nodeSelector:
+        kubernetes.io/os: linux
       volumes:
         - name: config-volume
           configMap:


### PR DESCRIPTION
*Issue #14 

*Description of changes:*

Added a Linux Node Selector to prevent the pods running on Windows nodes as there currently isn't a fluentd image available to Windows (according to AWS)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
