### PR TITLE
fix: pod limits and requests must be equal on fargate

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-fargate.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-fargate.yaml
@@ -402,8 +402,8 @@ spec:
           imagePullPolicy: Always
           resources:
             limits:
-              cpu:  1000m
-              memory: 1000Mi
+              cpu:  200m
+              memory: 200Mi
             requests:
               cpu: 200m
               memory: 200Mi


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-cloudwatch-agent/issues/580

*Description of changes:*
As per https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html, pod limits and requests on fargate must be equal (or omit limits).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
