### PR TITLE
fluent-bit: handle rotation of host var/log files

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
@@ -186,7 +186,7 @@ data:
     [INPUT]
         Name                tail
         Tag                 host.dmesg
-        Path                /var/log/dmesg
+        Path                /var/log/dmesg*
         Parser              syslog
         DB                  /var/fluent-bit/state/flb_dmesg.db
         Mem_Buf_Limit       5MB
@@ -197,7 +197,7 @@ data:
     [INPUT]
         Name                tail
         Tag                 host.messages
-        Path                /var/log/messages
+        Path                /var/log/messages*
         Parser              syslog
         DB                  /var/fluent-bit/state/flb_messages.db
         Mem_Buf_Limit       5MB
@@ -208,7 +208,7 @@ data:
     [INPUT]
         Name                tail
         Tag                 host.secure
-        Path                /var/log/secure
+        Path                /var/log/secure*
         Parser              syslog
         DB                  /var/fluent-bit/state/flb_secure.db
         Mem_Buf_Limit       5MB

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
@@ -180,7 +180,7 @@ data:
     [INPUT]
         Name                tail
         Tag                 host.dmesg
-        Path                /var/log/dmesg
+        Path                /var/log/dmesg*
         Parser              syslog
         DB                  /var/fluent-bit/state/flb_dmesg.db
         Mem_Buf_Limit       5MB
@@ -191,7 +191,7 @@ data:
     [INPUT]
         Name                tail
         Tag                 host.messages
-        Path                /var/log/messages
+        Path                /var/log/messages*
         Parser              syslog
         DB                  /var/fluent-bit/state/flb_messages.db
         Mem_Buf_Limit       5MB
@@ -202,7 +202,7 @@ data:
     [INPUT]
         Name                tail
         Tag                 host.secure
-        Path                /var/log/secure
+        Path                /var/log/secure*
         Parser              syslog
         DB                  /var/fluent-bit/state/flb_secure.db
         Mem_Buf_Limit       5MB


### PR DESCRIPTION
Signed-off-by: Wesley Pettit <wppttt@amazon.com>

*Issue #, if available:*

*Description of changes:*

In my experience, all of these var/log files can be rotated. I've seen this with default settings on Amazon Linux AMI. I think it depends on the settings on the host but we should handle rotation by default for this template.

For example, here is the current state of `/var/log` in one of my test instances that have been running for a while:

```
$ ls -l /var/log
total 17436
drwxr-xr-x  4 root   root                 28 Oct 13 20:43 amazon
drwx------  2 root   root                 23 Oct 26 17:52 audit
-rw-------  1 root   root             204400 Dec 11 05:16 boot.log
-rw-------  1 root   utmp            3363456 Dec 11 05:21 btmp
-rw-------  1 root   utmp            3257088 Dec  1 03:10 btmp-20221201
drwxr-x---  2 chrony chrony             4096 Dec 11 03:36 chrony
-rw-r--r--  1 root   root             104952 Oct 26 17:52 cloud-init.log
-rw-r-----  1 root   root               5426 Oct 26 17:52 cloud-init-output.log
-rw-------  1 root   root                926 Dec 11 05:01 cron
-rw-------  1 root   root              53112 Nov 20 03:10 cron-20221120
-rw-------  1 root   root              53343 Nov 27 03:41 cron-20221127
-rw-------  1 root   root              53114 Dec  4 03:23 cron-20221204
-rw-------  1 root   root              53519 Dec 11 03:36 cron-20221211
drwxr-xr-x  2 lp     sys                   6 Oct 15  2020 cups
-rw-r--r--  1 root   root              47124 Oct 26 17:52 dmesg
drwxr--r-x  3 root   root               4096 Dec 11 05:09 ecs
-rw-------  1 root   root               4699 Dec  6 06:41 grubby
-rw-r--r--  1 root   root                193 Sep 14 21:00 grubby_prune_debug
drwxr-sr-x+ 3 root   systemd-journal      46 Oct 26 17:52 journal
-rw-r--r--  1 root   root             292292 Dec 11 05:23 lastlog
-rw-------  1 root   root                  0 Dec 11 03:36 maillog
-rw-------  1 root   root                  0 Nov 13 03:39 maillog-20221120
-rw-------  1 root   root                  0 Nov 20 03:10 maillog-20221127
-rw-------  1 root   root                  0 Nov 27 03:41 maillog-20221204
-rw-------  1 root   root                  0 Dec  4 03:23 maillog-20221211
-rw-------  1 root   root               9044 Dec 11 05:23 messages
-rw-------  1 root   root             804535 Nov 20 03:09 messages-20221120
-rw-------  1 root   root             810939 Nov 27 03:40 messages-20221127
-rw-------  1 root   root             807403 Dec  4 03:23 messages-20221204
-rw-------  1 root   root             918895 Dec 11 03:35 messages-20221211
-rw-------  1 root   root              10275 Dec 11 05:23 secure
-rw-------  1 root   root             810162 Nov 20 02:34 secure-20221120
-rw-------  1 root   root            1008373 Nov 27 03:38 secure-20221127
-rw-------  1 root   root            1046990 Dec  4 03:22 secure-20221204
-rw-------  1 root   root            4218085 Dec 11 03:32 secure-20221211
-rw-------  1 root   root                  0 Dec 11 03:36 spooler
-rw-------  1 root   root                  0 Nov 13 03:39 spooler-20221120
-rw-------  1 root   root                  0 Nov 20 03:10 spooler-20221127
-rw-------  1 root   root                  0 Nov 27 03:41 spooler-20221204
-rw-------  1 root   root                  0 Dec  4 03:23 spooler-20221211
-rw-------  1 root   root                  0 Sep 14 21:00 tallylog
-rw-rw-r--  1 root   utmp              17280 Dec 11 05:23 wtmp
-rw-------  1 root   root              26269 Dec  6 06:41 yum.log
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
