### PR TITLE
Update manifest update script to include Windows

### DIFF
--- a/container-insights-manifest-update.sh
+++ b/container-insights-manifest-update.sh
@@ -9,6 +9,7 @@ newK8sVersion="k8s/1.3.23"
 agentVersion="public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300039.0b612"
 fluentdVersion="fluent/fluentd-kubernetes-daemonset:v1.10.3-debian-cloudwatch-1.0"
 fluentBitVersion="public.ecr.aws/aws-observability/aws-for-fluent-bit:stable"
+fluentBitWindowsVersion="public.ecr.aws/aws-observability/aws-for-fluent-bit:windowsservercore-stable"
 
 k8sPrometheusDirPrefix="./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus"
 ecsPrometheusDirPrefix="./ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus"
@@ -41,6 +42,9 @@ rm ${ecsDirPrefix}/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.jso
 sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${k8sDirPrefix}/cwagent/cwagent-daemonset.yaml
 rm ${k8sDirPrefix}/cwagent/cwagent-daemonset.yaml.bak
 
+sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${k8sDirPrefix}/cwagent/cwagent-daemonset-windows.yaml
+rm ${k8sDirPrefix}/cwagent/cwagent-daemonset-windows.yaml.bak
+
 sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${k8sQSDirPrefix}/cwagent-operator-rendered.yaml
 rm ${k8sQSDirPrefix}/cwagent-operator-rendered.yaml.bak
 
@@ -53,12 +57,16 @@ rm ${k8sDirPrefix}/fluentd/fluentd.yaml.bak
 sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public\.ecr\.aws/aws-observability/aws-for-fluent-bit.*|${fluentBitVersion}|g" ${k8sDirPrefix}/fluent-bit/fluent-bit.yaml
 rm ${k8sDirPrefix}/fluent-bit/fluent-bit.yaml.bak
 
+sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public\.ecr\.aws/aws-observability/aws-for-fluent-bit.*|${fluentBitWindowsVersion}|g" ${k8sDirPrefix}/fluent-bit/fluent-bit-windows.yaml
+rm ${k8sDirPrefix}/fluent-bit/fluent-bit-windows.yaml.bak
+
 sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public\.ecr\.aws/aws-observability/aws-for-fluent-bit.*|${fluentBitVersion}|g" ${k8sDirPrefix}/fluent-bit/fluent-bit-compatible.yaml
 rm ${k8sDirPrefix}/fluent-bit/fluent-bit-compatible.yaml.bak
 
 # generate quickstart manifest for K8s
 OUTPUT=${k8sDirPrefix}/quickstart/cwagent-fluentd-quickstart.yaml
 OUTPUT_FLUENT_BIT=${k8sDirPrefix}/quickstart/cwagent-fluent-bit-quickstart.yaml
+OUTPUT_FLUENT_BIT_WINDOWS=${k8sDirPrefix}/quickstart/cwagent-fluent-bit-quickstart-windows.yaml
 
 cat ${k8sDirPrefix}/cloudwatch-namespace.yaml > ${OUTPUT}
 echo -e "\n---\n" >> ${OUTPUT}
@@ -90,3 +98,7 @@ echo -e "\n---\n" >> ${OUTPUT_FLUENT_BIT}
 cat ${k8sDirPrefix}/fluent-bit/fluent-bit-configmap.yaml >> ${OUTPUT_FLUENT_BIT}
 echo -e "\n---\n" >> ${OUTPUT_FLUENT_BIT}
 cat ${k8sDirPrefix}/fluent-bit/fluent-bit.yaml >> ${OUTPUT_FLUENT_BIT}
+
+cat ${k8sDirPrefix}/cwagent/cwagent-daemonset-windows.yaml > ${OUTPUT_FLUENT_BIT_WINDOWS}
+echo -e "\n---\n" >> ${OUTPUT_FLUENT_BIT_WINDOWS}
+cat ${k8sDirPrefix}/fluent-bit/fluent-bit-windows.yaml >> ${OUTPUT_FLUENT_BIT_WINDOWS}

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset-windows.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset-windows.yaml
@@ -21,6 +21,7 @@ spec:
       containers:
       - name: cloudwatch-agent
         image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300036.0b573
+        workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
         volumeMounts:
         - name: cwagentconfig
           mountPath: C:\Program Files\Amazon\AmazonCloudWatchAgent\cwagentconfig

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-windows.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-windows.yaml
@@ -21,6 +21,7 @@ spec:
       containers:
       - name: cloudwatch-agent
         image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300036.0b573
+        workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
         volumeMounts:
         - name: cwagentconfig
           mountPath: C:\Program Files\Amazon\AmazonCloudWatchAgent\cwagentconfig


### PR DESCRIPTION
1. Update script to include Windows
2. Update CW agent daemonset yaml to include recent change in helm charts

# Description of the issue
Manifest udpate script doesn't update Windows daemonset yamls during new releases.

# Description of changes
1. This change update manifest update script to include windows daemonset.
2. Windows daemonset are updated to include workDir change similar to change in [helm charts](https://github.com/aws-observability/helm-charts/pull/26/files).

# License
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._

# Tests
1. Ran script locally to update daemonset yamls and it works as expected. 
<img width="1337" alt="Screenshot 2024-05-22 at 12 34 31 PM" src="https://github.com/aws-samples/amazon-cloudwatch-container-insights/assets/10296556/93bdeccb-5ad7-4e2f-b6d2-c1dfef54e318">
2. Windows daemonset update with `workDir` field was tested during helm chart change
https://github.com/aws-observability/helm-charts/actions/runs/8816835391

# Requirements
_Before committing the code, please verify the following:_

- If this commit includes changes to existing sample configurations, you acknowledge that you have confirmed this will not impact existing customer behavior.
- If not necessary, consider creating a new sample configuration for this change.

