### PR TITLE
Fix Some Typo in Redis Sample Workload README.md

### DIFF
--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_cloudwatch_dashboards/redis/README.md
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_cloudwatch_dashboards/redis/README.md
@@ -15,13 +15,13 @@ Replace the values below to match your setup
 DASHBOARD_NAME=your_cw_dashboard_name
 REGION_NAME=your_aws_region_eg:us-east-1
 CLUSTER_NAME=your_ecs_cluster_name_here
-ECS_TASK_DEF_FAMILY=your_redis_ecs_task definition_family_name_here
+ECS_TASK_DEF_FAMILY=your_redis_ecs_task_definition_family_name_here
 ```
 
 #### Create Dashboard
 Create the CloudWatch Dashboard by the AWS CLI command as below:
 ```
-cat cw_dashboard_javajmx.json \
+cat cw_dashboard_redis.json \
 | sed "s/{{YOUR_AWS_REGION}}/${REGION_NAME}/g" \
 | sed "s/{{YOUR_CLUSTER_NAME}}/${CLUSTER_NAME}/g" \
 | sed "s/{{YOUR_TASK_DEF_FAMILY}}/${ECS_TASK_DEF_FAMILY}/g" \

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_traffic/redis/README.md
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_traffic/redis/README.md
@@ -3,10 +3,9 @@ This directory contains the sample AWS CloudFormation template for Redis applica
 
 Installation Steps:
 * Setup ENV Variables
-```shell script
+```
 ECS_CLUSTER_NAME=your_target_ecs_fargate_cluster_name
 AWS_DEFAULT_REGION=your_ecs_cluster_region_eg_ca-central-1
-ECS_CLASTER_VPC=your_ecs_cluster_vpc_id
 ECS_CLUSTER_SUBNET=your_ecs_cluster_subnet_id_eg_subnet-xxxxxxx
 ECS_CLUSTER_SECURITY_GROUP=your_security_group_id_eg_sg-xxxxxxx
 ECS_TASK_ROLE_NAME=redis-prometheus-demo-ecs-task-role-name
@@ -14,7 +13,7 @@ ECS_EXECUTION_ROLE_NAME=redis-prometheus-demo-ecs-execution-role-name
 ```
 * Create AWS CloudFormation Stack
 Run the following command to install the Sample Redis Application on Amazon EKS or Kubernetes
-```shell script
+```
 aws cloudformation create-stack --stack-name Redis-Prometheus-Demo-ECS-$ECS_CLUSTER_NAME-fargate-awsvpc \
     --template-body file://redis-traffic-sample.yaml \
     --parameters ParameterKey=ECSClusterName,ParameterValue=$ECS_CLUSTER_NAME \

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_traffic/redis/redis-traffic-sample.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_traffic/redis/redis-traffic-sample.yaml
@@ -100,7 +100,7 @@ Resources:
         - FARGATE
       Cpu: '256'
       Memory: '512'
-  ECSRedistService:
+  ECSRedisService:
     Type: AWS::ECS::Service
     DependsOn: ECSRedisTaskDefinition
     Properties:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Remove the unused ENV in Redis CW Dashboard Readme.md
* Remove the excessive `t` in the Redis Sample CloudFormation Template Service Logical ID
* Fix the wrong CloudWatch Dashboard file name for Redis

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
