### PR TITLE
update ingress paths

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_traffic/nginx-traffic/nginx-traffic-sample.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_traffic/nginx-traffic/nginx-traffic-sample.yaml
@@ -77,24 +77,30 @@ spec:
 
 ---
 
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress-nginx-demo
   namespace: {{namespace}}
 spec:
   rules:
-  - host: {{external_ip}}
-    http:
-      paths:
-        - path: /apple
-          backend:
-            serviceName: apple-service
-            servicePort: 5678
-        - path: /banana
-          backend:
-            serviceName: banana-service
-            servicePort: 5678
+    - host: {{external_ip}}
+      http:
+        paths:
+          - path: /apple
+            pathType: Prefix
+            backend:
+              service:
+                name: apple-service
+                port: 
+                  number: 5678
+          - path: /banana
+            pathType: Prefix
+            backend:
+              service: 
+                name: banana-service
+                port: 
+                  number: 5678
 
 ---
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Update one section of the kubectl config to avoid the following error which was happening:
```
error: resource mapping not found for name: "ingress-nginx-demo" namespace: "nginx-sample-traffic" from "STDIN": no matches for kind "Ingress" in version "extensions/v1beta1"
ensure CRDs are installed first
```
Reference for changes: https://kubernetes.io/docs/concepts/services-networking/ingress/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
