### PR TITLE
Support for kustomize

### DIFF
--- a/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml
@@ -63,12 +63,12 @@ data:
   cwagentconfig.json: |
     {
       "agent": {
-        "region": "{{region_name}}"
+        "region": "REGION_NAME"
       },
       "logs": {
         "metrics_collected": {
           "kubernetes": {
-            "cluster_name": "{{cluster_name}}",
+            "cluster_name": "CLUSTER_NAME",
             "metrics_collection_interval": 60
           }
         },
@@ -171,11 +171,11 @@ spec:
 ---
 
 # create configmap for cluster name and aws region for CloudWatch Logs
-# need to replace the placeholders {{cluster_name}} and {{region_name}}
+# need to replace the placeholders CLUSTER_NAME and REGION_NAME
 apiVersion: v1
 data:
-  cluster.name: {{cluster_name}}
-  logs.region: {{region_name}}
+  cluster.name: CLUSTER_NAME
+  logs.region: REGION_NAME
 kind: ConfigMap
 metadata:
   name: cluster-info

--- a/k8s-yaml-templates/quickstart/kustomization.yaml
+++ b/k8s-yaml-templates/quickstart/kustomization.yaml
@@ -1,0 +1,26 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- cwagent-fluentd-quickstart.yaml
+
+configMapGenerator:
+  - name: cwagentconfig
+    namespace: amazon-cloudwatch
+    behavior: replace
+    literals:
+      - |
+        cwagentconfig.json={
+            "agent": {
+                "region": "REGION_NAME"
+            },
+            "logs": {
+                "metrics_collected": {
+                    "kubernetes": {
+                        "cluster_name": "CLUSTER_NAME",
+                        "metrics_collection_interval": 60
+                    }
+                },
+                "force_flush_interval": 5
+            }
+        }

--- a/k8s-yaml-templates/quickstart/kustomization.yaml
+++ b/k8s-yaml-templates/quickstart/kustomization.yaml
@@ -4,23 +4,30 @@ kind: Kustomization
 resources:
 - cwagent-fluentd-quickstart.yaml
 
+# need to replace the placeholders CLUSTER_NAME and REGION_NAME
 configMapGenerator:
-  - name: cwagentconfig
-    namespace: amazon-cloudwatch
-    behavior: replace
-    literals:
-      - |
-        cwagentconfig.json={
-            "agent": {
-                "region": "REGION_NAME"
+- name: cwagentconfig
+  namespace: amazon-cloudwatch
+  behavior: replace
+  literals:
+  - |
+    cwagentconfig.json={
+        "agent": {
+            "region": "REGION_NAME"
+        },
+        "logs": {
+            "metrics_collected": {
+                "kubernetes": {
+                    "cluster_name": "CLUSTER_NAME",
+                    "metrics_collection_interval": 60
+                }
             },
-            "logs": {
-                "metrics_collected": {
-                    "kubernetes": {
-                        "cluster_name": "CLUSTER_NAME",
-                        "metrics_collection_interval": 60
-                    }
-                },
-                "force_flush_interval": 5
-            }
+            "force_flush_interval": 5
         }
+    }
+- name: cluster-info
+  namespace: amazon-cloudwatch
+  behavior: replace
+  literals:
+  - cluster.name=CLUSTER_NAME
+  - region.name=REGION_NAME


### PR DESCRIPTION
*Issue #, if available:*

The trouble is I have to copy paste this yaml in order to use it. I'd like to just reference it with a small file like so

```
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization
resources:
- github.com/aws-samples//amazon-cloudwatch-container-insights/k8s-yaml-templates/quickstart?ref=d607898
```

Currently this is not possible. The simple changes in this PR make it possible.

*Description of changes:*

* Adding a `kustomization.yaml`
* changing variable style to support Kustomize

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
