### PR TITLE
Remove Mem_Buf_Limit when storage.type filesystem is enabled

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
@@ -70,7 +70,6 @@ data:
         Path                /var/log/containers/*.log
         multiline.parser    docker, cri
         DB                  /var/fluent-bit/state/flb_container.db
-        Mem_Buf_Limit       50MB
         Skip_Long_Lines     On
         Refresh_Interval    10
         Rotate_Wait         30
@@ -140,7 +139,6 @@ data:
         Path                /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
         multiline.parser    docker, cri
         DB                  /var/fluent-bit/state/flb_dataplane_tail.db
-        Mem_Buf_Limit       50MB
         Skip_Long_Lines     On
         Refresh_Interval    10
         Rotate_Wait         30


### PR DESCRIPTION
# Issue 

As mentioned in the fluent bit documents,

> Please note that Mem_Buf_Limit only applies when storage.type is set to the default value of memory. The section below explains the limits that apply when you enable storage.type filesystem.

https://docs.fluentbit.io/manual/administration/buffering-and-storage#buffering-and-memory

# Description of changes:

Removed Mem_Buf_Limit when storage.type filesystem is enabled

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
