### PR TITLE
Update agent version to 1.300030.1b305 and add templates for Enhanced Container Insights

### DIFF
--- a/container-insights-manifest-update.sh
+++ b/container-insights-manifest-update.sh
@@ -5,7 +5,7 @@ k8sDirPrefix="./k8s-deployment-manifest-templates/deployment-mode/daemonset/cont
 ecsDirPrefix="./ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric"
 
 newK8sVersion="k8s/1.3.17"
-agentVersion="public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210"
+agentVersion="public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305"
 fluentdVersion="fluent/fluentd-kubernetes-daemonset:v1.10.3-debian-cloudwatch-1.0"
 fluentBitVersion="public.ecr.aws/aws-observability/aws-for-fluent-bit:stable"
 

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json
@@ -105,7 +105,7 @@
         "ContainerDefinitions": [
           {
             "Name": "cloudwatch-agent",
-            "Image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
+            "Image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305",
             "MountPoints": [
               {
                 "ReadOnly": true,

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cwagent-ecs-instance-metric.json
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cwagent-ecs-instance-metric.json
@@ -6,7 +6,7 @@
   "containerDefinitions": [
     {
       "name": "cloudwatch-agent",
-      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
+      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305",
       "mountPoints": [
         {
           "readOnly": true,

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
@@ -224,7 +224,7 @@ Resources:
       NetworkMode: awsvpc
       ContainerDefinitions:
         - Name: cloudwatch-agent-prometheus
-          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
           Essential: true
           MountPoints: []
           PortMappings: []

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
@@ -219,7 +219,7 @@ Resources:
       NetworkMode: !Ref ECSNetworkMode
       ContainerDefinitions:
         - Name: cloudwatch-agent-prometheus
-          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
           Essential: true
           MountPoints: []
           PortMappings: []

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cwagent-prometheus-task-definition.json
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cwagent-prometheus-task-definition.json
@@ -6,7 +6,7 @@
   "containerDefinitions": [
     {
       "name": "cloudwatch-agent-prometheus",
-      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
+      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305",
       "essential": true,
       "mountPoints": [
       ],

--- a/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-ec2.json
@@ -22,7 +22,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-fargate.json
@@ -19,7 +19,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-ec2.json
@@ -22,7 +22,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-fargate.json
@@ -19,7 +19,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-ec2.json
@@ -22,7 +22,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-fargate.json
@@ -19,7 +19,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-ec2.json
@@ -27,7 +27,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-fargate.json
@@ -24,7 +24,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-configmap-enhanced.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-configmap-enhanced.yaml
@@ -1,0 +1,22 @@
+# create configmap for cwagent config
+apiVersion: v1
+data:
+  # Configuration is in Json format. No matter what configure change you make,
+  # please keep the Json blob valid.
+  cwagentconfig.json: |
+    {
+      "logs": {
+        "metrics_collected": {
+          "kubernetes": {
+            "cluster_name": "{{cluster_name}}",
+            "metrics_collection_interval": 60,
+            "enhanced_container_insights": true
+          }
+        },
+        "force_flush_interval": 5
+      }
+    }
+kind: ConfigMap
+metadata:
+  name: cwagentconfig
+  namespace: amazon-cloudwatch

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-serviceaccount.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-serviceaccount.yaml
@@ -15,7 +15,7 @@ rules:
     resources: ["pods", "nodes", "endpoints"]
     verbs: ["list", "watch"]
   - apiGroups: ["apps"]
-    resources: ["replicasets", "daemonsets", "deployments"]
+    resources: ["replicasets", "daemonsets", "deployments", "statefulsets"]
     verbs: ["list", "watch"]
   - apiGroups: ["batch"]
     resources: ["jobs"]

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-enhanced.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-enhanced.yaml
@@ -71,7 +71,8 @@ data:
         "metrics_collected": {
           "kubernetes": {
             "cluster_name": "{{cluster_name}}",
-            "metrics_collection_interval": 60
+            "metrics_collection_interval": 60,
+            "enhanced_container_insights": true
           }
         },
         "force_flush_interval": 5

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart-enhanced.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart-enhanced.yaml
@@ -62,40 +62,26 @@ apiVersion: v1
 data:
   # Configuration is in Json format. No matter what configure change you make,
   # please keep the Json blob valid.
-  # TODO: need to replace the placeholders {{cluster_name}} and {{region_name}}
   cwagentconfig.json: |
     {
       "agent": {
-        "region": "{{region_name}}",
-        "omit_hostname": true
+        "region": "{{region_name}}"
       },
       "logs": {
         "metrics_collected": {
           "kubernetes": {
             "cluster_name": "{{cluster_name}}",
-            "metrics_collection_interval": 60
-          },
-          "emf": {}
+            "metrics_collection_interval": 60,
+            "enhanced_container_insights": true
+          }
         },
         "force_flush_interval": 5
-      },
-      "metrics": {
-        "metrics_collected": {
-          "statsd": {
-            "service_address":":8125"
-          }
-        }
-      },
-      "csm": {
-        "service_addresses": ["udp4://0.0.0.0:31000", "udp6://[::]:31000"],
-        "memory_limit_in_mb": 20
       }
     }
 kind: ConfigMap
 metadata:
   name: cwagentconfig
   namespace: amazon-cloudwatch
-
 ---
 
 # deploy cwagent as daemonset
@@ -116,16 +102,10 @@ spec:
       containers:
         - name: cloudwatch-agent
           image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
-          ports:
-            - containerPort: 8125
-              hostPort: 8125
-              protocol: UDP
-            - containerPort: 25888
-              hostPort: 25888
-              protocol: UDP
-            - containerPort: 31000
-              hostPort: 31000
-              protocol: UDP
+          #ports:
+          #  - containerPort: 8125
+          #    hostPort: 8125
+          #    protocol: UDP
           resources:
             limits:
               cpu:  400m
@@ -147,6 +127,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: CI_VERSION
+              value: "k8s/1.3.17"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig
@@ -169,6 +151,8 @@ spec:
             - name: devdisk
               mountPath: /dev/disk
               readOnly: true
+      nodeSelector:
+        kubernetes.io/os: linux
       volumes:
         - name: cwagentconfig
           configMap:
@@ -197,7 +181,7 @@ spec:
 ---
 
 # create configmap for cluster name and aws region for CloudWatch Logs
-# TODO: need to replace the placeholders {{cluster_name}} and {{region_name}}
+# need to replace the placeholders {{cluster_name}} and {{region_name}}
 apiVersion: v1
 data:
   cluster.name: {{cluster_name}}
@@ -247,6 +231,8 @@ metadata:
   labels:
     k8s-app: fluentd-cloudwatch
 data:
+  kubernetes.conf: |
+    kubernetes.conf
   fluent.conf: |
     @include containers.conf
     @include systemd.conf
@@ -266,8 +252,8 @@ data:
       tag *
       read_from_head true
       <parse>
-        @type json
-        time_format %Y-%m-%dT%H:%M:%S.%NZ
+        @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"
+        time_format %Y-%m-%dT%H:%M:%S.%N%:z
       </parse>
     </source>
 
@@ -384,7 +370,7 @@ data:
       <match **>
         @type cloudwatch_logs
         @id out_cloudwatch_logs_containers
-        region "#{ENV.fetch('REGION')}"
+        region "#{ENV.fetch('AWS_REGION')}"
         log_group_name "/aws/containerinsights/#{ENV.fetch('CLUSTER_NAME')}/application"
         log_stream_name_key stream_name
         remove_log_stream_name_key true
@@ -473,7 +459,7 @@ data:
       <match **>
         @type cloudwatch_logs
         @id out_cloudwatch_logs_systemd
-        region "#{ENV.fetch('REGION')}"
+        region "#{ENV.fetch('AWS_REGION')}"
         log_group_name "/aws/containerinsights/#{ENV.fetch('CLUSTER_NAME')}/dataplane"
         log_stream_name_key stream_name
         auto_create_stream true
@@ -544,7 +530,7 @@ data:
       <match host.**>
         @type cloudwatch_logs
         @id out_cloudwatch_logs_host_logs
-        region "#{ENV.fetch('REGION')}"
+        region "#{ENV.fetch('AWS_REGION')}"
         log_group_name "/aws/containerinsights/#{ENV.fetch('CLUSTER_NAME')}/host"
         log_stream_name_key stream_name
         remove_log_stream_name_key true
@@ -593,9 +579,9 @@ spec:
           command: ['sh','-c','']
       containers:
         - name: fluentd-cloudwatch
-          image: fluent/fluentd-kubernetes-daemonset:v1.7.3-debian-cloudwatch-1.0
+          image: fluent/fluentd-kubernetes-daemonset:v1.10.3-debian-cloudwatch-1.0
           env:
-            - name: REGION
+            - name: AWS_REGION
               valueFrom:
                 configMapKeyRef:
                   name: cluster-info
@@ -605,6 +591,10 @@ spec:
                 configMapKeyRef:
                   name: cluster-info
                   key: cluster.name
+            - name: CI_VERSION
+              value: "k8s/1.3.17"
+            - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
+              value: /^(?<time>.+) (?<stream>stdout|stderr) (?<logtag>[FP]) (?<log>.*)$/
           resources:
             limits:
               memory: 400Mi
@@ -616,6 +606,9 @@ spec:
               mountPath: /config-volume
             - name: fluentdconf
               mountPath: /fluentd/etc
+            - name: fluentd-config
+              mountPath: /fluentd/etc/kubernetes.conf
+              subPath: kubernetes.conf
             - name: varlog
               mountPath: /var/log
             - name: varlibdockercontainers
@@ -633,6 +626,12 @@ spec:
             name: fluentd-config
         - name: fluentdconf
           emptyDir: {}
+        - name: fluentd-config
+          configMap:
+            name: fluentd-config
+            items:
+            - key: kubernetes.conf
+              path: kubernetes.conf
         - name: varlog
           hostPath:
             path: /var/log
@@ -645,68 +644,3 @@ spec:
         - name: dmesg
           hostPath:
             path: /var/log/dmesg
-
----
-# create role binding for XRay SDK to read config map
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: container-insights-discovery-role
-  namespace: amazon-cloudwatch
-rules:
-  - apiGroups:
-      - ""
-    resourceNames:
-      - cluster-info
-    resources:
-      - configmaps
-    verbs:
-      - get
-
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: service-users-cloudwatch-discovery-role-binding
-  namespace: amazon-cloudwatch
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: container-insights-discovery-role
-subjects:
-  - apiGroup: rbac.authorization.k8s.io
-    kind: Group
-    name: system:serviceaccounts
-
----
-# Deploy XRay daemon as daemon set
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: xray-daemon
-  namespace: amazon-cloudwatch
-spec:
-  selector:
-    matchLabels:
-      name: xray-daemon
-  template:
-    metadata:
-      labels:
-        name: xray-daemon
-    spec:
-      containers:
-        - name: xray-daemon
-          image: public.ecr.aws/xray/aws-xray-daemon:latest
-          imagePullPolicy: Always
-          ports:
-            - containerPort: 2000
-              hostPort: 2000
-              protocol: UDP
-          resources:
-            limits:
-              cpu:  100m
-              memory: 256Mi
-            requests:
-              cpu: 50m
-              memory: 50Mi
-      terminationGracePeriodSeconds: 60

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
@@ -24,7 +24,7 @@ rules:
     resources: ["pods", "nodes", "endpoints"]
     verbs: ["list", "watch"]
   - apiGroups: ["apps"]
-    resources: ["replicasets", "daemonsets", "deployments"]
+    resources: ["replicasets", "daemonsets", "deployments", "statefulsets"]
     verbs: ["list", "watch"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
@@ -100,7 +100,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-fluentd-xray/cwagent-fluentd-xray-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-fluentd-xray/cwagent-fluentd-xray-quickstart.yaml
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
           ports:
             - containerPort: 25888
               hostPort: 25888

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
           imagePullPolicy: Always
           ports:
             - containerPort: 31000

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-statsd/cwagent-statsd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-statsd/cwagent-statsd.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
           imagePullPolicy: Always
           ports:
             # containerPort should be consistent with the listen port defined in configmap

--- a/k8s-deployment-manifest-templates/deployment-mode/service/combination/combination.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/combination/combination.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-fargate.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-fargate.yaml
@@ -398,7 +398,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
@@ -449,7 +449,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-k8s.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-k8s.yaml
@@ -396,7 +396,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
@@ -40,7 +40,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-statsd/cwagent-statsd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-statsd/cwagent-statsd.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/combination/combination.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/combination/combination.yaml
@@ -24,7 +24,7 @@ spec:
           - name: AWS_CSM_HOST
             value: "127.0.0.1"
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf.yaml
@@ -17,7 +17,7 @@ spec:
           image: <demo-app-docker-image> # this is the your demo app docker image
           imagePullPolicy: Always
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
@@ -42,7 +42,7 @@ spec:
     - name: AWS_CSM_HOST
       value: "127.0.0.1"
   - name: cloudwatch-agent
-    image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+    image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
     imagePullPolicy: Always
     resources:
       limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd.yaml
@@ -19,7 +19,7 @@ spec:
           args: ["-c", "while true; do echo 'statsdTestMetric:1|c' | socat -v -t 0 - UDP:127.0.0.1:8125; sleep 1; done"]
           imagePullPolicy: Always
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-daemonset.yaml
+++ b/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-daemonset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125

--- a/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-serviceaccount.yaml
+++ b/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-serviceaccount.yaml
@@ -15,7 +15,7 @@ rules:
     resources: ["pods", "nodes", "endpoints"]
     verbs: ["list", "watch"]
   - apiGroups: ["apps"]
-    resources: ["replicasets", "daemonsets", "deployments"]
+    resources: ["replicasets", "daemonsets", "deployments", "statefulsets"]
     verbs: ["list", "watch"]
   - apiGroups: ["batch"]
     resources: ["jobs"]

--- a/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-daemonset.yaml
+++ b/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-daemonset.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
           imagePullPolicy: Always
           ports:
             # containerPort should be consistent with the listen port defined in configmap

--- a/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-deployment.yaml
+++ b/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml
@@ -24,7 +24,7 @@ rules:
     resources: ["pods", "nodes", "endpoints"]
     verbs: ["list", "watch"]
   - apiGroups: ["apps"]
-    resources: ["replicasets", "daemonsets", "deployments"]
+    resources: ["replicasets", "daemonsets", "deployments", "statefulsets"]
     verbs: ["list", "watch"]
   - apiGroups: ["batch"]
     resources: ["jobs"]
@@ -101,7 +101,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300028.1b210
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300030.1b305
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125


### PR DESCRIPTION
# Description of changes:
* Update CloudWatchAgent image to 1.300030.1b305
* Add templates for Enhanced Container Insights

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
