### PR TITLE
Add Redis Prometheus Artificats for Amazon ECS and K8S

### DIFF
--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_cloudwatch_dashboards/README.md
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_cloudwatch_dashboards/README.md
@@ -1,0 +1,7 @@
+## Sample CloudWatch Dashboards
+
+This directory contains sample CloudWatch dashboards for different workloads' Prometheus metrics.
+
+* [appmesh](appmesh) provides sample CloudWatch dashboard for [AWS App Mesh](https://aws.amazon.com/app-mesh/) Prometheus metrics.
+* [javajmx](javajmx) provides sample CloudWatch dashboard for [JMX_Exporter](https://github.com/prometheus/jmx_exporter) Prometheus metrics.
+* [redis](redis) provides sample CloudWatch dashboard for [Redis](https://redis.io/) Prometheus metrics.

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_cloudwatch_dashboards/redis/README.md
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_cloudwatch_dashboards/redis/README.md
@@ -1,0 +1,29 @@
+## Sample CloudWatch Dashboard for Redis Prometheus Metrics
+
+### Usage Guide
+
+#### Required Permission
+You need the following permission to create a dashboard or update an existing dashboard.
+```
+cloudwatch:PutDashboard
+```
+
+#### Setup Dashboard Variables
+Replace the values below to match your setup
+
+```
+DASHBOARD_NAME=your_cw_dashboard_name
+REGION_NAME=your_aws_region_eg:us-east-1
+CLUSTER_NAME=your_ecs_cluster_name_here
+ECS_TASK_DEF_FAMILY=your_redis_ecs_task definition_family_name_here
+```
+
+#### Create Dashboard
+Create the CloudWatch Dashboard by the AWS CLI command as below:
+```
+cat cw_dashboard_javajmx.json \
+| sed "s/{{YOUR_AWS_REGION}}/${REGION_NAME}/g" \
+| sed "s/{{YOUR_CLUSTER_NAME}}/${CLUSTER_NAME}/g" \
+| sed "s/{{YOUR_TASK_DEF_FAMILY}}/${ECS_TASK_DEF_FAMILY}/g" \
+| xargs -0 aws cloudwatch put-dashboard --dashboard-name ${DASHBOARD_NAME} --dashboard-body
+```

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_cloudwatch_dashboards/redis/cw_dashboard_redis.json
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_cloudwatch_dashboards/redis/cw_dashboard_redis.json
@@ -1,0 +1,174 @@
+{
+  "widgets": [
+    {
+      "type": "metric",
+      "x": 9,
+      "y": 19,
+      "width": 9,
+      "height": 6,
+      "properties": {
+        "metrics": [
+          [ "ECS/ContainerInsights/Prometheus", "redis_db_keys", "ClusterName", "{{YOUR_CLUSTER_NAME}}", "db", "db4", "TaskDefinitionFamily", "{{YOUR_TASK_DEF_FAMILY}}", { "label": "[max: ${MAX}, avg: ${AVG}] db4" } ],
+          [ "...", "db3", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db3" } ],
+          [ "...", "db6", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db6" } ],
+          [ "...", "db5", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db5" } ],
+          [ "...", "db0", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db0" } ],
+          [ "...", "db2", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db2" } ],
+          [ "...", "db1", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db1" } ],
+          [ "...", "db15", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db15" } ],
+          [ "...", "db14", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db14" } ],
+          [ "...", "db13", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db13" } ],
+          [ "...", "db12", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db12" } ],
+          [ "...", "db11", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db11" } ],
+          [ "...", "db10", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db10" } ],
+          [ "...", "db8", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db8" } ],
+          [ "...", "db7", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db7" } ],
+          [ "...", "db9", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db9" } ]
+        ],
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Average",
+        "period": 60,
+        "title": "Total Items per DB",
+        "legend": {
+          "position": "right"
+        }
+      }
+    },
+    {
+      "type": "text",
+      "x": 0,
+      "y": 0,
+      "width": 18,
+      "height": 1,
+      "properties": {
+        "markdown": "\n# ECS Redis\n"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 7,
+      "width": 9,
+      "height": 6,
+      "properties": {
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Average",
+        "period": 60,
+        "metrics": [
+          [ "ECS/ContainerInsights/Prometheus", "redis_keyspace_misses_total", "ClusterName", "{{YOUR_CLUSTER_NAME}}", "TaskDefinitionFamily", "{{YOUR_TASK_DEF_FAMILY}}", { "label": "[max: ${MAX}, avg: ${AVG}] redis_keyspace_misses_total" } ],
+          [ ".", "redis_keyspace_hits_total", ".", ".", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] redis_keyspace_hits_total" } ]
+        ],
+        "title": "Hits vs Missed"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 1,
+      "width": 9,
+      "height": 6,
+      "properties": {
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Average",
+        "period": 60,
+        "title": "Memory Usage",
+        "metrics": [
+          [ "ECS/ContainerInsights/Prometheus", "redis_memory_used_bytes", "ClusterName", "{{YOUR_CLUSTER_NAME}}", "TaskDefinitionFamily", "{{YOUR_TASK_DEF_FAMILY}}", { "label": "[max: ${MAX}, avg: ${AVG}] redis_memory_used_bytes" } ]
+        ],
+        "liveData": false,
+        "legend": {
+          "position": "bottom"
+        }
+      }
+    },
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 19,
+      "width": 9,
+      "height": 6,
+      "properties": {
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Average",
+        "period": 60,
+        "title": "Network I/O",
+        "metrics": [
+          [ "ECS/ContainerInsights/Prometheus", "redis_net_input_bytes_total", "ClusterName", "{{YOUR_CLUSTER_NAME}}", "TaskDefinitionFamily", "{{YOUR_TASK_DEF_FAMILY}}" ],
+          [ ".", "redis_net_output_bytes_total", ".", ".", ".", "." ]
+        ]
+      }
+    },
+    {
+      "type": "metric",
+      "x": 9,
+      "y": 7,
+      "width": 9,
+      "height": 6,
+      "properties": {
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Average",
+        "period": 60,
+        "title": "Expired/Evicted",
+        "metrics": [
+          [ "ECS/ContainerInsights/Prometheus", "redis_expired_keys_total", "ClusterName", "{{YOUR_CLUSTER_NAME}}", "TaskDefinitionFamily", "{{YOUR_TASK_DEF_FAMILY}}" ],
+          [ ".", "redis_evicted_keys_total", ".", ".", ".", "." ]
+        ]
+      }
+    },
+    {
+      "type": "metric",
+      "x": 9,
+      "y": 1,
+      "width": 9,
+      "height": 6,
+      "properties": {
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Average",
+        "period": 60,
+        "title": "Redis Connected Clients",
+        "metrics": [
+          [ "ECS/ContainerInsights/Prometheus", "redis_connected_clients", "ClusterName", "{{YOUR_CLUSTER_NAME}}", "TaskDefinitionFamily", "{{YOUR_TASK_DEF_FAMILY}}" ]
+        ]
+      }
+    },
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 13,
+      "width": 18,
+      "height": 6,
+      "properties": {
+        "metrics": [
+          [ "ECS/ContainerInsights/Prometheus", "redis_commands_total", "ClusterName", "{{YOUR_CLUSTER_NAME}}", "cmd", "slowlog", "TaskDefinitionFamily", "{{YOUR_TASK_DEF_FAMILY}}", { "label": "[max: ${MAX}, avg: ${AVG}] slowlog" } ],
+          [ "...", "client", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] client" } ],
+          [ "...", "config", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] config" } ],
+          [ "...", "info", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] info" } ],
+          [ "...", "latency", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] latency" } ],
+          [ "...", "append", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] append" } ],
+          [ "...", "command", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] command" } ],
+          [ "...", "set", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] set" } ],
+          [ "...", "get", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] get" } ],
+          [ "...", "del", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] del" } ]
+        ],
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "title": "Redis Command Calls per Type",
+        "period": 60,
+        "stat": "Average"
+      }
+    }
+  ]
+}

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_traffic/redis/README.md
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_traffic/redis/README.md
@@ -1,0 +1,27 @@
+## Sample AWS CloudFormation Template for Redis Application
+This directory contains the sample AWS CloudFormation template for Redis application to be installed on the ECS Fargate cluster.
+
+Installation Steps:
+* Setup ENV Variables
+```shell script
+ECS_CLUSTER_NAME=your_target_ecs_fargate_cluster_name
+AWS_DEFAULT_REGION=your_ecs_cluster_region_eg_ca-central-1
+ECS_CLASTER_VPC=your_ecs_cluster_vpc_id
+ECS_CLUSTER_SUBNET=your_ecs_cluster_subnet_id_eg_subnet-xxxxxxx
+ECS_CLUSTER_SECURITY_GROUP=your_security_group_id_eg_sg-xxxxxxx
+ECS_TASK_ROLE_NAME=redis-prometheus-demo-ecs-task-role-name
+ECS_EXECUTION_ROLE_NAME=redis-prometheus-demo-ecs-execution-role-name
+```
+* Create AWS CloudFormation Stack
+Run the following command to install the Sample Redis Application on Amazon EKS or Kubernetes
+```shell script
+aws cloudformation create-stack --stack-name Redis-Prometheus-Demo-ECS-$ECS_CLUSTER_NAME-fargate-awsvpc \
+    --template-body file://redis-traffic-sample.yaml \
+    --parameters ParameterKey=ECSClusterName,ParameterValue=$ECS_CLUSTER_NAME \
+                 ParameterKey=SecurityGroupID,ParameterValue=$ECS_CLASTER_SECURITY_GROUP \
+                 ParameterKey=SubnetID,ParameterValue=$ECS_CLUSTER_SUBNET \
+                 ParameterKey=TaskRoleName,ParameterValue=$ECS_TASK_ROLE_NAME \
+                 ParameterKey=ExecutionRoleName,ParameterValue=$ECS_EXECUTION_ROLE_NAME \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --region $AWS_DEFAULT_REGION
+```

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_traffic/redis/redis-traffic-sample.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_traffic/redis/redis-traffic-sample.yaml
@@ -1,0 +1,119 @@
+---
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  ECSClusterName:
+    Type: String
+    Description: Enter ECS FARGATE cluster name for installing the sample Redis workload
+  SecurityGroupID:
+    Type: 'AWS::EC2::SecurityGroup::Id'
+    Description: Enter the Security Group ID for running the CloudWatch Agent ECS Task
+  SubnetID:
+    Type: 'AWS::EC2::Subnet::Id'
+    Description: Enter the Subnet ID for running the CloudWatch Agent ECS Task
+  TaskRoleName:
+    Type: String
+    Description: Enter the ECS task role name to be created for Redis ECS task definition
+  ExecutionRoleName:
+    Type: String
+    Description: Enter the ECS execution role name to be created for Redis ECS task definition
+Resources:
+  RedisECSExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref ExecutionRoleName
+      Description: Allows ECS container agent makes calls to the Amazon ECS API on your behalf.
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+  RedisECSTaskRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Ref TaskRoleName
+      Description: Allows ECS tasks to call AWS services on your behalf.
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+  ECSRedisTaskDefinition:
+    Type: 'AWS::ECS::TaskDefinition'
+    DependsOn:
+      - RedisECSExecutionRole
+      - RedisECSTaskRole
+    Properties:
+      Family: !Sub 'redis-prometheus-demo-${ECSClusterName}-fargate-awsvpc'
+      TaskRoleArn: !Ref RedisECSTaskRole
+      ExecutionRoleArn: !Ref RedisECSExecutionRole
+      NetworkMode: awsvpc
+      ContainerDefinitions:
+        - Name: redis-0
+          Image: redis:6.0.8-alpine3.12
+          Essential: true
+          MountPoints: []
+          portMappings:
+            - protocol: tcp
+              containerPort: 6379
+          dockerLabels:
+            app: redis
+          Environment: []
+          Secrets: []
+          LogConfiguration:
+            logDriver: awslogs
+            options:
+              awslogs-create-group: 'True'
+              awslogs-group: "/ecs/ecs-redis-prometheus-demo"
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: !Sub 'redis-fargate-awsvpc'
+        - Name: redis-exporter-0
+          Image: oliver006/redis_exporter:v1.11.1-alpine
+          Essential: false
+          MountPoints: []
+          portMappings:
+            - protocol: tcp
+              containerPort: 9121
+          dockerLabels:
+            CWAgent-Usage-invalid-prometheus-label: Prometheus-Monitoring-Workload-Demo
+            ECS_PROMETHEUS_EXPORTER_PORT: '9121'
+            job: prometheus-redis
+            app_x: redis_exporter
+          Environment: []
+          Secrets: []
+          LogConfiguration:
+            logDriver: awslogs
+            options:
+              awslogs-create-group: 'True'
+              awslogs-group: "/ecs/ecs-redis-prometheus-demo"
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: !Sub 'redis-exporter-fargate-awsvpc'
+      requiresCompatibilities:
+        - FARGATE
+      Cpu: '256'
+      Memory: '512'
+  ECSRedistService:
+    Type: AWS::ECS::Service
+    DependsOn: ECSRedisTaskDefinition
+    Properties:
+      Cluster: !Ref ECSClusterName
+      DesiredCount: 1
+      LaunchType: FARGATE
+      SchedulingStrategy: REPLICA
+      ServiceName: !Sub 'redis-prometheus-demo-fargate-awsvpc'
+      TaskDefinition: !Ref ECSRedisTaskDefinition
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: ENABLED
+          SecurityGroups:
+            - !Ref SecurityGroupID
+          Subnets:
+            - !Ref SubnetID

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/README.md
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/README.md
@@ -1,6 +1,6 @@
 ## Sample CloudWatch Dashboards
 
-This directory contains sample CloudWatch dashboards for the EMF metrics configurations in [prometheus-eks.yaml](../prometheus-eks.yaml) and [prometheus-k8s.yaml](../prometheus-k8s.yaml).
+This directory contains sample CloudWatch dashboards for different workloads' Prometheus metrics.
 
 * [appmesh](appmesh) provides sample CloudWatch dashboard for [AWS App Mesh](https://aws.amazon.com/app-mesh/) Prometheus metrics.
 * [haproxy-ingress](haproxy-ingress) provides sample CloudWatch dashboard for [Haproxy-Ingress](https://github.com/helm/charts/tree/master/incubator/haproxy-ingress) Prometheus metrics.
@@ -8,3 +8,4 @@ This directory contains sample CloudWatch dashboards for the EMF metrics configu
 * [kubernetes_api_server](kubernetes_api_server) provides sample CloudWatch dashboard for [Kubernetes API Server](https://github.com/prometheus/prometheus/blob/master/documentation/examples/prometheus-kubernetes.yml) Prometheus metrics.
 * [memcached](memcached) provides sample CloudWatch dashboard for [Memcached](https://github.com/helm/charts/tree/master/stable/memcached) Prometheus metrics.
 * [nginx-ingress](nginx-ingress) provides sample CloudWatch dashboard for [Nginx-Ingress](https://github.com/helm/charts/tree/master/stable/nginx-ingress) Prometheus metrics.
+* [redis](redis) provides sample CloudWatch dashboard for [Redis](https://redis.io/) Prometheus metrics.

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/redis/README.md
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/redis/README.md
@@ -1,0 +1,29 @@
+## Sample CloudWatch Dashboard for Redis Prometheus Metrics
+
+### Usage Guide
+
+#### Required Permission
+You need the following permission to create a dashboard or update an existing dashboard.
+```
+cloudwatch:PutDashboard
+```
+
+#### Setup Dashboard Variables
+Replace the values below to match your setup
+
+```
+DASHBOARD_NAME=your_cw_dashboard_name
+REGION_NAME=your_metric_region_name_eg_us-east-1
+CLUSTER_NAME=your_k8s_cluster_name_here
+NAMESPACE=your_redis_service_namespace_here
+```
+
+#### Create Dashboard
+Create the CloudWatch Dashboard by the AWS CLI command as below:
+```
+curl https://cwagent-prometheus-yamls-justin.s3-us-west-2.amazonaws.com/cw_dashboard_redis.json \
+| sed "s/{{YOUR_AWS_REGION}}/${REGION_NAME}/g" \
+| sed "s/{{YOUR_CLUSTER_NAME}}/${CLUSTER_NAME}/g" \
+| sed "s/{{YOUR_NAMESPACE}}/${NAMESPACE}/g" \
+| xargs -0 aws cloudwatch put-dashboard --dashboard-name ${DASHBOARD_NAME} --dashboard-body
+```

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/redis/cw_dashboard_redis.json
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/redis/cw_dashboard_redis.json
@@ -1,0 +1,174 @@
+{
+  "widgets": [
+    {
+      "type": "metric",
+      "x": 9,
+      "y": 19,
+      "width": 9,
+      "height": 6,
+      "properties": {
+        "metrics": [
+          [ "ContainerInsights/Prometheus", "redis_db_keys", "ClusterName", "{{YOUR_CLUSTER_NAME}}", "db", "db4", "Namespace", "{{YOUR_NAMESPACE}}", { "label": "[max: ${MAX}, avg: ${AVG}] db4" } ],
+          [ "...", "db3", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db3" } ],
+          [ "...", "db6", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db6" } ],
+          [ "...", "db5", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db5" } ],
+          [ "...", "db0", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db0" } ],
+          [ "...", "db2", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db2" } ],
+          [ "...", "db1", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db1" } ],
+          [ "...", "db15", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db15" } ],
+          [ "...", "db14", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db14" } ],
+          [ "...", "db13", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db13" } ],
+          [ "...", "db12", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db12" } ],
+          [ "...", "db11", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db11" } ],
+          [ "...", "db10", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db10" } ],
+          [ "...", "db8", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db8" } ],
+          [ "...", "db7", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db7" } ],
+          [ "...", "db9", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] db9" } ]
+        ],
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Average",
+        "period": 60,
+        "title": "Total Items per DB",
+        "legend": {
+          "position": "right"
+        }
+      }
+    },
+    {
+      "type": "text",
+      "x": 0,
+      "y": 0,
+      "width": 18,
+      "height": 1,
+      "properties": {
+        "markdown": "\n# K8S Redis\n"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 7,
+      "width": 9,
+      "height": 6,
+      "properties": {
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Average",
+        "period": 60,
+        "metrics": [
+          [ "ContainerInsights/Prometheus", "redis_keyspace_misses_total", "ClusterName", "{{YOUR_CLUSTER_NAME}}", "Namespace", "{{YOUR_NAMESPACE}}", { "label": "[max: ${MAX}, avg: ${AVG}] redis_keyspace_misses_total" } ],
+          [ ".", "redis_keyspace_hits_total", ".", ".", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] redis_keyspace_hits_total" } ]
+        ],
+        "title": "Hits vs Missed"
+      }
+    },
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 1,
+      "width": 9,
+      "height": 6,
+      "properties": {
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Average",
+        "period": 60,
+        "title": "Memory Usage",
+        "metrics": [
+          [ "ContainerInsights/Prometheus", "redis_memory_used_bytes", "ClusterName", "{{YOUR_CLUSTER_NAME}}", "Namespace", "{{YOUR_NAMESPACE}}", { "label": "[max: ${MAX}, avg: ${AVG}] redis_memory_used_bytes" } ]
+        ],
+        "liveData": false,
+        "legend": {
+          "position": "bottom"
+        }
+      }
+    },
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 19,
+      "width": 9,
+      "height": 6,
+      "properties": {
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Average",
+        "period": 60,
+        "title": "Network I/O",
+        "metrics": [
+          [ "ContainerInsights/Prometheus", "redis_net_input_bytes_total", "ClusterName", "{{YOUR_CLUSTER_NAME}}", "Namespace", "{{YOUR_NAMESPACE}}" ],
+          [ ".", "redis_net_output_bytes_total", ".", ".", ".", "." ]
+        ]
+      }
+    },
+    {
+      "type": "metric",
+      "x": 9,
+      "y": 7,
+      "width": 9,
+      "height": 6,
+      "properties": {
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Average",
+        "period": 60,
+        "title": "Expired/Evicted",
+        "metrics": [
+          [ "ContainerInsights/Prometheus", "redis_expired_keys_total", "ClusterName", "{{YOUR_CLUSTER_NAME}}", "Namespace", "{{YOUR_NAMESPACE}}" ],
+          [ ".", "redis_evicted_keys_total", ".", ".", ".", "." ]
+        ]
+      }
+    },
+    {
+      "type": "metric",
+      "x": 9,
+      "y": 1,
+      "width": 9,
+      "height": 6,
+      "properties": {
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "stat": "Average",
+        "period": 60,
+        "title": "Redis Connected Clients",
+        "metrics": [
+          [ "ContainerInsights/Prometheus", "redis_connected_clients", "ClusterName", "{{YOUR_CLUSTER_NAME}}", "Namespace", "{{YOUR_NAMESPACE}}" ]
+        ]
+      }
+    },
+    {
+      "type": "metric",
+      "x": 0,
+      "y": 13,
+      "width": 18,
+      "height": 6,
+      "properties": {
+        "metrics": [
+          [ "ContainerInsights/Prometheus", "redis_commands_total", "ClusterName", "{{YOUR_CLUSTER_NAME}}", "cmd", "slowlog", "Namespace", "{{YOUR_NAMESPACE}}", { "label": "[max: ${MAX}, avg: ${AVG}] slowlog" } ],
+          [ "...", "client", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] client" } ],
+          [ "...", "config", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] config" } ],
+          [ "...", "info", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] info" } ],
+          [ "...", "latency", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] latency" } ],
+          [ "...", "append", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] append" } ],
+          [ "...", "command", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] command" } ],
+          [ "...", "set", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] set" } ],
+          [ "...", "get", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] get" } ],
+          [ "...", "del", ".", ".", { "label": "[max: ${MAX}, avg: ${AVG}] del" } ]
+        ],
+        "view": "timeSeries",
+        "stacked": false,
+        "region": "{{YOUR_AWS_REGION}}",
+        "title": "Redis Command Calls per Type",
+        "period": 60,
+        "stat": "Average"
+      }
+    }
+  ]
+}

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_traffic/redis/README.md
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_traffic/redis/README.md
@@ -1,0 +1,13 @@
+## Sample Redis Application Installation Yaml
+
+Set the namespace for the Redis sample workload
+```shell script
+REDIS_NAMESPACE=redis-sample
+```
+
+Run the following command to install the Sample Redis Application on Amazon EKS or Kubernetes
+```shell script
+curl https://cwagent-prometheus-yamls-justin.s3-us-west-2.amazonaws.com/redis-traffic-sample.yaml \
+| sed "s/{{namespace}}/$REDIS_NAMESPACE/g" \
+| kubectl apply -f -
+```

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_traffic/redis/redis-traffic-sample.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_traffic/redis/redis-traffic-sample.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{namespace}}
+  labels:
+    name: {{namespace}}
+    usage: redis-demo
+
+---
+kind: Pod
+apiVersion: v1
+metadata:
+  name: redis-instance
+  namespace: {{namespace}}
+  labels:
+    app: redis
+spec:
+  containers:
+    - name: redis-0
+      image: redis:6.0.8-alpine3.12
+      imagePullPolicy: Always
+      ports:
+        - containerPort: 6379
+    - name: redis-exporter-0
+      image: oliver006/redis_exporter:v1.11.1-alpine
+      imagePullPolicy: Always
+      ports:
+        - containerPort: 9121
+          name: metrics
+          protocol: TCP
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: my-redis-metrics
+  namespace: {{namespace}}
+  annotations:
+    prometheus.io/port: "9121"
+    prometheus.io/scrape: "true"
+spec:
+  selector:
+    app: redis
+  clusterIP: None
+  ports:
+    - name: metrics
+      port: 9121
+      protocol: TCP
+      targetPort: metrics


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add Redis Prometheus Metircs Support Artificats for both K8S and Amazon ECS, includes:
For K8S:
* Sample Redis Application Installation Yaml file
* Sample Redis CloudWatch Dashboard

For ECS:
* Sample Redis Application CloudFormation Template Yaml file
* Sample Redis CloudWatch Dashboard

The docker images are provided redis community in docker hub:
* Redis: https://hub.docker.com/_/redis?tab=description
* Redis_exporter: https://hub.docker.com/r/oliver006/redis_exporter


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
