### PR TITLE
Remove legacy EMF ssm parameter definition from cwagent-emf README

### DIFF
--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/README.md
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/README.md
@@ -11,25 +11,12 @@ You must replace all the placeholders (with ```{{ }}```) in the above task defin
 * ```{{task-role-arn}}```: ECS task role ARN.
   * This is role that you application containers will use. The permission should be whatever your applications need.
   * Additionally, ensure that the ```CloudWatchAgentServerPolicy``` policy is attached to your ECS Task Role.
-  
+
 * ```{{execution-role-arn}}```: ECS task execution role ARN.
   * This is the role that Amazon ECS requires to launch/execute your containers, e.g. get the parameters from SSM parameter store.
   * Ensure that the ```AmazonSSMReadOnlyAccess```, ```AmazonECSTaskExecutionRolePolicy``` and ```CloudWatchAgentServerPolicy``` policies are attached to your ECS Task execution role.
-  * If you would like to store more sensitive data for ECS to use, refer to https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html.    
+  * If you would like to store more sensitive data for ECS to use, refer to https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html.
 
 * ```{{awslogs-region}}```: The AWS region where the container logs should be published: e.g. ```us-west-2```
 
 You can also adjust the resource limit (e.g. cpu and memory) based on your particular use cases.
-
-Configure the CloudWatch agent through [SSM parameter](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-su-create.html). Please create a SSM parameter (```ecs-cwagent-sidecar-ec2``` or ```ecs-cwagent-sidecar-fargate```) in the region where your cluster is located, with the following text:
-```
-{
-  "logs": {
-    "metrics_collected": {
-      "emf": {}
-    }
-  }
-}
-```
-
-


### PR DESCRIPTION
# Issue 

# Description of changes: 

* Removed trailing whitespace
* Updated cwagent-emf.README.md to represent more current aws docs: 

> metrics_collected – This is a legacy field that specified that the agent is to collect logs that are in embedded metric format. You can generate metric data from these logs. It contained the emf field which specified that the agent is to collect metrics embedded in logs. To collect metrics embedded in logs it is no longer necessary to include either the metrics_collected field or the emf field.

https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Agent-Configuration-File-Details.html#CloudWatch-Agent-Configuration-File-Logssection

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
