### PR TITLE
Update container registry to ecr public

### DIFF
--- a/container-insights-manifest-update.sh
+++ b/container-insights-manifest-update.sh
@@ -5,7 +5,7 @@ k8sDirPrefix="./k8s-deployment-manifest-templates/deployment-mode/daemonset/cont
 ecsDirPrefix="./ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric"
 
 newK8sVersion="k8s/1.3.11"
-agentVersion="amazon/cloudwatch-agent:1.247355.0b252062"
+agentVersion="public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247357.0b252275"
 fluentdVersion="fluent/fluentd-kubernetes-daemonset:v1.7.3-debian-cloudwatch-1.0"
 fluentBitVersion="public.ecr.aws/aws-observability/aws-for-fluent-bit:stable"
 
@@ -13,31 +13,31 @@ k8sPrometheusDirPrefix="./k8s-deployment-manifest-templates/deployment-mode/serv
 ecsPrometheusDirPrefix="./ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus"
 
 # replace agent version for ECS Prometheus
-sed -i'.bak' "s|amazon/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*\(-prometheus\)\?|${agentVersion}|g" ${ecsPrometheusDirPrefix}/cwagent-prometheus-task-definition.json
+sed -i'.bak' "s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*\(-prometheus\)\?|${agentVersion}|g" ${ecsPrometheusDirPrefix}/cwagent-prometheus-task-definition.json
 rm ${ecsPrometheusDirPrefix}/cwagent-prometheus-task-definition.json.bak
-sed -i'.bak' "s|amazon/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*\(-prometheus\)\?|${agentVersion}|g" ${ecsPrometheusDirPrefix}/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
+sed -i'.bak' "s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*\(-prometheus\)\?|${agentVersion}|g" ${ecsPrometheusDirPrefix}/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
 rm ${ecsPrometheusDirPrefix}/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml.bak
-sed -i'.bak' "s|amazon/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*\(-prometheus\)\?|${agentVersion}|g" ${ecsPrometheusDirPrefix}/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
+sed -i'.bak' "s|public.ecr.aws/cloudwatch-agentcloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*\(-prometheus\)\?|${agentVersion}|g" ${ecsPrometheusDirPrefix}/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
 rm ${ecsPrometheusDirPrefix}/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml.bak
 
 # replace agent and k8s version for K8s Prometheus
-sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*\(-prometheus\)\?|${newK8sVersion}|g;s|amazon/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*\(-prometheus\)\?|${agentVersion}|g" ${k8sPrometheusDirPrefix}/prometheus-eks.yaml
+sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*\(-prometheus\)\?|${newK8sVersion}|g;s|public.ecr.aws/cloudwatch-agentcloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*\(-prometheus\)\?|${agentVersion}|g" ${k8sPrometheusDirPrefix}/prometheus-eks.yaml
 rm ${k8sPrometheusDirPrefix}/prometheus-eks.yaml.bak
-sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*\(-prometheus\)\?|${newK8sVersion}|g;s|amazon/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*\(-prometheus\)\?|${agentVersion}|g" ${k8sPrometheusDirPrefix}/prometheus-eks-fargate.yaml
+sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*\(-prometheus\)\?|${newK8sVersion}|g;s|public.ecr.aws/cloudwatch-agentcloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*\(-prometheus\)\?|${agentVersion}|g" ${k8sPrometheusDirPrefix}/prometheus-eks-fargate.yaml
 rm ${k8sPrometheusDirPrefix}/prometheus-eks-fargate.yaml.bak
-sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*\(-prometheus\)\?|${newK8sVersion}|g;s|amazon/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*\(-prometheus\)\?|${agentVersion}|g" ${k8sPrometheusDirPrefix}/prometheus-k8s.yaml
+sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*\(-prometheus\)\?|${newK8sVersion}|g;s|public.ecr.aws/cloudwatch-agentcloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*\(-prometheus\)\?|${agentVersion}|g" ${k8sPrometheusDirPrefix}/prometheus-k8s.yaml
 rm ${k8sPrometheusDirPrefix}/prometheus-k8s.yaml.bak
 
 
 # replace agent version for ECS
-sed -i'.bak' "s|amazon/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${ecsDirPrefix}/cwagent-ecs-instance-metric.json
+sed -i'.bak' "s|public.ecr.aws/cloudwatch-agentcloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${ecsDirPrefix}/cwagent-ecs-instance-metric.json
 rm ${ecsDirPrefix}/cwagent-ecs-instance-metric.json.bak
 
-sed -i'.bak' "s|amazon/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${ecsDirPrefix}/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json
+sed -i'.bak' "s|public.ecr.aws/cloudwatch-agentcloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${ecsDirPrefix}/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json
 rm ${ecsDirPrefix}/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json.bak
 
 # replace agent, fluentD and fluent-bit version for K8s
-sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|amazon/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${k8sDirPrefix}/cwagent/cwagent-daemonset.yaml
+sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public.ecr.aws/cloudwatch-agentcloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${k8sDirPrefix}/cwagent/cwagent-daemonset.yaml
 rm ${k8sDirPrefix}/cwagent/cwagent-daemonset.yaml.bak
 
 sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|fluent/fluentd-kubernetes-daemonset:.*|${fluentdVersion}|g" ${k8sDirPrefix}/fluentd/fluentd.yaml

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json
@@ -105,7 +105,7 @@
         "ContainerDefinitions": [
           {
             "Name": "cloudwatch-agent",
-            "Image": "amazon/cloudwatch-agent:1.247355.0b252062",
+            "Image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247357.0b252275",
             "MountPoints": [
               {
                 "ReadOnly": true,

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cwagent-ecs-instance-metric.json
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cwagent-ecs-instance-metric.json
@@ -6,7 +6,7 @@
   "containerDefinitions": [
     {
       "name": "cloudwatch-agent",
-      "image": "amazon/cloudwatch-agent:1.247355.0b252062",
+      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247357.0b252275",
       "mountPoints": [
         {
           "readOnly": true,

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
@@ -224,7 +224,7 @@ Resources:
       NetworkMode: awsvpc
       ContainerDefinitions:
         - Name: cloudwatch-agent-prometheus
-          Image: amazon/cloudwatch-agent:1.247355.0b252062
+          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247357.0b252275
           Essential: true
           MountPoints: []
           PortMappings: []

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
@@ -219,7 +219,7 @@ Resources:
       NetworkMode: !Ref ECSNetworkMode
       ContainerDefinitions:
         - Name: cloudwatch-agent-prometheus
-          Image: amazon/cloudwatch-agent:1.247355.0b252062
+          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247357.0b252275
           Essential: true
           MountPoints: []
           PortMappings: []

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cwagent-prometheus-task-definition.json
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cwagent-prometheus-task-definition.json
@@ -6,7 +6,7 @@
   "containerDefinitions": [
     {
       "name": "cloudwatch-agent-prometheus",
-      "image": "amazon/cloudwatch-agent:1.247355.0b252062",
+      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247357.0b252275",
       "essential": true,
       "mountPoints": [
       ],

--- a/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-ec2.json
@@ -22,7 +22,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "amazon/cloudwatch-agent:latest",
+            "image": "public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-fargate.json
@@ -19,7 +19,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "amazon/cloudwatch-agent:latest",
+            "image": "public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-ec2.json
@@ -22,7 +22,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "amazon/cloudwatch-agent:latest",
+            "image": "public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-fargate.json
@@ -19,7 +19,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "amazon/cloudwatch-agent:latest",
+            "image": "public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-ec2.json
@@ -22,7 +22,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "amazon/cloudwatch-agent:latest",
+            "image": "public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-fargate.json
@@ -19,7 +19,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "amazon/cloudwatch-agent:latest",
+            "image": "public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-ec2.json
@@ -27,7 +27,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "amazon/cloudwatch-agent:latest",
+            "image": "public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-fargate.json
@@ -24,7 +24,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "amazon/cloudwatch-agent:latest",
+            "image": "public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/combination/combination.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/combination/combination.yaml
@@ -113,7 +113,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:latest
+          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
           ports:
             - containerPort: 8125
               hostPort: 8125
@@ -694,7 +694,7 @@ spec:
     spec:
       containers:
         - name: xray-daemon
-          image: amazon/aws-xray-daemon:latest
+          image: public.ecr.public/xray/aws-xray-daemon:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 2000

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:1.247355.0b252062
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247357.0b252275
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
@@ -98,7 +98,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:1.247355.0b252062
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247357.0b252275
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -148,6 +148,8 @@ spec:
             - name: devdisk
               mountPath: /dev/disk
               readOnly: true
+      nodeSelector:
+        kubernetes.io/os: linux
       volumes:
         - name: cwagentconfig
           configMap:
@@ -241,6 +243,7 @@ data:
   fluent-bit.conf: |
     [SERVICE]
         Flush                     5
+        Grace                     30
         Log_Level                 info
         Daemon                    off
         Parsers_File              parsers.conf
@@ -361,7 +364,7 @@ data:
         log_stream_prefix   ${HOST_NAME}-
         auto_create_group   true
         extra_user_agent    container-insights
-    
+
   host-log.conf: |
     [INPUT]
         Name                tail

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
@@ -98,7 +98,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:1.247355.0b252062
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247357.0b252275
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -228,6 +228,8 @@ metadata:
   labels:
     k8s-app: fluentd-cloudwatch
 data:
+  kubernetes.conf: |
+    kubernetes.conf
   fluent.conf: |
     @include containers.conf
     @include systemd.conf
@@ -247,8 +249,8 @@ data:
       tag *
       read_from_head true
       <parse>
-        @type json
-        time_format %Y-%m-%dT%H:%M:%S.%NZ
+        @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"
+        time_format %Y-%m-%dT%H:%M:%S.%N%:z
       </parse>
     </source>
 
@@ -588,6 +590,8 @@ spec:
                   key: cluster.name
             - name: CI_VERSION
               value: "k8s/1.3.11"
+            - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
+              value: /^(?<time>.+) (?<stream>stdout|stderr) (?<logtag>[FP]) (?<log>.*)$/
           resources:
             limits:
               memory: 400Mi
@@ -599,6 +603,9 @@ spec:
               mountPath: /config-volume
             - name: fluentdconf
               mountPath: /fluentd/etc
+            - name: fluentd-config
+              mountPath: /fluentd/etc/kubernetes.conf
+              subPath: kubernetes.conf
             - name: varlog
               mountPath: /var/log
             - name: varlibdockercontainers
@@ -610,14 +617,18 @@ spec:
             - name: dmesg
               mountPath: /var/log/dmesg
               readOnly: true
-      nodeSelector:
-        kubernetes.io/os: linux
       volumes:
         - name: config-volume
           configMap:
             name: fluentd-config
         - name: fluentdconf
           emptyDir: {}
+        - name: fluentd-config
+          configMap:
+            name: fluentd-config
+            items:
+            - key: kubernetes.conf
+              path: kubernetes.conf
         - name: varlog
           hostPath:
             path: /var/log

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-fluentd-xray/cwagent-fluentd-xray-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-fluentd-xray/cwagent-fluentd-xray-quickstart.yaml
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:latest
+          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
           ports:
             - containerPort: 25888
               hostPort: 25888
@@ -579,7 +579,7 @@ spec:
     spec:
       containers:
         - name: xray-daemon
-          image: amazon/aws-xray-daemon:latest
+          image: public.ecr.public/xray/aws-xray-daemon:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 2000

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:latest
+          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 31000

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-statsd/cwagent-statsd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-statsd/cwagent-statsd.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:latest
+          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
           imagePullPolicy: Always
           ports:
             # containerPort should be consistent with the listen port defined in configmap

--- a/k8s-deployment-manifest-templates/deployment-mode/service/combination/combination.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/combination/combination.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:latest
+          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-fargate.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-fargate.yaml
@@ -398,7 +398,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:1.247355.0b252062
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247357.0b252275
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
@@ -449,7 +449,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:1.247355.0b252062
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247357.0b252275
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-k8s.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-k8s.yaml
@@ -396,7 +396,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:1.247355.0b252062
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247357.0b252275
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
@@ -40,7 +40,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:latest
+          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-statsd/cwagent-statsd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-statsd/cwagent-statsd.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:latest
+          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/combination/combination.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/combination/combination.yaml
@@ -24,7 +24,7 @@ spec:
           - name: AWS_CSM_HOST
             value: "127.0.0.1"
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:latest
+          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf.yaml
@@ -17,7 +17,7 @@ spec:
           image: <demo-app-docker-image> # this is the your demo app docker image
           imagePullPolicy: Always
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:latest
+          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
@@ -42,7 +42,7 @@ spec:
     - name: AWS_CSM_HOST
       value: "127.0.0.1"
   - name: cloudwatch-agent
-    image: amazon/cloudwatch-agent:latest
+    image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
     imagePullPolicy: Always
     resources:
       limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd.yaml
@@ -19,7 +19,7 @@ spec:
           args: ["-c", "while true; do echo 'statsdTestMetric:1|c' | socat -v -t 0 - UDP:127.0.0.1:8125; sleep 1; done"]
           imagePullPolicy: Always
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:latest
+          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-daemonset.yaml
+++ b/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-daemonset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:1.230621.0
+          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:1.230621.0
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125

--- a/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-daemonset.yaml
+++ b/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-daemonset.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:latest
+          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
           imagePullPolicy: Always
           ports:
             # containerPort should be consistent with the listen port defined in configmap

--- a/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-deployment.yaml
+++ b/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:latest
+          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml
@@ -99,7 +99,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: amazon/cloudwatch-agent:1.230621.0
+          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:1.230621.0
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125


### PR DESCRIPTION
*Issue #, if available:*
fixes #121 

*Description of changes:*
Updated all templates to use `public.ecr.aws` with appropriate namespace instead of dockerhub `amazon/` namespace.

I updated the `container-insights-manifest-update.sh` script, ran it, and then updated the sed text to replace. Running the script made additional changes to files I didn't expect that I'm not sure if it should be reverted and fixed in the generation script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
