### PR TITLE
Fix for issue#101 - Missing AWS_EMF_AGENT_ENDPOINT env var

### DIFF
--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/README.md
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/README.md
@@ -19,6 +19,9 @@ You must replace all the placeholders (with ```{{ }}```) in the above task defin
 
 * ```{{awslogs-region}}```: The AWS region where the container logs should be published: e.g. ```us-west-2```
 
+* ```{{aws-emf-agent-endpoint}}```: This should point to the endpoint that the agent is listening on. e.g ```tcp://cloudwatch-agent:25888```
+  * Refer to https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format_Generation_CloudWatch_Agent.html.
+
 You can also adjust the resource limit (e.g. cpu and memory) based on your particular use cases.
 
 Configure the CloudWatch agent through [SSM parameter](https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-su-create.html). Please create a SSM parameter (```ecs-cwagent-sidecar-ec2``` or ```ecs-cwagent-sidecar-fargate```) in the region where your cluster is located, with the following text:

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-ec2.json
@@ -10,6 +10,10 @@
             "links": [
                 "cloudwatch-agent"
             ],
+	    "environment": [{
+		"name": "AWS_EMF_AGENT_ENDPOINT",
+		"value": "{{aws-emf-agent-endpoint}}"
+	    }],
             "logConfiguration": {
                 "logDriver": "awslogs",
                 "options": {

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-fargate.json
@@ -7,6 +7,10 @@
         {
             "name": "demo-app",
             "image": "{{demo-app-image}}",
+            "environment": [{
+                "name": "AWS_EMF_AGENT_ENDPOINT",
+                "value": "{{aws-emf-agent-endpoint}}"
+            }],
             "logConfiguration": {
                 "logDriver": "awslogs",
                 "options": {


### PR DESCRIPTION
# Issue 
https://github.com/aws-samples/amazon-cloudwatch-container-insights/issues/101

# Description of changes:
Missing AWS_EMF_AGENT_ENDPOINT env var to ECS task fix
updated readme

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
