### PR TITLE
When Containerd is used for container runtime, Fluentd cannot Forward.

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
@@ -37,6 +37,8 @@ metadata:
   labels:
     k8s-app: fluentd-cloudwatch
 data:
+  kubernetes.conf: |
+    kubernetes.conf
   fluent.conf: |
     @include containers.conf
     @include systemd.conf
@@ -397,7 +399,7 @@ spec:
                   key: cluster.name
             - name: CI_VERSION
               value: "k8s/1.3.11"
-            - - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
+            - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
               value: /^(?<time>.+) (?<stream>stdout|stderr) (?<logtag>[FP]) (?<log>.*)$/
           resources:
             limits:
@@ -410,6 +412,9 @@ spec:
               mountPath: /config-volume
             - name: fluentdconf
               mountPath: /fluentd/etc
+            - name: fluentd-config
+              mountPath: /fluentd/etc/kubernetes.conf
+              subPath: kubernetes.conf
             - name: varlog
               mountPath: /var/log
             - name: varlibdockercontainers
@@ -421,14 +426,18 @@ spec:
             - name: dmesg
               mountPath: /var/log/dmesg
               readOnly: true
-      nodeSelector:
-        kubernetes.io/os: linux
       volumes:
         - name: config-volume
           configMap:
             name: fluentd-config
         - name: fluentdconf
           emptyDir: {}
+        - name: fluentd-config
+          configMap:
+            name: fluentd-config
+            items:
+            - key: kubernetes.conf
+              path: kubernetes.conf
         - name: varlog
           hostPath:
             path: /var/log

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
@@ -56,8 +56,8 @@ data:
       tag *
       read_from_head true
       <parse>
-        @type json
-        time_format %Y-%m-%dT%H:%M:%S.%NZ
+        @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"
+        time_format %Y-%m-%dT%H:%M:%S.%N%:z
       </parse>
     </source>
 
@@ -397,6 +397,8 @@ spec:
                   key: cluster.name
             - name: CI_VERSION
               value: "k8s/1.3.11"
+            - - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
+              value: /^(?<time>.+) (?<stream>stdout|stderr) (?<logtag>[FP]) (?<log>.*)$/
           resources:
             limits:
               memory: 400Mi


### PR DESCRIPTION
*Issue #, if available:*
Fix: https://github.com/aws-samples/amazon-cloudwatch-container-insights/issues/116
*Description of changes:*

The configuration of the fluentd sample is based on the assumption that docker logs are handled, so it should be changed to support logs when the runtime is containerd.

Docker is in json format, but containerd is in one-line text format.
Therefore, type @JSON cannot parse the containerd log.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
