### PR TITLE
update fluent bit optimized configuration with use_kubelet option ena…

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
@@ -18,6 +18,8 @@ rules:
       - namespaces
       - pods
       - pods/logs
+      - nodes
+      - nodes/proxy
     verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -113,6 +115,9 @@ data:
         K8S-Logging.Exclude Off
         Labels              Off
         Annotations         Off
+        Use_Kubelet         On
+        Kubelet_Port        10250
+        Buffer_Size         0
 
     [OUTPUT]
         Name                cloudwatch_logs
@@ -269,7 +274,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: amazon/aws-for-fluent-bit:2.10.0
+        image: public.ecr.aws/aws-observability/aws-for-fluent-bit:2.19.0
         imagePullPolicy: Always
         env:
             - name: AWS_REGION
@@ -306,6 +311,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
             - name: CI_VERSION
               value: "k8s/1.3.8"
         resources:
@@ -333,6 +343,8 @@ spec:
           mountPath: /var/log/dmesg
           readOnly: true
       terminationGracePeriodSeconds: 10
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       volumes:
       - name: fluentbitstate
         hostPath:


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/fluent/fluent-bit/pull/3025
Fluent Bit is supporting use_kubelet opetion for EKS to address large cluster scalability issue in fluent bit version 1.7.2. https://fluentbit.io/announcements/v1.7.2/
And this feature is supported in aws-for-fluent-bit in version 2.12.0.

*Description of changes:*
The change is about enable the use_kubelet option in fluent bit filter config and change related configuration in template to support this feature.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
