### PR TITLE
Fix memcached traffic sample

### DIFF
--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_traffic/memcached/memcached-traffic-sample.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_traffic/memcached/memcached-traffic-sample.yaml
@@ -62,16 +62,16 @@ Resources:
           Image: memcached:1.6.7
           Essential: true
           MountPoints: []
-          portMappings:
-            - protocol: tcp
-              containerPort: 11211
-          dockerLabels:
+          PortMappings:
+            - Protocol: tcp
+              ContainerPort: 11211
+          DockerLabels:
             app: memcached
           Environment: []
           Secrets: []
           LogConfiguration:
-            logDriver: awslogs
-            options:
+            LogDriver: awslogs
+            Options:
               awslogs-create-group: 'True'
               awslogs-group: "/ecs/ecs-memcached-prometheus-demo"
               awslogs-region: !Ref AWS::Region
@@ -80,22 +80,22 @@ Resources:
           Image: prom/memcached-exporter:v0.7.0
           Essential: false
           MountPoints: []
-          portMappings:
-            - protocol: tcp
-              containerPort: 9150
-          dockerLabels:
+          PortMappings:
+            - Protocol: tcp
+              ContainerPort: 9150
+          DockerLabels:
             job: prometheus-memcached
             app_x: memcached_exporter
           Environment: []
           Secrets: []
           LogConfiguration:
-            logDriver: awslogs
-            options:
+            LogDriver: awslogs
+            Options:
               awslogs-create-group: 'True'
               awslogs-group: "/ecs/ecs-memcached-prometheus-demo"
               awslogs-region: !Ref AWS::Region
               awslogs-stream-prefix: "memcached-exporter-tutorial"
-      requiresCompatibilities:
+      RequiresCompatibilities:
         - EC2
       Cpu: '256'
       Memory: '512'

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_traffic/memcached/memcached-traffic-sample.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_traffic/memcached/memcached-traffic-sample.yaml
@@ -17,6 +17,8 @@ Parameters:
   ExecutionRoleName:
     Type: String
     Description: Enter the ECS execution role name to be created for Memcached ECS task definition
+Conditions:
+  IsBridgeNetworking: !Equals [ !Ref ECSNetworkMode, 'bridge' ]
 Resources:
   MemcachedECSExecutionRole:
     Type: AWS::IAM::Role
@@ -79,12 +81,21 @@ Resources:
               awslogs-stream-prefix: "memcached-tutorial"
         - Name: memcached-exporter-0
           Image: prom/memcached-exporter:v0.7.0
+          Command: !If
+            - IsBridgeNetworking
+            - ["--memcached.address=memcached-0:11211"]
+            - !Ref 'AWS::NoValue'
           Essential: false
           MountPoints: []
           PortMappings:
             - Protocol: tcp
               ContainerPort: 9150
               HostPort: 9150
+          Links:
+            - !If
+              - IsBridgeNetworking
+              - "memcached-0"
+              - !Ref 'AWS::NoValue'
           DockerLabels:
             job: prometheus-memcached
             app_x: memcached_exporter

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_traffic/memcached/memcached-traffic-sample.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_traffic/memcached/memcached-traffic-sample.yaml
@@ -65,6 +65,7 @@ Resources:
           PortMappings:
             - Protocol: tcp
               ContainerPort: 11211
+              HostPort: 11211
           DockerLabels:
             app: memcached
           Environment: []
@@ -83,6 +84,7 @@ Resources:
           PortMappings:
             - Protocol: tcp
               ContainerPort: 9150
+              HostPort: 9150
           DockerLabels:
             job: prometheus-memcached
             app_x: memcached_exporter


### PR DESCRIPTION
*Description of changes:*

I noticed some problems when using the memcached traffic sample.  This PR proposes the following changes:

- Template did not work due to apparent capitalization issues in template attributes - corrected those.
- Template offers `bridge` networking as a parameter (although the tutorial does suggest `host` networking to be fair) - but as it stood, the memcached exporter won't be working correctly with this networking mode.  So conditional on networking mode being `bridge`, added a link to the memcached host from the exporter, and passed this hostname as a command argument.
- Also added `HostPort` matching `ContainerPort` - this is helpful in bridge mode, and is compatible with host mode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
