### PR TITLE
bump version to 1.3.9 with new CloudWatch agent release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## k8s/1.3.9
+- Upgrade cloudwatch-agent image version to cloudwatch-agent:1.247350.0b251780
+- Fixes K8s performance issue in CloudWatch agent in [commit](https://github.com/aws/amazon-cloudwatch-agent/commit/b49543ba62206613c3bb67c52a861b29e26c51a3)
 ## k8s/1.3.8
 - Disable fluentd watch on kubernetes metadata
 ## k8s/1.3.7

--- a/container-insights-manifest-update.sh
+++ b/container-insights-manifest-update.sh
@@ -4,8 +4,8 @@ cd "$(dirname "$0")"
 k8sDirPrefix="./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring"
 ecsDirPrefix="./ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric"
 
-newK8sVersion="k8s/1.3.8"
-agentVersion="amazon/cloudwatch-agent:1.247348.0b251302"
+newK8sVersion="k8s/1.3.9"
+agentVersion="amazon/cloudwatch-agent:1.247350.0b251780"
 fluentdVersion="fluent/fluentd-kubernetes-daemonset:v1.7.3-debian-cloudwatch-1.0"
 fluentBitVersion="amazon/aws-for-fluent-bit:2.10.0"
 

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json
@@ -105,7 +105,7 @@
         "ContainerDefinitions": [
           {
             "Name": "cloudwatch-agent",
-            "Image": "amazon/cloudwatch-agent:1.247348.0b251302",
+            "Image": "amazon/cloudwatch-agent:1.247350.0b251780",
             "MountPoints": [
               {
                 "ReadOnly": true,

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cwagent-ecs-instance-metric.json
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cwagent-ecs-instance-metric.json
@@ -6,7 +6,7 @@
   "containerDefinitions": [
     {
       "name": "cloudwatch-agent",
-      "image": "amazon/cloudwatch-agent:1.247348.0b251302",
+      "image": "amazon/cloudwatch-agent:1.247350.0b251780",
       "mountPoints": [
         {
           "readOnly": true,

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
@@ -224,7 +224,7 @@ Resources:
       NetworkMode: awsvpc
       ContainerDefinitions:
         - Name: cloudwatch-agent-prometheus
-          Image: amazon/cloudwatch-agent:1.247348.0b251302
+          Image: amazon/cloudwatch-agent:1.247350.0b251780
           Essential: true
           MountPoints: []
           PortMappings: []

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
@@ -219,7 +219,7 @@ Resources:
       NetworkMode: !Ref ECSNetworkMode
       ContainerDefinitions:
         - Name: cloudwatch-agent-prometheus
-          Image: amazon/cloudwatch-agent:1.247348.0b251302
+          Image: amazon/cloudwatch-agent:1.247350.0b251780
           Essential: true
           MountPoints: []
           PortMappings: []

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cwagent-prometheus-task-definition.json
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cwagent-prometheus-task-definition.json
@@ -6,7 +6,7 @@
   "containerDefinitions": [
     {
       "name": "cloudwatch-agent-prometheus",
-      "image": "amazon/cloudwatch-agent:1.247348.0b251302",
+      "image": "amazon/cloudwatch-agent:1.247350.0b251780",
       "essential": true,
       "mountPoints": [
       ],

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:1.247348.0b251302
+          image: amazon/cloudwatch-agent:1.247350.0b251780
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -42,7 +42,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.8"
+              value: "k8s/1.3.9"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
@@ -318,7 +318,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: CI_VERSION
-              value: "k8s/1.3.8"
+              value: "k8s/1.3.9"
         resources:
             limits:
               memory: 200Mi

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
@@ -307,7 +307,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: CI_VERSION
-              value: "k8s/1.3.8"
+              value: "k8s/1.3.9"
         resources:
             limits:
               memory: 200Mi

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
@@ -396,7 +396,7 @@ spec:
                   name: cluster-info
                   key: cluster.name
             - name: CI_VERSION
-              value: "k8s/1.3.8"
+              value: "k8s/1.3.9"
           resources:
             limits:
               memory: 400Mi

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
@@ -98,7 +98,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:1.247348.0b251302
+          image: amazon/cloudwatch-agent:1.247350.0b251780
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -125,7 +125,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.8"
+              value: "k8s/1.3.9"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig
@@ -502,7 +502,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: CI_VERSION
-              value: "k8s/1.3.8"
+              value: "k8s/1.3.9"
         resources:
             limits:
               memory: 200Mi

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
@@ -98,7 +98,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:1.247348.0b251302
+          image: amazon/cloudwatch-agent:1.247350.0b251780
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -125,7 +125,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.8"
+              value: "k8s/1.3.9"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig
@@ -585,7 +585,7 @@ spec:
                   name: cluster-info
                   key: cluster.name
             - name: CI_VERSION
-              value: "k8s/1.3.8"
+              value: "k8s/1.3.9"
           resources:
             limits:
               memory: 400Mi

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-fargate.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-fargate.yaml
@@ -398,7 +398,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:1.247348.0b251302
+          image: amazon/cloudwatch-agent:1.247350.0b251780
           imagePullPolicy: Always
           resources:
             limits:
@@ -410,7 +410,7 @@ spec:
           # Please don't change below envs
           env:
             - name: CI_VERSION
-              value: "k8s/1.3.8"
+              value: "k8s/1.3.9"
             - name: RUN_IN_AWS
               value: "True"
           # Please don't change the mountPath

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
@@ -449,7 +449,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:1.247348.0b251302
+          image: amazon/cloudwatch-agent:1.247350.0b251780
           imagePullPolicy: Always
           resources:
             limits:
@@ -461,7 +461,7 @@ spec:
           # Please don't change below envs
           env:
             - name: CI_VERSION
-              value: "k8s/1.3.8"
+              value: "k8s/1.3.9"
           # Please don't change the mountPath
           volumeMounts:
             - name: prometheus-cwagentconfig

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-k8s.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-k8s.yaml
@@ -396,7 +396,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:1.247348.0b251302
+          image: amazon/cloudwatch-agent:1.247350.0b251780
           imagePullPolicy: Always
           resources:
             limits:
@@ -408,7 +408,7 @@ spec:
           # Please don't change below envs
           env:
             - name: CI_VERSION
-              value: "k8s/1.3.8"
+              value: "k8s/1.3.9"
           # Please don't change the mountPath
           volumeMounts:
             - name: prometheus-cwagentconfig


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/amazon-cloudwatch-agent/pull/256

*Description of changes:*
Update to use latest version of CloudWatch agent, which fixes a memory leak noted in https://github.com/aws/amazon-cloudwatch-agent/issues/264

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
