### PR TITLE
Remove unnecessary tolerations from fluent-bit pods

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
@@ -55,11 +55,11 @@ data:
         storage.sync              normal
         storage.checksum          off
         storage.backlog.mem_limit 5M
-        
+
     @INCLUDE application-log.conf
     @INCLUDE dataplane-log.conf
     @INCLUDE host-log.conf
-  
+
   application-log.conf: |
     [INPUT]
         Name                tail
@@ -125,7 +125,7 @@ data:
         Name                modify
         Match               application.*
         Rename              Nested.docker_id            Docker.container_id
-    
+
     [FILTER]
         Name                nest
         Match               application.*
@@ -133,7 +133,7 @@ data:
         Wildcard            Nested.*
         Nested_under        kubernetes
         Remove_prefix       Nested.
-    
+
     [FILTER]
         Name                nest
         Match               application.*
@@ -183,7 +183,7 @@ data:
         log_stream_name     $(tag[2]).$(tag[3])-$(hostname)
         auto_create_group   true
         extra_user_agent    container-insight
-    
+
   host-log.conf: |
     [INPUT]
         Name                tail
@@ -366,11 +366,3 @@ spec:
         hostPath:
           path: /var/log/dmesg
       serviceAccountName: fluent-bit
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: "Exists"
-        effect: "NoExecute"
-      - operator: "Exists"
-        effect: "NoSchedule"

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
@@ -57,11 +57,11 @@ data:
         storage.sync              normal
         storage.checksum          off
         storage.backlog.mem_limit 5M
-        
+
     @INCLUDE application-log.conf
     @INCLUDE dataplane-log.conf
     @INCLUDE host-log.conf
-  
+
   application-log.conf: |
     [INPUT]
         Name                tail
@@ -352,11 +352,3 @@ spec:
         hostPath:
           path: /var/log/dmesg
       serviceAccountName: fluent-bit
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: "Exists"
-        effect: "NoExecute"
-      - operator: "Exists"
-        effect: "NoSchedule"

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
@@ -254,11 +254,11 @@ data:
         storage.sync              normal
         storage.checksum          off
         storage.backlog.mem_limit 5M
-        
+
     @INCLUDE application-log.conf
     @INCLUDE dataplane-log.conf
     @INCLUDE host-log.conf
-  
+
   application-log.conf: |
     [INPUT]
         Name                tail
@@ -549,11 +549,3 @@ spec:
         hostPath:
           path: /var/log/dmesg
       serviceAccountName: fluent-bit
-      tolerations:
-      - key: node-role.kubernetes.io/master
-        operator: Exists
-        effect: NoSchedule
-      - operator: "Exists"
-        effect: "NoExecute"
-      - operator: "Exists"
-        effect: "NoSchedule"


### PR DESCRIPTION
# Description of changes:

Remove unnecessary tolerations from fluent-bit pods. These tolerations were far too broad and caused scheduling of these pods onto Fargate nodes, where daemonsets aren't supported. Customers can apply their own site-specific tolerations as necessary.

There weren't similar tolerations for the cloudwatch-agent daemonset, so the impact on existing clusters should be only to remove fluent-bit pods from tainted nodes. Again, customers can apply their own specific tolerations if they desire fluent-bit to be rescheduled on tainted nodes.

Fixes #61 

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
