### PR TITLE
Update fluentd image version to support multi-arch image for running on Graviton 2 instance

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
@@ -378,7 +378,7 @@ spec:
           command: ['sh','-c','']
       containers:
         - name: fluentd-cloudwatch
-          image: fluent/fluentd-kubernetes-daemonset:v1.7.3-debian-cloudwatch-1.0
+          image: fluent/fluentd-kubernetes-daemonset:v1.12-debian-cloudwatch-1
           env:
             - name: AWS_REGION
               valueFrom:


### PR DESCRIPTION
The image `fluent/fluentd-kubernetes-daemonset:v1.7.3-debian-cloudwatch-1.0` is not supporting arm64
