### PR TITLE
Release agent version 1.300041.0b681

### DIFF
--- a/container-insights-manifest-update.sh
+++ b/container-insights-manifest-update.sh
@@ -5,8 +5,8 @@ k8sDirPrefix="./k8s-deployment-manifest-templates/deployment-mode/daemonset/cont
 k8sQSDirPrefix="./k8s-quickstart"
 ecsDirPrefix="./ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric"
 
-newK8sVersion="k8s/1.3.24"
-agentVersion="public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300040.0b650"
+newK8sVersion="k8s/1.3.25"
+agentVersion="public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300041.0b681"
 fluentdVersion="fluent/fluentd-kubernetes-daemonset:v1.10.3-debian-cloudwatch-1.0"
 fluentBitVersion="public.ecr.aws/aws-observability/aws-for-fluent-bit:stable"
 fluentBitWindowsVersion="public.ecr.aws/aws-observability/aws-for-fluent-bit:windowsservercore-stable"

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json
@@ -105,7 +105,7 @@
         "ContainerDefinitions": [
           {
             "Name": "cloudwatch-agent",
-            "Image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300040.0b650",
+            "Image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300041.0b681",
             "MountPoints": [
               {
                 "ReadOnly": true,

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cwagent-ecs-instance-metric.json
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cwagent-ecs-instance-metric.json
@@ -6,7 +6,7 @@
   "containerDefinitions": [
     {
       "name": "cloudwatch-agent",
-      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300040.0b650",
+      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300041.0b681",
       "mountPoints": [
         {
           "readOnly": true,

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
@@ -224,7 +224,7 @@ Resources:
       NetworkMode: awsvpc
       ContainerDefinitions:
         - Name: cloudwatch-agent-prometheus
-          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300040.0b650
+          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300041.0b681
           Essential: true
           MountPoints: []
           PortMappings: []

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
@@ -219,7 +219,7 @@ Resources:
       NetworkMode: !Ref ECSNetworkMode
       ContainerDefinitions:
         - Name: cloudwatch-agent-prometheus
-          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300040.0b650
+          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300041.0b681
           Essential: true
           MountPoints: []
           PortMappings: []

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cwagent-prometheus-task-definition.json
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cwagent-prometheus-task-definition.json
@@ -6,7 +6,7 @@
   "containerDefinitions": [
     {
       "name": "cloudwatch-agent-prometheus",
-      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300040.0b650",
+      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300041.0b681",
       "essential": true,
       "mountPoints": [
       ],

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset-windows.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset-windows.yaml
@@ -20,7 +20,7 @@ spec:
       hostNetwork: true
       containers:
       - name: cloudwatch-agent
-        image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300040.0b650
+        image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300041.0b681
         workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
         volumeMounts:
         - name: cwagentconfig
@@ -47,7 +47,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: CI_VERSION
-            value: "k8s/1.3.24"
+            value: "k8s/1.3.25"
           - name: CWAGENT_LOG_LEVEL
             value: DEBUG
           - name: RUN_IN_CONTAINER

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300040.0b650
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300041.0b681
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -42,7 +42,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.24"
+              value: "k8s/1.3.25"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
@@ -320,7 +320,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: CI_VERSION
-              value: "k8s/1.3.24"
+              value: "k8s/1.3.25"
         resources:
             limits:
               memory: 200Mi

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-windows.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-windows.yaml
@@ -205,7 +205,7 @@ spec:
               apiVersion: v1
               fieldPath: metadata.name
         - name: CI_VERSION
-          value: "k8s/1.3.24"
+          value: "k8s/1.3.25"
         resources:
             limits:
               cpu: 500m

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
@@ -304,7 +304,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.name
             - name: CI_VERSION
-              value: "k8s/1.3.24"
+              value: "k8s/1.3.25"
         resources:
             limits:
               memory: 200Mi

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
@@ -398,7 +398,7 @@ spec:
                   name: cluster-info
                   key: cluster.name
             - name: CI_VERSION
-              value: "k8s/1.3.24"
+              value: "k8s/1.3.25"
             - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
               value: /^(?<time>.+) (?<stream>stdout|stderr) (?<logtag>[FP]) (?<log>.*)$/
           resources:

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-windows.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-windows.yaml
@@ -20,7 +20,7 @@ spec:
       hostNetwork: true
       containers:
       - name: cloudwatch-agent
-        image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300040.0b650
+        image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300041.0b681
         workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
         volumeMounts:
         - name: cwagentconfig
@@ -47,7 +47,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: CI_VERSION
-            value: "k8s/1.3.24"
+            value: "k8s/1.3.25"
           - name: CWAGENT_LOG_LEVEL
             value: DEBUG
           - name: RUN_IN_CONTAINER
@@ -271,7 +271,7 @@ spec:
               apiVersion: v1
               fieldPath: metadata.name
         - name: CI_VERSION
-          value: "k8s/1.3.24"
+          value: "k8s/1.3.25"
         resources:
             limits:
               cpu: 500m

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
@@ -103,7 +103,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300040.0b650
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300041.0b681
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -130,7 +130,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.24"
+              value: "k8s/1.3.25"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig
@@ -506,7 +506,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.name
             - name: CI_VERSION
-              value: "k8s/1.3.24"
+              value: "k8s/1.3.25"
         resources:
             limits:
               memory: 200Mi

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
@@ -103,7 +103,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300040.0b650
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300041.0b681
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -130,7 +130,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.24"
+              value: "k8s/1.3.25"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig
@@ -594,7 +594,7 @@ spec:
                   name: cluster-info
                   key: cluster.name
             - name: CI_VERSION
-              value: "k8s/1.3.24"
+              value: "k8s/1.3.25"
             - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
               value: /^(?<time>.+) (?<stream>stdout|stderr) (?<logtag>[FP]) (?<log>.*)$/
           resources:

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-fargate.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-fargate.yaml
@@ -398,7 +398,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300040.0b650
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300041.0b681
           imagePullPolicy: Always
           resources:
             limits:
@@ -410,7 +410,7 @@ spec:
           # Please don't change below envs
           env:
             - name: CI_VERSION
-              value: "k8s/1.3.24"
+              value: "k8s/1.3.25"
             - name: RUN_IN_AWS
               value: "True"
           # Please don't change the mountPath

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
@@ -449,7 +449,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300040.0b650
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300041.0b681
           imagePullPolicy: Always
           resources:
             limits:
@@ -461,7 +461,7 @@ spec:
           # Please don't change below envs
           env:
             - name: CI_VERSION
-              value: "k8s/1.3.24"
+              value: "k8s/1.3.25"
           # Please don't change the mountPath
           volumeMounts:
             - name: prometheus-cwagentconfig

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-k8s.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-k8s.yaml
@@ -396,7 +396,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300040.0b650
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300041.0b681
           imagePullPolicy: Always
           resources:
             limits:
@@ -408,7 +408,7 @@ spec:
           # Please don't change below envs
           env:
             - name: CI_VERSION
-              value: "k8s/1.3.24"
+              value: "k8s/1.3.25"
           # Please don't change the mountPath
           volumeMounts:
             - name: prometheus-cwagentconfig

--- a/k8s-quickstart/cwagent-operator-rendered.yaml
+++ b/k8s-quickstart/cwagent-operator-rendered.yaml
@@ -649,7 +649,7 @@ spec:
               apiVersion: v1
               fieldPath: metadata.name
         - name: CI_VERSION
-          value: "k8s/1.3.24"
+          value: "k8s/1.3.25"
         resources:
           limits:
             cpu: 500m
@@ -754,7 +754,7 @@ spec:
               apiVersion: v1
               fieldPath: metadata.name
         - name: CI_VERSION
-          value: "k8s/1.3.24"
+          value: "k8s/1.3.25"
         resources:
           limits:
             cpu: 500m
@@ -839,7 +839,7 @@ metadata:
   name: cloudwatch-agent
   namespace: amazon-cloudwatch
 spec:
-  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300040.0b650
+  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300041.0b681
   mode: daemonset
   nodeSelector:
     kubernetes.io/os: linux
@@ -934,7 +934,7 @@ spec:
       hostProcess: true
       runAsUserName: "NT AUTHORITY\\System"
   hostNetwork: true
-  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300040.0b650
+  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300041.0b681
   mode: daemonset
   serviceAccount: cloudwatch-agent
   nodeSelector:

--- a/k8s-quickstart/cwagent-version.yaml
+++ b/k8s-quickstart/cwagent-version.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cloudwatch-agent
   namespace: amazon-cloudwatch
 spec:
-  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300040.0b650
+  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300041.0b681
   mode: daemonset
   nodeSelector:
     kubernetes.io/os: linux


### PR DESCRIPTION
# Description of the issue
Update container insights scripts with new version of the cloudwatch agent: 1.300041.0b681

# Description of changes
Updated ./container-insights-manifest-update.sh with the following values:
```
newK8sVersion="k8s/1.3.25"
agentVersion="public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300041.0b681"
```
Then ran the script

# License
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._

# Tests
_Describe what tests you have done._

# Requirements
_Before committing the code, please verify the following:_

- If this commit includes changes to existing sample configurations, you acknowledge that you have confirmed this will not impact existing customer behavior.
- If not necessary, consider creating a new sample configuration for this change.

