### PR TITLE
update fluent-bit to support CRI format

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
@@ -68,10 +68,7 @@ data:
         Tag                 application.*
         Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
         Path                /var/log/containers/*.log
-        Docker_Mode         On
-        Docker_Mode_Flush   5
-        Docker_Mode_Parser  container_firstline
-        Parser              docker, cri
+        multiline.parser    docker, cri
         DB                  /var/fluent-bit/state/flb_container.db
         Mem_Buf_Limit       50MB
         Skip_Long_Lines     On
@@ -84,7 +81,7 @@ data:
         Name                tail
         Tag                 application.*
         Path                /var/log/containers/fluent-bit*
-        Parser              docker, cri
+        multiline.parser    docker, cri
         DB                  /var/fluent-bit/state/flb_log.db
         Mem_Buf_Limit       5MB
         Skip_Long_Lines     On
@@ -95,10 +92,7 @@ data:
         Name                tail
         Tag                 application.*
         Path                /var/log/containers/cloudwatch-agent*
-        Docker_Mode         On
-        Docker_Mode_Flush   5
-        Docker_Mode_Parser  cwagent_firstline
-        Parser              docker, cri
+        multiline.parser    docker, cri
         DB                  /var/fluent-bit/state/flb_cwagent.db
         Mem_Buf_Limit       5MB
         Skip_Long_Lines     On
@@ -143,10 +137,7 @@ data:
         Name                tail
         Tag                 dataplane.tail.*
         Path                /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
-        Docker_Mode         On
-        Docker_Mode_Flush   5
-        Docker_Mode_Parser  container_firstline
-        Parser              docker
+        multiline.parser    docker, cri
         DB                  /var/fluent-bit/state/flb_dataplane_tail.db
         Mem_Buf_Limit       50MB
         Skip_Long_Lines     On
@@ -176,7 +167,7 @@ data:
         log_stream_prefix   ${HOST_NAME}-
         auto_create_group   true
         extra_user_agent    container-insights
-    
+
   host-log.conf: |
     [INPUT]
         Name                tail
@@ -231,6 +222,14 @@ data:
         Format              json
         Time_Key            time
         Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
+    
+    [PARSER]
+        Name                cri
+        Format              regex
+        Regex               ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
+        Time_Key            time
+        Time_Format         %Y-%m-%dT%H:%M:%S.%L%z
+        Time_Keep           On
 
     [PARSER]
         Name                syslog

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
@@ -222,14 +222,6 @@ data:
         Format              json
         Time_Key            time
         Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
-    
-    [PARSER]
-        Name                cri
-        Format              regex
-        Regex               ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-        Time_Key            time
-        Time_Format         %Y-%m-%dT%H:%M:%S.%L%z
-        Time_Keep           On
 
     [PARSER]
         Name                syslog

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
@@ -71,7 +71,7 @@ data:
         Docker_Mode         On
         Docker_Mode_Flush   5
         Docker_Mode_Parser  container_firstline
-        Parser              docker
+        Parser              docker, cri
         DB                  /var/fluent-bit/state/flb_container.db
         Mem_Buf_Limit       50MB
         Skip_Long_Lines     On
@@ -84,7 +84,7 @@ data:
         Name                tail
         Tag                 application.*
         Path                /var/log/containers/fluent-bit*
-        Parser              docker
+        Parser              docker, cri
         DB                  /var/fluent-bit/state/flb_log.db
         Mem_Buf_Limit       5MB
         Skip_Long_Lines     On
@@ -98,7 +98,7 @@ data:
         Docker_Mode         On
         Docker_Mode_Flush   5
         Docker_Mode_Parser  cwagent_firstline
-        Parser              docker
+        Parser              docker, cri
         DB                  /var/fluent-bit/state/flb_cwagent.db
         Mem_Buf_Limit       5MB
         Skip_Long_Lines     On

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
@@ -218,12 +218,6 @@ data:
 
   parsers.conf: |
     [PARSER]
-        Name                docker
-        Format              json
-        Time_Key            time
-        Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
-
-    [PARSER]
         Name                syslog
         Format              regex
         Regex               ^(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
@@ -416,14 +416,6 @@ data:
         Format              json
         Time_Key            time
         Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
-    
-    [PARSER]
-        Name                cri
-        Format              regex
-        Regex               ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
-        Time_Key            time
-        Time_Format         %Y-%m-%dT%H:%M:%S.%L%z
-        Time_Keep           On
 
     [PARSER]
         Name                syslog

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
@@ -412,12 +412,6 @@ data:
 
   parsers.conf: |
     [PARSER]
-        Name                docker
-        Format              json
-        Time_Key            time
-        Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
-
-    [PARSER]
         Name                syslog
         Format              regex
         Regex               ^(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
@@ -265,7 +265,7 @@ data:
         Docker_Mode         On
         Docker_Mode_Flush   5
         Docker_Mode_Parser  container_firstline
-        Parser              docker
+        Parser              docker, cri
         DB                  /var/fluent-bit/state/flb_container.db
         Mem_Buf_Limit       50MB
         Skip_Long_Lines     On
@@ -278,7 +278,7 @@ data:
         Name                tail
         Tag                 application.*
         Path                /var/log/containers/fluent-bit*
-        Parser              docker
+        Parser              docker, cri
         DB                  /var/fluent-bit/state/flb_log.db
         Mem_Buf_Limit       5MB
         Skip_Long_Lines     On
@@ -292,7 +292,7 @@ data:
         Docker_Mode         On
         Docker_Mode_Flush   5
         Docker_Mode_Parser  cwagent_firstline
-        Parser              docker
+        Parser              docker, cri
         DB                  /var/fluent-bit/state/flb_cwagent.db
         Mem_Buf_Limit       5MB
         Skip_Long_Lines     On

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
@@ -262,10 +262,7 @@ data:
         Tag                 application.*
         Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
         Path                /var/log/containers/*.log
-        Docker_Mode         On
-        Docker_Mode_Flush   5
-        Docker_Mode_Parser  container_firstline
-        Parser              docker, cri
+        multiline.parser    docker, cri
         DB                  /var/fluent-bit/state/flb_container.db
         Mem_Buf_Limit       50MB
         Skip_Long_Lines     On
@@ -278,7 +275,7 @@ data:
         Name                tail
         Tag                 application.*
         Path                /var/log/containers/fluent-bit*
-        Parser              docker, cri
+        multiline.parser    docker, cri
         DB                  /var/fluent-bit/state/flb_log.db
         Mem_Buf_Limit       5MB
         Skip_Long_Lines     On
@@ -289,10 +286,7 @@ data:
         Name                tail
         Tag                 application.*
         Path                /var/log/containers/cloudwatch-agent*
-        Docker_Mode         On
-        Docker_Mode_Flush   5
-        Docker_Mode_Parser  cwagent_firstline
-        Parser              docker, cri
+        multiline.parser    docker, cri
         DB                  /var/fluent-bit/state/flb_cwagent.db
         Mem_Buf_Limit       5MB
         Skip_Long_Lines     On
@@ -337,10 +331,7 @@ data:
         Name                tail
         Tag                 dataplane.tail.*
         Path                /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
-        Docker_Mode         On
-        Docker_Mode_Flush   5
-        Docker_Mode_Parser  container_firstline
-        Parser              docker
+        multiline.parser    docker, cri
         DB                  /var/fluent-bit/state/flb_dataplane_tail.db
         Mem_Buf_Limit       50MB
         Skip_Long_Lines     On
@@ -425,6 +416,14 @@ data:
         Format              json
         Time_Key            time
         Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
+    
+    [PARSER]
+        Name                cri
+        Format              regex
+        Regex               ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<message>.*)$
+        Time_Key            time
+        Time_Format         %Y-%m-%dT%H:%M:%S.%L%z
+        Time_Keep           On
 
     [PARSER]
         Name                syslog


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I updated in two locations. Although the quickstart yaml derives its content from the source fluent-bit yaml, that only happens when we run an update script, which I don't really want to do for this single change. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
