### PR TITLE
fix(parser): parse correctly the dmesg logs

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
@@ -181,7 +181,7 @@ data:
         Name                tail
         Tag                 host.dmesg
         Path                /var/log/dmesg
-        Parser              dmesg
+        Key                 message
         DB                  /var/fluent-bit/state/flb_dmesg.db
         Mem_Buf_Limit       5MB
         Skip_Long_Lines     On
@@ -251,10 +251,6 @@ data:
         Regex               (?<log>(?<="log":")\d{4}[\/-]\d{1,2}[\/-]\d{1,2}[ T]\d{2}:\d{2}:\d{2}(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
         Time_Key            time
         Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
-    [PARSER]
-        Name                dmesg
-        Format              regex
-        Regex               ^(?<message>.*)$
 ---
 apiVersion: apps/v1
 kind: DaemonSet

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
@@ -181,7 +181,7 @@ data:
         Name                tail
         Tag                 host.dmesg
         Path                /var/log/dmesg
-        Parser              syslog
+        Parser              dmesg
         DB                  /var/fluent-bit/state/flb_dmesg.db
         Mem_Buf_Limit       5MB
         Skip_Long_Lines     On
@@ -251,6 +251,10 @@ data:
         Regex               (?<log>(?<="log":")\d{4}[\/-]\d{1,2}[\/-]\d{1,2}[ T]\d{2}:\d{2}:\d{2}(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
         Time_Key            time
         Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
+    [PARSER]
+        Name                dmesg
+        Format              regex
+        Regex               ^(?<message>.*)$
 ---
 apiVersion: apps/v1
 kind: DaemonSet


### PR DESCRIPTION
Closes #30 #107

The syslog regexp doesn't work for dmesg because in dmesg format there isn't the timestamp in the `[]`

For that reason, every log entry from `dmesg` is giving a warning in fluentbit:

```
Invalid time format %b %d %H:%M:%S
```

Log example:
```
[    4.008137] ACPI: Sleep Button [SLPF]
[    4.009304] random: systemd-sysctl: uninitialized urandom read (16 bytes read)
[    4.020355] random: systemd-sysctl: uninitialized urandom read (16 bytes read)
[    4.028476] random: systemd-sysctl: uninitialized urandom read (16 bytes read)
[    4.039216] cryptd: max_cpu_qlen set to 1000
[    4.040617] mousedev: PS/2 mouse device common for all mice
[    4.124564] AVX2 version of gcm_enc/dec engaged.
[    4.129423] AES CTR mode by8 optimization enabled
[    4.356031] RPC: Registered named UNIX socket transport module.
[    4.361383] RPC: Registered udp transport module.
[    4.365930] RPC: Registered tcp transport module.
[    4.370478] RPC: Registered tcp NFSv4.1 backchannel transport module.
[    4.429209] xfs filesystem being remounted at /tmp supports timestamps until 2038 (0x7fffffff)
[    4.440170] xfs filesystem being remounted at /var/tmp supports timestamps until 2038 (0x7fffffff)
```

New regexp validation:
https://regex101.com/r/3Jx7Wy/1




Signed-off-by: Pier <53210578+pie-r@users.noreply.github.com>