### PR TITLE
fluent-bit: set 30 second shutdown grace period

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
@@ -44,6 +44,7 @@ data:
   fluent-bit.conf: |
     [SERVICE]
         Flush                     5
+        Grace                     30
         Log_Level                 info
         Daemon                    off
         Parsers_File              parsers.conf

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
@@ -46,6 +46,7 @@ data:
   fluent-bit.conf: |
     [SERVICE]
         Flush                     5
+        Grace                     30
         Log_Level                 info
         Daemon                    off
         Parsers_File              parsers.conf


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

*Issue #, if available:*

*Description of changes:*

The default is 5 seconds, which is too short. Kubernetes gives a 30 second SIGTERM to SIGKILL grace period. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
