### PR TITLE
Always use AWS for Fluent Bit stable version

### DIFF
--- a/container-insights-manifest-update.sh
+++ b/container-insights-manifest-update.sh
@@ -7,7 +7,7 @@ ecsDirPrefix="./ecs-task-definition-templates/deployment-mode/daemon-service/cwa
 newK8sVersion="k8s/1.3.9"
 agentVersion="amazon/cloudwatch-agent:1.247350.0b251780"
 fluentdVersion="fluent/fluentd-kubernetes-daemonset:v1.7.3-debian-cloudwatch-1.0"
-fluentBitVersion="amazon/aws-for-fluent-bit:2.10.0"
+fluentBitVersion="amazon/aws-for-fluent-bit:stable"
 
 k8sPrometheusDirPrefix="./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus"
 ecsPrometheusDirPrefix="./ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus"

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
@@ -280,7 +280,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit-compatible
-        image: amazon/aws-for-fluent-bit:2.10.0
+        image: amazon/aws-for-fluent-bit:stable
         imagePullPolicy: Always
         env:
             - name: AWS_REGION

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
@@ -269,7 +269,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: public.ecr.aws/aws-observability/aws-for-fluent-bit:latest
+        image: public.ecr.aws/aws-observability/aws-for-fluent-bit:stable
         imagePullPolicy: Always
         env:
             - name: AWS_REGION

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
@@ -464,7 +464,7 @@ spec:
     spec:
       containers:
       - name: fluent-bit
-        image: amazon/aws-for-fluent-bit:2.10.0
+        image: amazon/aws-for-fluent-bit:stable
         imagePullPolicy: Always
         env:
             - name: AWS_REGION


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

We should always direct customers to use the AWS for Fluent Bit stable version as it is the most likely to be free of bugs and validated by users at any given point in time: https://github.com/aws/aws-for-fluent-bit#using-the-stable-tag

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
