### PR TITLE
updates for enhanced container insights

### DIFF
--- a/container-insights-manifest-update.sh
+++ b/container-insights-manifest-update.sh
@@ -4,8 +4,8 @@ cd "$(dirname "$0")"
 k8sDirPrefix="./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring"
 ecsDirPrefix="./ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric"
 
-newK8sVersion="k8s/1.3.16"
-agentVersion="public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247360.0b252689"
+newK8sVersion="k8s/1.3.17"
+agentVersion="public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210"
 fluentdVersion="fluent/fluentd-kubernetes-daemonset:v1.10.3-debian-cloudwatch-1.0"
 fluentBitVersion="public.ecr.aws/aws-observability/aws-for-fluent-bit:stable"
 

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json
@@ -105,7 +105,7 @@
         "ContainerDefinitions": [
           {
             "Name": "cloudwatch-agent",
-            "Image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247360.0b252689",
+            "Image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
             "MountPoints": [
               {
                 "ReadOnly": true,

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cwagent-ecs-instance-metric.json
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cwagent-ecs-instance-metric.json
@@ -6,7 +6,7 @@
   "containerDefinitions": [
     {
       "name": "cloudwatch-agent",
-      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247360.0b252689",
+      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
       "mountPoints": [
         {
           "readOnly": true,

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
@@ -224,7 +224,7 @@ Resources:
       NetworkMode: awsvpc
       ContainerDefinitions:
         - Name: cloudwatch-agent-prometheus
-          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247360.0b252689
+          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           Essential: true
           MountPoints: []
           PortMappings: []

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
@@ -219,7 +219,7 @@ Resources:
       NetworkMode: !Ref ECSNetworkMode
       ContainerDefinitions:
         - Name: cloudwatch-agent-prometheus
-          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247360.0b252689
+          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           Essential: true
           MountPoints: []
           PortMappings: []

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cwagent-prometheus-task-definition.json
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cwagent-prometheus-task-definition.json
@@ -6,7 +6,7 @@
   "containerDefinitions": [
     {
       "name": "cloudwatch-agent-prometheus",
-      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247360.0b252689",
+      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
       "essential": true,
       "mountPoints": [
       ],

--- a/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-ec2.json
@@ -22,7 +22,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-fargate.json
@@ -19,7 +19,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-ec2.json
@@ -22,7 +22,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-fargate.json
@@ -19,7 +19,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-ec2.json
@@ -22,7 +22,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-fargate.json
@@ -19,7 +19,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-ec2.json
@@ -27,7 +27,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-fargate.json
@@ -24,7 +24,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/combination/combination.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/combination/combination.yaml
@@ -24,7 +24,7 @@ rules:
     resources: ["pods", "nodes", "endpoints"]
     verbs: ["list", "watch"]
   - apiGroups: ["apps"]
-    resources: ["replicasets"]
+    resources: ["replicasets", "daemonsets", "deployments"]
     verbs: ["list", "watch"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
@@ -39,6 +39,8 @@ rules:
     resources: ["configmaps"]
     resourceNames: ["cwagent-clusterleader"]
     verbs: ["get","update"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get", "list", "watch"]
 
 ---
 kind: ClusterRoleBinding
@@ -71,7 +73,8 @@ data:
         "metrics_collected": {
           "kubernetes": {
             "cluster_name": "{{cluster_name}}",
-            "metrics_collection_interval": 60
+            "metrics_collection_interval": 60,
+            "enhanced_container_insights": true
           },
           "emf": {}
         },
@@ -113,7 +116,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           ports:
             - containerPort: 8125
               hostPort: 8125
@@ -126,11 +129,11 @@ spec:
               protocol: UDP
           resources:
             limits:
-              cpu:  200m
-              memory: 200Mi
+              cpu:  400m
+              memory: 400Mi
             requests:
-              cpu: 200m
-              memory: 200Mi
+              cpu: 400m
+              memory: 400Mi
           # Please don't change below envs
           env:
             - name: HOST_IP

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-configmap.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-configmap.yaml
@@ -9,7 +9,8 @@ data:
         "metrics_collected": {
           "kubernetes": {
             "cluster_name": "{{cluster_name}}",
-            "metrics_collection_interval": 60
+            "metrics_collection_interval": 60,
+            "enhanced_container_insights": true
           }
         },
         "force_flush_interval": 5

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset.yaml
@@ -15,18 +15,18 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247360.0b252689
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
           #    protocol: UDP
           resources:
             limits:
-              cpu:  200m
-              memory: 200Mi
+              cpu:  400m
+              memory: 400Mi
             requests:
-              cpu: 200m
-              memory: 200Mi
+              cpu: 400m
+              memory: 400Mi
           # Please don't change below envs
           env:
             - name: HOST_IP
@@ -42,7 +42,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.16"
+              value: "k8s/1.3.17"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-serviceaccount.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-serviceaccount.yaml
@@ -15,7 +15,7 @@ rules:
     resources: ["pods", "nodes", "endpoints"]
     verbs: ["list", "watch"]
   - apiGroups: ["apps"]
-    resources: ["replicasets"]
+    resources: ["replicasets", "daemonsets", "deployments"]
     verbs: ["list", "watch"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
@@ -30,6 +30,8 @@ rules:
     resources: ["configmaps"]
     resourceNames: ["cwagent-clusterleader"]
     verbs: ["get","update"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get", "list", "watch"]
 
 ---
 kind: ClusterRoleBinding

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
@@ -320,7 +320,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: CI_VERSION
-              value: "k8s/1.3.16"
+              value: "k8s/1.3.17"
         resources:
             limits:
               memory: 200Mi

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
@@ -304,7 +304,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.name
             - name: CI_VERSION
-              value: "k8s/1.3.16"
+              value: "k8s/1.3.17"
         resources:
             limits:
               memory: 200Mi

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
@@ -398,7 +398,7 @@ spec:
                   name: cluster-info
                   key: cluster.name
             - name: CI_VERSION
-              value: "k8s/1.3.16"
+              value: "k8s/1.3.17"
             - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
               value: /^(?<time>.+) (?<stream>stdout|stderr) (?<logtag>[FP]) (?<log>.*)$/
           resources:

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
@@ -24,7 +24,7 @@ rules:
     resources: ["pods", "nodes", "endpoints"]
     verbs: ["list", "watch"]
   - apiGroups: ["apps"]
-    resources: ["replicasets"]
+    resources: ["replicasets", "daemonsets", "deployments"]
     verbs: ["list", "watch"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
@@ -39,6 +39,8 @@ rules:
     resources: ["configmaps"]
     resourceNames: ["cwagent-clusterleader"]
     verbs: ["get","update"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get", "list", "watch"]
 
 ---
 kind: ClusterRoleBinding
@@ -69,7 +71,8 @@ data:
         "metrics_collected": {
           "kubernetes": {
             "cluster_name": "{{cluster_name}}",
-            "metrics_collection_interval": 60
+            "metrics_collection_interval": 60,
+            "enhanced_container_insights": true
           }
         },
         "force_flush_interval": 5
@@ -98,18 +101,18 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247360.0b252689
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
           #    protocol: UDP
           resources:
             limits:
-              cpu:  200m
-              memory: 200Mi
+              cpu:  400m
+              memory: 400Mi
             requests:
-              cpu: 200m
-              memory: 200Mi
+              cpu: 400m
+              memory: 400Mi
           # Please don't change below envs
           env:
             - name: HOST_IP
@@ -125,7 +128,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.16"
+              value: "k8s/1.3.17"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig
@@ -501,7 +504,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.name
             - name: CI_VERSION
-              value: "k8s/1.3.16"
+              value: "k8s/1.3.17"
         resources:
             limits:
               memory: 200Mi

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
@@ -24,7 +24,7 @@ rules:
     resources: ["pods", "nodes", "endpoints"]
     verbs: ["list", "watch"]
   - apiGroups: ["apps"]
-    resources: ["replicasets"]
+    resources: ["replicasets", "daemonsets", "deployments"]
     verbs: ["list", "watch"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
@@ -39,6 +39,8 @@ rules:
     resources: ["configmaps"]
     resourceNames: ["cwagent-clusterleader"]
     verbs: ["get","update"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get", "list", "watch"]
 
 ---
 kind: ClusterRoleBinding
@@ -69,7 +71,8 @@ data:
         "metrics_collected": {
           "kubernetes": {
             "cluster_name": "{{cluster_name}}",
-            "metrics_collection_interval": 60
+            "metrics_collection_interval": 60,
+            "enhanced_container_insights": true
           }
         },
         "force_flush_interval": 5
@@ -98,18 +101,18 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247360.0b252689
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
           #    protocol: UDP
           resources:
             limits:
-              cpu:  200m
-              memory: 200Mi
+              cpu:  400m
+              memory: 400Mi
             requests:
-              cpu: 200m
-              memory: 200Mi
+              cpu: 400m
+              memory: 400Mi
           # Please don't change below envs
           env:
             - name: HOST_IP
@@ -125,7 +128,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.16"
+              value: "k8s/1.3.17"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig
@@ -576,7 +579,7 @@ spec:
           command: ['sh','-c','']
       containers:
         - name: fluentd-cloudwatch
-          image: fluent/fluentd-kubernetes-daemonset:v1.7.3-debian-cloudwatch-1.0
+          image: fluent/fluentd-kubernetes-daemonset:v1.10.3-debian-cloudwatch-1.0
           env:
             - name: AWS_REGION
               valueFrom:
@@ -589,7 +592,7 @@ spec:
                   name: cluster-info
                   key: cluster.name
             - name: CI_VERSION
-              value: "k8s/1.3.16"
+              value: "k8s/1.3.17"
             - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
               value: /^(?<time>.+) (?<stream>stdout|stderr) (?<logtag>[FP]) (?<log>.*)$/
           resources:

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-fluentd-xray/cwagent-fluentd-xray-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-fluentd-xray/cwagent-fluentd-xray-quickstart.yaml
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           ports:
             - containerPort: 25888
               hostPort: 25888

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           imagePullPolicy: Always
           ports:
             - containerPort: 31000

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-statsd/cwagent-statsd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-statsd/cwagent-statsd.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           imagePullPolicy: Always
           ports:
             # containerPort should be consistent with the listen port defined in configmap

--- a/k8s-deployment-manifest-templates/deployment-mode/service/combination/combination.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/combination/combination.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-fargate.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-fargate.yaml
@@ -398,7 +398,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247360.0b252689
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           imagePullPolicy: Always
           resources:
             limits:
@@ -410,7 +410,7 @@ spec:
           # Please don't change below envs
           env:
             - name: CI_VERSION
-              value: "k8s/1.3.16"
+              value: "k8s/1.3.17"
             - name: RUN_IN_AWS
               value: "True"
           # Please don't change the mountPath

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
@@ -449,7 +449,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247360.0b252689
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           imagePullPolicy: Always
           resources:
             limits:
@@ -461,7 +461,7 @@ spec:
           # Please don't change below envs
           env:
             - name: CI_VERSION
-              value: "k8s/1.3.16"
+              value: "k8s/1.3.17"
           # Please don't change the mountPath
           volumeMounts:
             - name: prometheus-cwagentconfig

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-k8s.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-k8s.yaml
@@ -396,7 +396,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.247360.0b252689
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           imagePullPolicy: Always
           resources:
             limits:
@@ -408,7 +408,7 @@ spec:
           # Please don't change below envs
           env:
             - name: CI_VERSION
-              value: "k8s/1.3.16"
+              value: "k8s/1.3.17"
           # Please don't change the mountPath
           volumeMounts:
             - name: prometheus-cwagentconfig

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
@@ -40,7 +40,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-statsd/cwagent-statsd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-statsd/cwagent-statsd.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/combination/combination.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/combination/combination.yaml
@@ -24,7 +24,7 @@ spec:
           - name: AWS_CSM_HOST
             value: "127.0.0.1"
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf.yaml
@@ -17,7 +17,7 @@ spec:
           image: <demo-app-docker-image> # this is the your demo app docker image
           imagePullPolicy: Always
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
@@ -42,7 +42,7 @@ spec:
     - name: AWS_CSM_HOST
       value: "127.0.0.1"
   - name: cloudwatch-agent
-    image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
+    image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
     imagePullPolicy: Always
     resources:
       limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd.yaml
@@ -19,7 +19,7 @@ spec:
           args: ["-c", "while true; do echo 'statsdTestMetric:1|c' | socat -v -t 0 - UDP:127.0.0.1:8125; sleep 1; done"]
           imagePullPolicy: Always
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-configmap.yaml
+++ b/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-configmap.yaml
@@ -9,7 +9,8 @@ data:
         "metrics_collected": {
           "kubernetes": {
             "cluster_name": "{{cluster_name}}",
-            "metrics_collection_interval": 60
+            "metrics_collection_interval": 60,
+            "enhanced_container_insights": true
           }
         },
         "force_flush_interval": 5

--- a/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-daemonset.yaml
+++ b/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-daemonset.yaml
@@ -15,18 +15,18 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
           #    protocol: UDP
           resources:
             limits:
-              cpu:  200m
-              memory: 200Mi
+              cpu:  400m
+              memory: 400Mi
             requests:
-              cpu: 200m
-              memory: 200Mi
+              cpu: 400m
+              memory: 400Mi
           # Please don't change below envs
           env:
             - name: HOST_IP

--- a/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-serviceaccount.yaml
+++ b/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-serviceaccount.yaml
@@ -15,7 +15,7 @@ rules:
     resources: ["pods", "nodes", "endpoints"]
     verbs: ["list", "watch"]
   - apiGroups: ["apps"]
-    resources: ["replicasets"]
+    resources: ["replicasets", "daemonsets", "deployments"]
     verbs: ["list", "watch"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
@@ -30,6 +30,8 @@ rules:
     resources: ["configmaps"]
     resourceNames: ["cwagent-clusterleader"]
     verbs: ["get","update"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get", "list", "watch"]
 
 ---
 kind: ClusterRoleBinding

--- a/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-daemonset.yaml
+++ b/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-daemonset.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           imagePullPolicy: Always
           ports:
             # containerPort should be consistent with the listen port defined in configmap

--- a/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-deployment.yaml
+++ b/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml
@@ -24,7 +24,7 @@ rules:
     resources: ["pods", "nodes", "endpoints"]
     verbs: ["list", "watch"]
   - apiGroups: ["apps"]
-    resources: ["replicasets"]
+    resources: ["replicasets", "daemonsets", "deployments"]
     verbs: ["list", "watch"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
@@ -39,6 +39,8 @@ rules:
     resources: ["configmaps"]
     resourceNames: ["cwagent-clusterleader"]
     verbs: ["get","update"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get", "list", "watch"]
 
 ---
 kind: ClusterRoleBinding
@@ -69,7 +71,8 @@ data:
         "metrics_collected": {
           "kubernetes": {
             "cluster_name": "{{cluster_name}}",
-            "metrics_collection_interval": 60
+            "metrics_collection_interval": 60,
+            "enhanced_container_insights": true
           }
         },
         "force_flush_interval": 5
@@ -99,18 +102,18 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:latest
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
           #    protocol: UDP
           resources:
             limits:
-              cpu:  200m
-              memory: 200Mi
+              cpu:  400m
+              memory: 400Mi
             requests:
-              cpu: 200m
-              memory: 200Mi
+              cpu: 400m
+              memory: 400Mi
           # Please don't change below envs
           env:
             - name: HOST_IP


### PR DESCRIPTION
# Issue 
# Description of changes:

1. update image to the currently released version.  We need to pin and not use the latest because kubernetes will not cache the latest image which results in scale issues in clusters that are creating a lot of pods
2. update samples to enable `enhanced` by default
3. increase mem/cpu limits for enhanced

# Testing
I set up a new cluster using this guide
https://docs.aws.amazon.com/eks/latest/userguide/getting-started-eksctl.html

And I deployed the modified `cwagent-fluent-bit-quickstart.yaml` with this example
https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-EKS-quickstart.html

Data is flowing:
![Screenshot 2023-09-29 at 3 24 49 PM](https://github.com/aws-samples/amazon-cloudwatch-container-insights/assets/5192710/c7a2e13c-cc5e-45c6-9ab2-88662c0a62a5)

Pods are running:
```
➜  amazon-cloudwatch-container-insights git:(enhanced-ci) kubectl get pods --all-namespaces
NAMESPACE           NAME                       READY   STATUS    RESTARTS   AGE
amazon-cloudwatch   cloudwatch-agent-48zg5     1/1     Running   0          4m26s
amazon-cloudwatch   cloudwatch-agent-dzztp     1/1     Running   0          4m26s
amazon-cloudwatch   fluent-bit-bh62k           1/1     Running   0          4m25s
amazon-cloudwatch   fluent-bit-gsvrz           1/1     Running   0          4m25s
```

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
