### PR TITLE
Fix ECR image name

### DIFF
--- a/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-ec2.json
@@ -22,7 +22,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-fargate.json
@@ -19,7 +19,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-ec2.json
@@ -22,7 +22,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-fargate.json
@@ -19,7 +19,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-ec2.json
@@ -22,7 +22,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-fargate.json
@@ -19,7 +19,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-ec2.json
@@ -27,7 +27,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-fargate.json
@@ -24,7 +24,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/combination/combination.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/combination/combination.yaml
@@ -113,7 +113,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
           ports:
             - containerPort: 8125
               hostPort: 8125
@@ -694,7 +694,7 @@ spec:
     spec:
       containers:
         - name: xray-daemon
-          image: public.ecr.public/xray/aws-xray-daemon:latest
+          image: public.ecr.aws/xray/aws-xray-daemon:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 2000

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-fluentd-xray/cwagent-fluentd-xray-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-fluentd-xray/cwagent-fluentd-xray-quickstart.yaml
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
           ports:
             - containerPort: 25888
               hostPort: 25888
@@ -579,7 +579,7 @@ spec:
     spec:
       containers:
         - name: xray-daemon
-          image: public.ecr.public/xray/aws-xray-daemon:latest
+          image: public.ecr.aws/xray/aws-xray-daemon:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 2000

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
           imagePullPolicy: Always
           ports:
             - containerPort: 31000

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-statsd/cwagent-statsd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-statsd/cwagent-statsd.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
           imagePullPolicy: Always
           ports:
             # containerPort should be consistent with the listen port defined in configmap

--- a/k8s-deployment-manifest-templates/deployment-mode/service/combination/combination.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/combination/combination.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
@@ -40,7 +40,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-statsd/cwagent-statsd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-statsd/cwagent-statsd.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/combination/combination.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/combination/combination.yaml
@@ -24,7 +24,7 @@ spec:
           - name: AWS_CSM_HOST
             value: "127.0.0.1"
         - name: cloudwatch-agent
-          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf.yaml
@@ -17,7 +17,7 @@ spec:
           image: <demo-app-docker-image> # this is the your demo app docker image
           imagePullPolicy: Always
         - name: cloudwatch-agent
-          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
@@ -42,7 +42,7 @@ spec:
     - name: AWS_CSM_HOST
       value: "127.0.0.1"
   - name: cloudwatch-agent
-    image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
+    image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
     imagePullPolicy: Always
     resources:
       limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd.yaml
@@ -19,7 +19,7 @@ spec:
           args: ["-c", "while true; do echo 'statsdTestMetric:1|c' | socat -v -t 0 - UDP:127.0.0.1:8125; sleep 1; done"]
           imagePullPolicy: Always
         - name: cloudwatch-agent
-          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-daemonset.yaml
+++ b/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-daemonset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:1.230621.0
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.230621.0
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125

--- a/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-daemonset.yaml
+++ b/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-daemonset.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
           imagePullPolicy: Always
           ports:
             # containerPort should be consistent with the listen port defined in configmap

--- a/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-deployment.yaml
+++ b/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml
@@ -99,7 +99,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.public/cloudwatch-agent/cloudwatch-agent:1.230621.0
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.230621.0
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125


### PR DESCRIPTION
#122 broke ECR images with a bad sed call, pointing to `public.ecr.public` instead of `public.ecr.aws`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
