### PR TITLE
Updated ingress for Kubernetes >v1.22

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_traffic/nginx-traffic/README.md
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_traffic/nginx-traffic/README.md
@@ -1,2 +1,2 @@
-## Sample Nginx-Igress Application Yaml File for Demo
+## Sample Nginx-Ingress Application Yaml File for Demo
 Please refer to [Set Up NGINX with Sample Traffic](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights-Prometheus-Sample-Workloads-nginx.html) for installation guide.

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_traffic/nginx-traffic/nginx-traffic-samplev122.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_traffic/nginx-traffic/nginx-traffic-samplev122.yaml
@@ -1,0 +1,124 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{namespace}}
+  labels:
+    name: {{namespace}}
+
+---
+
+kind: Pod
+apiVersion: v1
+metadata:
+  name: banana-app
+  namespace: {{namespace}}
+  labels:
+    app: banana
+spec:
+  containers:
+    - name: banana-app
+      image: hashicorp/http-echo
+      args:
+        - "-text=banana"
+      resources:
+        limits:
+          cpu:  100m
+          memory: 100Mi
+        requests:
+          cpu: 50m
+          memory: 50Mi
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: banana-service
+  namespace: {{namespace}}
+spec:
+  selector:
+    app: banana
+  ports:
+    - port: 5678 # Default port for image
+
+---
+
+kind: Pod
+apiVersion: v1
+metadata:
+  name: apple-app
+  namespace: {{namespace}}
+  labels:
+    app: apple
+spec:
+  containers:
+    - name: apple-app
+      image: hashicorp/http-echo
+      args:
+        - "-text=apple"
+      resources:
+        limits:
+          cpu:  100m
+          memory: 100Mi
+        requests:
+          cpu: 50m
+          memory: 50Mi
+---
+
+kind: Service
+apiVersion: v1
+metadata:
+  name: apple-service
+  namespace: {{namespace}}
+spec:
+  selector:
+    app: apple
+  ports:
+    - port: 5678 # Default port for image
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-nginx-demo
+  namespace: {{namespace}}
+spec:
+  rules:
+  - host: {{external_ip}}
+    http:
+      paths:
+        - path: /apple
+          pathType: ImplementationSpecific
+          backend:
+            service:
+              name: apple-service
+              port:
+                number: 5678
+        - path: /banana
+          pathType: ImplementationSpecific
+          backend:
+            service:
+              name: banana-service
+              port: 
+                number: 5678
+
+---
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: traffic-generator
+  namespace: {{namespace}}
+spec:
+  containers:
+    - name: traffic-generator
+      image: ellerbrock/alpine-bash-curl-ssl
+      command: ["/bin/bash"]
+      args: ["-c", "while :; do curl http://{{external_ip}}/apple > /dev/null 2>&1; curl http://{{external_ip}}/banana > /dev/null 2>&1; sleep 1; done"]
+      resources:
+        limits:
+          cpu:  100m
+          memory: 100Mi
+        requests:
+          cpu: 50m
+          memory: 50Mi


### PR DESCRIPTION
*Description of changes:*

This example application is failing to deploy on Kubernete > v1.22 due some API changes.

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22

This new example is compatible. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
