### PR TITLE
Enhance ECS Container Insights by enabling host logs to be sent to CloudWatch

### DIFF
--- a/ecs-task-definition-templates/deployment-mode/daemon-service/README.md
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/README.md
@@ -6,3 +6,9 @@ Check the sub folders for different functionality:
 
 ### [cwagent-ecs-instance-metric](cwagent-ecs-instance-metric)
 This folder provides the functionality that enables you to deploy the CloudWatch Agent to collect ECS Instance Metrics.
+
+### [fluent-bit-ecs-instance-logs]( fluent-bit-ecs-instance-logs)
+This folder provides the functionality that enables you to deploy Fluent-Bit to collect ECS Container Instance.
+
+### [fluent-bit-cwagent-combined-cfn]( fluent-bit-cwagent-combined-cfn)
+This folder provides the functionality that enables you to deploy both the CloudWatch Agent and Fluent-Bit in a single CloudFormation stack.

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/fluent-bit-cwagent-combined-cfn/README.md
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/fluent-bit-cwagent-combined-cfn/README.md
@@ -1,0 +1,19 @@
+## CloudWatch Agent and Fluent-Bit for ECS Instance Metrics and Logs Collection Quick Start
+
+The cloudformation template in this folder helps you to quickly deploy both the CloudWatch agent and Fluent-Bit as daemon-services using a single CloudFormation stack to collect ECS Container Instance Metrics and Logs.
+
+* [fluent-bit-cwagent-combined-cfn.yaml](fluent-bit-cwagent-combined-cfn.yaml): sample cloudformation template
+
+
+Run following aws cloudformation command with the cloudformation template file to deploy the Fluent-Bit and CloudWatch agent Daemonsets with required IAM roles. ***Please assign the actual ECS cluster name and the cluster region in the first two lines of the command separately.***
+
+```
+ClusterName=<your-ecs-cluster-name>
+Region=<your-ecs-cluster-region>
+aws cloudformation create-stack --stack-name Fluent-Bit-${ClusterName}-${Region} \
+    --template-body file://fluent-bit-cwagent-combined-cfn.yaml \
+    --parameters ParameterKey=ClusterName,ParameterValue=${ClusterName} \
+                 ParameterKey=CreateIAMRoles,ParameterValue=True \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --region ${Region}
+```

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/fluent-bit-cwagent-combined-cfn/fluent-bit-cwagent-combined-cfn.yaml
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/fluent-bit-cwagent-combined-cfn/fluent-bit-cwagent-combined-cfn.yaml
@@ -1,0 +1,448 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  ClusterName:
+    Type: String
+    Description: Enter the name of your ECS cluster from which you want to collect metrics and/or logs
+  CreateIAMRoles:
+    Type: String
+    Default: 'False'
+    AllowedValues:
+      - 'True'
+      - 'False'
+    Description: Whether to create default IAM roles
+    ConstraintDescription: must specify True or False.
+  CWAgentTaskRoleArn:
+    Type: String
+    Default: Default
+    Description: Enter the role arn you want to use for the CloudWatch Agent ecs task role
+  CWAgentExecutionRoleArn:
+    Type: String
+    Default: Default
+    Description: Enter the role arn you want to use for the CloudWatch Agent execution role
+  FluentBitTaskRoleArn:
+    Type: String
+    Default: Default
+    Description: Enter the role arn you want to use for the CloudWatch Agent ecs task role
+  FluentBitExecutionRoleArn:
+    Type: String
+    Default: Default
+    Description: Enter the role arn you want to use for the CloudWatch Agent execution role
+Conditions:
+  CreateRoles: !Equals
+    - !Ref CreateIAMRoles
+    - 'True'
+  DefaultCWAgentTaskRole: !Equals
+    - !Ref CWAgentTaskRoleArn
+    - Default
+  DefaultCWAgentExecutionRole: !Equals
+    - !Ref CWAgentExecutionRoleArn
+    - Default
+  DefaultFluentBitTaskRole: !Equals
+    - !Ref FluentBitTaskRoleArn
+    - Default
+  DefaultFluentBitExecutionRole: !Equals
+    - !Ref FluentBitExecutionRoleArn
+    - Default
+Resources:
+  CWAgentECSTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      TaskRoleArn: !If
+        - CreateRoles
+        - !GetAtt CWAgentECSTaskRole.Arn
+        - !If
+          - DefaultCWAgentTaskRole
+          - !Sub arn:aws:iam::${AWS::AccountId}:role/CWAgentECSTaskRole
+          - !Ref CWAgentTaskRoleArn
+      ExecutionRoleArn: !If
+        - CreateRoles
+        - !GetAtt CWAgentECSExecutionRole.Arn
+        - !If
+          - DefaultCWAgentExecutionRole
+          - !Sub arn:aws:iam::${AWS::AccountId}:role/CWAgentECSExecutionRole
+          - !Ref CWAgentExecutionRoleArn
+      NetworkMode: bridge
+      ContainerDefinitions:
+        - Name: cloudwatch-agent
+          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300042.1b746
+          MountPoints:
+            - ReadOnly: true
+              ContainerPath: /rootfs/proc
+              SourceVolume: proc
+            - ReadOnly: true
+              ContainerPath: /rootfs/dev
+              SourceVolume: dev
+            - ReadOnly: true
+              ContainerPath: /sys/fs/cgroup
+              SourceVolume: al2_cgroup
+            - ReadOnly: true
+              ContainerPath: /cgroup
+              SourceVolume: al1_cgroup
+            - ReadOnly: true
+              ContainerPath: /rootfs/sys/fs/cgroup
+              SourceVolume: al2_cgroup
+            - ReadOnly: true
+              ContainerPath: /rootfs/cgroup
+              SourceVolume: al1_cgroup
+          Environment:
+            - Name: USE_DEFAULT_CONFIG
+              Value: 'True'
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-create-group: 'True'
+              awslogs-group: /ecs/ecs-cwagent-daemon-service
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: ecs
+      RequiresCompatibilities:
+        - EC2
+      Volumes:
+        - Name: proc
+          Host:
+            SourcePath: /proc
+        - Name: dev
+          Host:
+            SourcePath: /dev
+        - Name: al1_cgroup
+          Host:
+            SourcePath: /cgroup
+        - Name: al2_cgroup
+          Host:
+            SourcePath: /sys/fs/cgroup
+      Cpu: '128'
+      Memory: '64'
+  CWAgentECSDaemonService:
+    Type: AWS::ECS::Service
+    Properties:
+      TaskDefinition: !Ref CWAgentECSTaskDefinition
+      Cluster: !Ref ClusterName
+      LaunchType: EC2
+      SchedulingStrategy: DAEMON
+      ServiceName: cwagent-daemon-service
+  CWAgentECSTaskRole:
+    Type: AWS::IAM::Role
+    Condition: CreateRoles
+    Properties:
+      Description: Allows ECS tasks to call AWS services on your behalf.
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: ''
+            Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+      RoleName: CWAgentECSTaskRole
+  CWAgentECSExecutionRole:
+    Type: AWS::IAM::Role
+    Condition: CreateRoles
+    Properties:
+      Description: Allows ECS container agent makes calls to the Amazon ECS API on your behalf.
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: ''
+            Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      RoleName: CWAgentECSExecutionRole
+  FluentBitTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      TaskRoleArn: !If
+        - CreateRoles
+        - !GetAtt FluentBitTaskRole.Arn
+        - !If
+          - DefaultFluentBitTaskRole
+          - !Sub arn:aws:iam::${AWS::AccountId}:role/FluentBitECSTaskRole
+          - !Ref FluentBitTaskRoleArn
+      ExecutionRoleArn: !If
+        - CreateRoles
+        - !GetAtt FluentBitExecutionRole.Arn
+        - !If
+          - DefaultFluentBitExecutionRole
+          - !Sub arn:aws:iam::${AWS::AccountId}:role/FluentBitECSExecutionRole
+          - !Ref FluentBitExecutionRoleArn
+      NetworkMode: bridge
+      ContainerDefinitions:
+        - Name: fluent-bit
+          Image: fluent/fluent-bit:3.1.4
+          MountPoints:
+            - ContainerPath: /fluent-bit/etc/
+              SourceVolume: fluent-bit-config
+            - ContainerPath: /var/fluent-bit/state
+              SourceVolume: fluent-bit-state
+            - ReadOnly: true
+              ContainerPath: /var/log
+              SourceVolume: instance-logs
+            - ReadOnly: true
+              ContainerPath: /run/log/journal
+              SourceVolume: systemd-journal
+            - ReadOnly: true
+              ContainerPath: /etc/machine-id
+              SourceVolume: machine-id
+          Environment:
+            - Name: AWS_REGION
+              Value: !Ref AWS::Region
+            - Name: CLUSTER_NAME
+              Value: !Ref ClusterName
+          DependsOn:
+            - ContainerName: fluent-bit-config-init
+              Condition: COMPLETE
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-create-group: 'True'
+              awslogs-group: /ecs/ecs-fluent-bit-daemon-service
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: ecs
+        - Name: fluent-bit-config-init
+          Image: amazon/aws-cli:2.17.24
+          Essential: False
+          EntryPoint:
+            - '/bin/sh'
+            - '-c'
+          Command:
+            - |
+              set -ex && if [ -z $( ls -A '/run/log/journal' ) ]; then echo @SET SYSTEMD_PATH=/var/log/journal >> /fluent-bit/etc/fluent-bit.conf; else echo @SET SYSTEMD_PATH=/run/log/journal >> /fluent-bit/etc/fluent-bit.conf; fi && echo @SET INSTANCE_ID=$(cat /var/lib/cloud/data/instance-id) >> /fluent-bit/etc/fluent-bit.conf && aws ssm get-parameter --name $FB_CONFIG_SSM_PARAM --query Parameter.Value --output text >> /fluent-bit/etc/fluent-bit.conf && aws ssm get-parameter --name $FB_PARSER_SSM_PARAM --query Parameter.Value --output text >> /fluent-bit/etc/parsers.conf && cat /fluent-bit/etc/fluent-bit.conf
+          Environment:
+            - Name: FB_CONFIG_SSM_PARAM
+              Value: !Ref FluentBitConfigParam
+            - Name: FB_PARSER_SSM_PARAM
+              Value: !Ref FluentBitParserParam
+          MountPoints:
+            - ContainerPath: /fluent-bit/etc/
+              SourceVolume: fluent-bit-config
+            - ReadOnly: true
+              ContainerPath: /var/lib/cloud/data/instance-id
+              SourceVolume: instance-id
+            - ReadOnly: true
+              ContainerPath: /run/log/journal
+              SourceVolume: systemd-journal
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-create-group: 'True'
+              awslogs-group: /ecs/ecs-fluent-bit-daemon-service
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: ecs
+      RequiresCompatibilities:
+        - EC2
+      Volumes:
+        - Name: fluent-bit-config
+          DockerVolumeConfiguration:
+            Scope: 'task'
+        - Name: instance-id
+          Host:
+            SourcePath: /var/lib/cloud/data/instance-id
+        - Name: fluent-bit-state
+          Host:
+            SourcePath: /var/fluent-bit/state
+        - Name: instance-logs
+          Host:
+            SourcePath: /var/log
+        - Name: systemd-journal
+          Host:
+            SourcePath: /run/log/journal
+        - Name: machine-id
+          Host:
+            SourcePath: /etc/machine-id
+      Cpu: '512'
+      Memory: '256'
+  FluentBitECSDaemonService:
+    Type: AWS::ECS::Service
+    Properties:
+      TaskDefinition: !Ref FluentBitTaskDefinition
+      Cluster: !Ref ClusterName
+      LaunchType: EC2
+      SchedulingStrategy: DAEMON
+      ServiceName: fluent-bit-daemon-service
+  FluentBitTaskRole:
+    Type: AWS::IAM::Role
+    Condition: CreateRoles
+    Properties:
+      Description: Allows ECS tasks to call AWS services on your behalf.
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: ''
+            Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: fluent-bit-task-role-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+                - Sid: FluentBitLogs
+                  Effect: Allow
+                  Action:
+                    - 'logs:CreateLogStream'
+                    - 'logs:CreateLogGroup'
+                    - 'logs:PutLogEvents'
+                  Resource: '*'
+                - Sid: FluentBitSSMParameterAccess
+                  Effect: Allow
+                  Action:
+                    - 'ssm:GetParameters'
+                    - 'ssm:GetParameter'
+                  Resource: 
+                    - !Sub
+                      - 'arn:${Partition}:ssm:${Region}:${AccountID}:parameter/*'
+                      - Partition: !Ref AWS::Partition
+                        Region: !Ref AWS::Region
+                        AccountID: !Ref AWS::AccountId
+      RoleName: FluentBitECSTaskRole
+  FluentBitExecutionRole:
+    Type: AWS::IAM::Role
+    Condition: CreateRoles
+    Properties:
+      Description: Allows ECS container agent makes calls to the Amazon ECS API on your behalf.
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: ''
+            Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      RoleName: FluentBitECSExecutionRole
+  FluentBitConfigParam:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Join
+        - '-'
+        - - 'fluent-bit-config'
+          - !Ref ClusterName
+      Type: String
+      Value: |
+        [SERVICE]
+            Flush                     5
+            Grace                     30
+            Log_Level                 error
+            Daemon                    off
+            Parsers_File              parsers.conf
+            storage.path              /var/fluent-bit/state/flb-storage/
+            storage.sync              normal
+            storage.checksum          off
+            storage.backlog.mem_limit 5M
+
+        [INPUT]
+            Name                systemd
+            Tag                 systemd-*
+            Systemd_Filter      _SYSTEMD_UNIT=docker.service
+            Systemd_Filter      _SYSTEMD_UNIT=containerd.service
+            DB                  /var/fluent-bit/state/systemd.db
+            Path                ${SYSTEMD_PATH}
+
+        [INPUT]
+            Name                systemd
+            Tag                 systemd-syslog
+            DB                  /var/fluent-bit/state/systemd-syslog.db
+            Path                ${SYSTEMD_PATH}
+            
+        [INPUT]
+            Name                systemd
+            Tag                 systemd-dmesg.*
+            Systemd_Filter      _TRANSPORT=kernel
+            DB                  /var/fluent-bit/state/dmesg.db
+            Path                ${SYSTEMD_PATH}
+
+        [INPUT]
+            Name                tail
+            Tag                 secure
+            Path                /var/log/secure
+            Parser              syslog
+            DB                  /var/fluent-bit/state/flb_secure.db
+            Mem_Buf_Limit       5MB
+            Skip_Long_Lines     On
+            Refresh_Interval    10
+            Read_from_Head      On
+
+        [INPUT]
+            Name                tail
+            Tag                 ecs-agent.log
+            Path                /var/log/ecs/ecs-agent.log
+            DB                  /var/fluent-bit/state/flb_ecs_agent.db
+            Mem_Buf_Limit       5MB
+            Skip_Long_Lines     On
+            Refresh_Interval    10
+            Read_from_Head      On
+
+        [INPUT]
+            Name                tail
+            Tag                 ecs-init.log
+            Path                /var/log/ecs/ecs-init.log
+            DB                  /var/fluent-bit/state/flb_ecs_init.db
+            Mem_Buf_Limit       5MB
+            Skip_Long_Lines     On
+            Refresh_Interval    10
+            Read_from_Head      On
+
+        [INPUT]
+            Name                tail
+            Tag                 ecs-audit.log
+            Path                /var/log/ecs/audit.log
+            DB                  /var/fluent-bit/state/flb_ecs_audit.db
+            Mem_Buf_Limit       5MB
+            Skip_Long_Lines     On
+            Refresh_Interval    10
+            Read_from_Head      On
+
+        [INPUT]
+            Name                tail
+            Tag                 ecs-volume-plugin.log
+            Path                /var/log/ecs/ecs-volume-plugin.log
+            DB                  /var/fluent-bit/state/flb_ecs_volume_plugin.db
+            Mem_Buf_Limit       5MB
+            Skip_Long_Lines     On
+            Refresh_Interval    10
+            Read_from_Head      On 
+
+        [FILTER]
+            Name                modify
+            Match               systemd-*
+            Rename              _HOSTNAME                   hostname
+            Rename              _SYSTEMD_UNIT               systemd_unit
+            Rename              MESSAGE                     message
+            Remove_regex        ^((?!hostname|systemd_unit|message).)*$
+
+        [FILTER]
+            Name                aws
+            Match               *
+            imds_version        v2
+
+        [OUTPUT]
+            Name                cloudwatch_logs
+            Match               *
+            region              ${AWS_REGION}
+            log_group_name      /aws/ecs/containerinsights/${CLUSTER_NAME}/instance-logs
+            log_stream_prefix   ${INSTANCE_ID}-
+            auto_create_group   true
+      Description: SSM Parameter for Fluent Bit configuration in ECS
+  FluentBitParserParam:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Join
+        - '-'
+        - - 'fluent-bit-parser'
+          - !Ref ClusterName
+      Type: String
+      Value: !Sub |
+        [PARSER]
+            Name                syslog
+            Format              regex
+            Regex               ^(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+            Time_Key            time
+            Time_Format         %b %d %H:%M:%S
+      Description: SSM Parameter for Fluent Bit parser in ECS

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/fluent-bit-ecs-instance-logs/README.md
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/fluent-bit-ecs-instance-logs/README.md
@@ -1,0 +1,56 @@
+## Fluent-Bit for ECS Instance Logs Collection
+
+The sample ECS task definition in this folder deploys Fluent-Bit as a DaemonService.
+
+* [fluent-bit-ecs-instance-logs.json](fluent-bit-ecs-instance-logs.json): sample ECS task definition
+* [fluent-bit.conf](fluent-bit.conf): sample fluent-bit configuration
+* [parsers.conf](parsers.conf): sample fluent-bit parsers file
+
+You must replace all the placeholders (with ```{{ }}```) in the above task definitions with your information:
+* ```{{task-role-arn}}```: ECS task role ARN.
+  * This is role that you application containers will use. The permission should be whatever your applications need.
+  * Ensure that your Task role has the below permissions attached in order to access CloudWatch (for log ingestion) and SSM parameters (for the Fluent-Bit configuration).
+  ```
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Action": [
+                  "logs:CreateLogStream",
+                  "logs:CreateLogGroup",
+                  "logs:PutLogEvents"
+              ],
+              "Resource": "*",
+              "Effect": "Allow",
+              "Sid": "FluentBitLogs"
+          },
+          {
+              "Action": [
+                  "ssm:GetParameters",
+                  "ssm:GetParameter"
+              ],
+              "Resource": [
+                  "arn:aws:ssm:{{region}}:{{account-id}}:parameter/*"
+              ],
+              "Effect": "Allow",
+              "Sid": "FluentBitSSMParameterAccess"
+          }
+      ]
+  }
+  ```
+  
+* ```{{execution-role-arn}}```: ECS task execution role ARN.
+  * This is the role that Amazon ECS requires to launch/execute your containers, e.g. get the parameters from SSM parameter store.
+  * Ensure that the ```AmazonSSMReadOnlyAccess```, ```AmazonECSTaskExecutionRolePolicy``` and ```CloudWatchAgentServerPolicy``` policies are attached to your ECS Task execution role.
+  * If you would like to store more sensitive data for ECS to use, refer to https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html.    
+
+* ```{{aws-region}}```: The AWS region where the ECS Daemonset will be deployed: e.g. ```us-west-2```
+
+* ```{{fluent-bit-config-ssm-parameter-name}}```: The name of the SSM parameter used to store the Fluent-Bit configuration. [fluent-bit.conf](fluent-bit.conf) contains a sample configuration from which you can create an SSM parameter.
+
+* ```{{fluent-bit-parser-ssm-parameter-name}}```: The name of the SSM parameter used to store the Fluent-Bit parsers. [parsers.conf](parsers.conf) contains a sample fluent-bit parser configuration from which you can create an SSM parameter.
+  
+* ```{{ecs-cluster-name}}```: The name of the ECS cluster in which you are deploying the Fluent-Bit Daemonset.
+
+
+You can also adjust the resource limit (e.g. cpu and memory) based on your particular use cases.

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/fluent-bit-ecs-instance-logs/cloudformation-quickstart/README.md
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/fluent-bit-ecs-instance-logs/cloudformation-quickstart/README.md
@@ -1,0 +1,19 @@
+## CloudWatch Agent for ECS Instance Logs Collection Quick Start
+
+The cloudformation template in this folder helps you to quickly deploy Fluent-Bit as a daemon-service to collect ECS Container Instance Logs.
+
+* [fluent-bit-ecs-instance-logs-cfn.yaml](fluent-bit-ecs-instance-logs-cfn.yaml): sample cloudformation template
+
+
+Run following aws cloudformation command with the cloudformation template file to deploy the Fluent-Bit Daemonset with required IAM roles. ***Please assign the actual ECS cluster name and the cluster region in the first two lines of the command separately.***
+
+```
+ClusterName=<your-ecs-cluster-name>
+Region=<your-ecs-cluster-region>
+aws cloudformation create-stack --stack-name Fluent-Bit-${ClusterName}-${Region} \
+    --template-body file://fluent-bit-ecs-instance-logs-cfn.yaml \
+    --parameters ParameterKey=ClusterName,ParameterValue=${ClusterName} \
+                 ParameterKey=CreateIAMRoles,ParameterValue=True \
+    --capabilities CAPABILITY_NAMED_IAM \
+    --region ${Region}
+```

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/fluent-bit-ecs-instance-logs/cloudformation-quickstart/fluent-bit-ecs-instance-logs.cfn.yaml
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/fluent-bit-ecs-instance-logs/cloudformation-quickstart/fluent-bit-ecs-instance-logs.cfn.yaml
@@ -1,0 +1,326 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters:
+  ClusterName:
+    Type: String
+    Description: Enter the name of your ECS cluster from which you want to collect metrics and/or logs
+  CreateIAMRoles:
+    Type: String
+    Default: 'False'
+    AllowedValues:
+      - 'True'
+      - 'False'
+    Description: Whether to create default IAM roles
+    ConstraintDescription: must specify True or False.
+  FluentBitTaskRoleArn:
+    Type: String
+    Default: Default
+    Description: Enter the role arn you want to use for the CloudWatch Agent ecs task role
+  FluentBitExecutionRoleArn:
+    Type: String
+    Default: Default
+    Description: Enter the role arn you want to use for the CloudWatch Agent execution role
+Conditions:
+  CreateRoles: !Equals
+    - !Ref CreateIAMRoles
+    - 'True'
+  DefaultFluentBitTaskRole: !Equals
+    - !Ref FluentBitTaskRoleArn
+    - Default
+  DefaultFluentBitExecutionRole: !Equals
+    - !Ref FluentBitExecutionRoleArn
+    - Default
+Resources:
+  FluentBitTaskDefinition:
+    Type: AWS::ECS::TaskDefinition
+    Properties:
+      TaskRoleArn: !If
+        - CreateRoles
+        - !GetAtt FluentBitTaskRole.Arn
+        - !If
+          - DefaultFluentBitTaskRole
+          - !Sub arn:aws:iam::${AWS::AccountId}:role/FluentBitECSTaskRole
+          - !Ref FluentBitTaskRoleArn
+      ExecutionRoleArn: !If
+        - CreateRoles
+        - !GetAtt FluentBitExecutionRole.Arn
+        - !If
+          - DefaultFluentBitExecutionRole
+          - !Sub arn:aws:iam::${AWS::AccountId}:role/FluentBitECSExecutionRole
+          - !Ref FluentBitExecutionRoleArn
+      NetworkMode: bridge
+      ContainerDefinitions:
+        - Name: fluent-bit
+          Image: fluent/fluent-bit:3.1.4
+          MountPoints:
+            - ContainerPath: /fluent-bit/etc/
+              SourceVolume: fluent-bit-config
+            - ContainerPath: /var/fluent-bit/state
+              SourceVolume: fluent-bit-state
+            - ReadOnly: true
+              ContainerPath: /var/log
+              SourceVolume: instance-logs
+            - ReadOnly: true
+              ContainerPath: /run/log/journal
+              SourceVolume: systemd-journal
+            - ReadOnly: true
+              ContainerPath: /etc/machine-id
+              SourceVolume: machine-id
+          Environment:
+            - Name: AWS_REGION
+              Value: !Ref AWS::Region
+            - Name: CLUSTER_NAME
+              Value: !Ref ClusterName
+          DependsOn:
+            - ContainerName: fluent-bit-config-init
+              Condition: COMPLETE
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-create-group: 'True'
+              awslogs-group: /ecs/ecs-fluent-bit-daemon-service
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: ecs
+        - Name: fluent-bit-config-init
+          Image: amazon/aws-cli:2.17.24
+          Essential: False
+          EntryPoint:
+            - '/bin/sh'
+            - '-c'
+          Command:
+            - |
+              set -ex && if [ -z $( ls -A '/run/log/journal' ) ]; then echo @SET SYSTEMD_PATH=/var/log/journal >> /fluent-bit/etc/fluent-bit.conf; else echo @SET SYSTEMD_PATH=/run/log/journal >> /fluent-bit/etc/fluent-bit.conf; fi && echo @SET INSTANCE_ID=$(cat /var/lib/cloud/data/instance-id) >> /fluent-bit/etc/fluent-bit.conf && aws ssm get-parameter --name $FB_CONFIG_SSM_PARAM --query Parameter.Value --output text >> /fluent-bit/etc/fluent-bit.conf && aws ssm get-parameter --name $FB_PARSER_SSM_PARAM --query Parameter.Value --output text >> /fluent-bit/etc/parsers.conf && cat /fluent-bit/etc/fluent-bit.conf
+          Environment:
+            - Name: FB_CONFIG_SSM_PARAM
+              Value: !Ref FluentBitConfigParam
+            - Name: FB_PARSER_SSM_PARAM
+              Value: !Ref FluentBitParserParam
+          MountPoints:
+            - ContainerPath: /fluent-bit/etc/
+              SourceVolume: fluent-bit-config
+            - ReadOnly: true
+              ContainerPath: /var/lib/cloud/data/instance-id
+              SourceVolume: instance-id
+            - ReadOnly: true
+              ContainerPath: /run/log/journal
+              SourceVolume: systemd-journal
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-create-group: 'True'
+              awslogs-group: /ecs/ecs-fluent-bit-daemon-service
+              awslogs-region: !Ref AWS::Region
+              awslogs-stream-prefix: ecs
+      RequiresCompatibilities:
+        - EC2
+      Volumes:
+        - Name: fluent-bit-config
+          DockerVolumeConfiguration:
+            Scope: 'task'
+        - Name: instance-id
+          Host:
+            SourcePath: /var/lib/cloud/data/instance-id
+        - Name: fluent-bit-state
+          Host:
+            SourcePath: /var/fluent-bit/state
+        - Name: instance-logs
+          Host:
+            SourcePath: /var/log
+        - Name: systemd-journal
+          Host:
+            SourcePath: /run/log/journal
+        - Name: machine-id
+          Host:
+            SourcePath: /etc/machine-id
+      Cpu: '512'
+      Memory: '256'
+  FluentBitECSDaemonService:
+    Type: AWS::ECS::Service
+    Properties:
+      TaskDefinition: !Ref FluentBitTaskDefinition
+      Cluster: !Ref ClusterName
+      LaunchType: EC2
+      SchedulingStrategy: DAEMON
+      ServiceName: fluent-bit-daemon-service
+  FluentBitTaskRole:
+    Type: AWS::IAM::Role
+    Condition: CreateRoles
+    Properties:
+      Description: Allows ECS tasks to call AWS services on your behalf.
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: ''
+            Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: fluent-bit-task-role-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+                - Sid: FluentBitLogs
+                  Effect: Allow
+                  Action:
+                    - 'logs:CreateLogStream'
+                    - 'logs:CreateLogGroup'
+                    - 'logs:PutLogEvents'
+                  Resource: '*'
+                - Sid: FluentBitSSMParameterAccess
+                  Effect: Allow
+                  Action:
+                    - 'ssm:GetParameters'
+                    - 'ssm:GetParameter'
+                  Resource: 
+                    - !Sub
+                      - 'arn:${Partition}:ssm:${Region}:${AccountID}:parameter/*'
+                      - Partition: !Ref AWS::Partition
+                        Region: !Ref AWS::Region
+                        AccountID: !Ref AWS::AccountId
+      RoleName: FluentBitECSTaskRole
+  FluentBitExecutionRole:
+    Type: AWS::IAM::Role
+    Condition: CreateRoles
+    Properties:
+      Description: Allows ECS container agent makes calls to the Amazon ECS API on your behalf.
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: ''
+            Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      RoleName: FluentBitECSExecutionRole
+  FluentBitConfigParam:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Join
+        - '-'
+        - - 'fluent-bit-config'
+          - !Ref ClusterName
+      Type: String
+      Value: |
+        [SERVICE]
+            Flush                     5
+            Grace                     30
+            Log_Level                 error
+            Daemon                    off
+            Parsers_File              parsers.conf
+            storage.path              /var/fluent-bit/state/flb-storage/
+            storage.sync              normal
+            storage.checksum          off
+            storage.backlog.mem_limit 5M
+
+        [INPUT]
+            Name                systemd
+            Tag                 systemd-*
+            Systemd_Filter      _SYSTEMD_UNIT=docker.service
+            Systemd_Filter      _SYSTEMD_UNIT=containerd.service
+            DB                  /var/fluent-bit/state/systemd.db
+            Path                ${SYSTEMD_PATH}
+
+        [INPUT]
+            Name                systemd
+            Tag                 systemd-syslog
+            DB                  /var/fluent-bit/state/systemd-syslog.db
+            Path                ${SYSTEMD_PATH}
+            
+        [INPUT]
+            Name                systemd
+            Tag                 systemd-dmesg.*
+            Systemd_Filter      _TRANSPORT=kernel
+            DB                  /var/fluent-bit/state/dmesg.db
+            Path                ${SYSTEMD_PATH}
+
+        [INPUT]
+            Name                tail
+            Tag                 secure
+            Path                /var/log/secure
+            Parser              syslog
+            DB                  /var/fluent-bit/state/flb_secure.db
+            Mem_Buf_Limit       5MB
+            Skip_Long_Lines     On
+            Refresh_Interval    10
+            Read_from_Head      On
+
+        [INPUT]
+            Name                tail
+            Tag                 ecs-agent.log
+            Path                /var/log/ecs/ecs-agent.log
+            DB                  /var/fluent-bit/state/flb_ecs_agent.db
+            Mem_Buf_Limit       5MB
+            Skip_Long_Lines     On
+            Refresh_Interval    10
+            Read_from_Head      On
+
+        [INPUT]
+            Name                tail
+            Tag                 ecs-init.log
+            Path                /var/log/ecs/ecs-init.log
+            DB                  /var/fluent-bit/state/flb_ecs_init.db
+            Mem_Buf_Limit       5MB
+            Skip_Long_Lines     On
+            Refresh_Interval    10
+            Read_from_Head      On
+
+        [INPUT]
+            Name                tail
+            Tag                 ecs-audit.log
+            Path                /var/log/ecs/audit.log
+            DB                  /var/fluent-bit/state/flb_ecs_audit.db
+            Mem_Buf_Limit       5MB
+            Skip_Long_Lines     On
+            Refresh_Interval    10
+            Read_from_Head      On
+
+        [INPUT]
+            Name                tail
+            Tag                 ecs-volume-plugin.log
+            Path                /var/log/ecs/ecs-volume-plugin.log
+            DB                  /var/fluent-bit/state/flb_ecs_volume_plugin.db
+            Mem_Buf_Limit       5MB
+            Skip_Long_Lines     On
+            Refresh_Interval    10
+            Read_from_Head      On 
+
+        [FILTER]
+            Name                modify
+            Match               systemd-*
+            Rename              _HOSTNAME                   hostname
+            Rename              _SYSTEMD_UNIT               systemd_unit
+            Rename              MESSAGE                     message
+            Remove_regex        ^((?!hostname|systemd_unit|message).)*$
+
+        [FILTER]
+            Name                aws
+            Match               *
+            imds_version        v2
+
+        [OUTPUT]
+            Name                cloudwatch_logs
+            Match               *
+            region              ${AWS_REGION}
+            log_group_name      /aws/ecs/containerinsights/${CLUSTER_NAME}/instance-logs
+            log_stream_prefix   ${INSTANCE_ID}-
+            auto_create_group   true
+      Description: SSM Parameter for Fluent Bit configuration in ECS
+  FluentBitParserParam:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Join
+        - '-'
+        - - 'fluent-bit-parser'
+          - !Ref ClusterName
+      Type: String
+      Value: !Sub |
+        [PARSER]
+            Name                syslog
+            Format              regex
+            Regex               ^(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+            Time_Key            time
+            Time_Format         %b %d %H:%M:%S
+      Description: SSM Parameter for Fluent Bit parser in ECS

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/fluent-bit-ecs-instance-logs/fluent-bit-ecs-instance-logs.json
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/fluent-bit-ecs-instance-logs/fluent-bit-ecs-instance-logs.json
@@ -1,0 +1,157 @@
+{
+    "family": "fluent-bit-daemon-service",
+    "taskRoleArn": "{{task-role-arn}}",
+    "executionRoleArn": "{{execution-role-arn}}",
+    "containerDefinitions": [
+        {
+            "name": "fluent-bit-config-init",
+            "image": "amazon/aws-cli:2.17.24",
+            "cpu": 0,
+            "essential": false,
+            "entryPoint": [
+                "/bin/sh",
+                "-c"
+            ],
+            "command": [
+                "set -ex && if [ -z $( ls -A '/run/log/journal' ) ]; then echo @SET SYSTEMD_PATH=/var/log/journal >> /fluent-bit/etc/fluent-bit.conf; else echo @SET SYSTEMD_PATH=/run/log/journal >> /fluent-bit/etc/fluent-bit.conf; fi && echo @SET INSTANCE_ID=$(cat /var/lib/cloud/data/instance-id) >> /fluent-bit/etc/fluent-bit.conf && aws ssm get-parameter --name $FB_CONFIG_SSM_PARAM --query Parameter.Value --output text >> /fluent-bit/etc/fluent-bit.conf && aws ssm get-parameter --name $FB_PARSER_SSM_PARAM --query Parameter.Value --output text >> /fluent-bit/etc/parsers.conf && cat /fluent-bit/etc/fluent-bit.conf\n"
+            ],
+            "environment": [
+                {
+                    "name": "FB_CONFIG_SSM_PARAM",
+                    "value": "{{fluent-bit-config-ssm-parameter-name}}"
+                },
+                {
+                    "name": "FB_PARSER_SSM_PARAM",
+                    "value": "{{fluent-bit-parser-ssm-parameter-name}}"
+                }
+            ],
+            "environmentFiles": [],
+            "mountPoints": [
+                {
+                    "sourceVolume": "fluent-bit-config",
+                    "containerPath": "/fluent-bit/etc/"
+                },
+                {
+                    "sourceVolume": "instance-id",
+                    "containerPath": "/var/lib/cloud/data/instance-id",
+                    "readOnly": true
+                },
+                {
+                    "sourceVolume": "systemd-journal",
+                    "containerPath": "/run/log/journal",
+                    "readOnly": true
+                }
+            ],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "/ecs/ecs-fluent-bit-daemon-service",
+                    "awslogs-create-group": "True",
+                    "awslogs-region": "{{aws-region}}",
+                    "awslogs-stream-prefix": "ecs"
+                }
+            }
+        },
+        {
+            "name": "fluent-bit",
+            "image": "fluent/fluent-bit:3.1.4",
+            "cpu": 0,
+            "essential": true,
+            "environment": [
+                {
+                    "name": "AWS_REGION",
+                    "value": "{{aws-region}}"
+                },
+                {
+                    "name": "CLUSTER_NAME",
+                    "value": "{{cluster-name}}"
+                }
+            ],
+            "mountPoints": [
+                {
+                    "sourceVolume": "fluent-bit-config",
+                    "containerPath": "/fluent-bit/etc/"
+                },
+                {
+                    "sourceVolume": "fluent-bit-state",
+                    "containerPath": "/var/fluent-bit/state"
+                },
+                {
+                    "sourceVolume": "instance-logs",
+                    "containerPath": "/var/log",
+                    "readOnly": true
+                },
+                {
+                    "sourceVolume": "systemd-journal",
+                    "containerPath": "/run/log/journal",
+                    "readOnly": true
+                },
+                {
+                    "sourceVolume": "machine-id",
+                    "containerPath": "/etc/machine-id",
+                    "readOnly": true
+                }
+            ],
+            "dependsOn": [
+                {
+                    "containerName": "fluent-bit-config-init",
+                    "condition": "COMPLETE"
+                }
+            ],
+            "logConfiguration": {
+                "logDriver": "awslogs",
+                "options": {
+                    "awslogs-group": "/ecs/ecs-fluent-bit-daemon-service",
+                    "awslogs-create-group": "True",
+                    "awslogs-region": "{{aws-region}}",
+                    "awslogs-stream-prefix": "ecs"
+                }
+            }
+        }
+    ],
+    "networkMode": "bridge",
+    "volumes": [
+        {
+            "name": "fluent-bit-state",
+            "host": {
+                "sourcePath": "/var/fluent-bit/state"
+            }
+        },
+        {
+            "name": "instance-logs",
+            "host": {
+                "sourcePath": "/var/log"
+            }
+        },
+        {
+            "name": "instance-id",
+            "host": {
+                "sourcePath": "/var/lib/cloud/data/instance-id"
+            }
+        },
+        {
+            "name": "systemd-journal",
+            "host": {
+                "sourcePath": "/run/log/journal"
+            }
+        },
+        {
+            "name": "machine-id",
+            "host": {
+                "sourcePath": "/etc/machine-id"
+            }
+        },
+        {
+            "name": "fluent-bit-config",
+            "dockerVolumeConfiguration": {
+                "scope": "task",
+                "driver": "local"
+            }
+        }
+    ],
+    "requiresCompatibilities": [
+        "EC2"
+    ],
+    "cpu": "512",
+    "memory": "256"
+}

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/fluent-bit-ecs-instance-logs/fluent-bit.conf
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/fluent-bit-ecs-instance-logs/fluent-bit.conf
@@ -1,0 +1,103 @@
+[SERVICE]
+    Flush                     5
+    Grace                     30
+    Log_Level                 error
+    Daemon                    off
+    Parsers_File              parsers.conf
+    storage.path              /var/fluent-bit/state/flb-storage/
+    storage.sync              normal
+    storage.checksum          off
+    storage.backlog.mem_limit 5M
+
+[INPUT]
+    Name                systemd
+    Tag                 systemd-*
+    Systemd_Filter      _SYSTEMD_UNIT=docker.service
+    Systemd_Filter      _SYSTEMD_UNIT=containerd.service
+    DB                  /var/fluent-bit/state/systemd.db
+    Path                ${SYSTEMD_PATH}
+
+[INPUT]
+    Name                systemd
+    Tag                 systemd-syslog
+    DB                  /var/fluent-bit/state/systemd-syslog.db
+    Path                ${SYSTEMD_PATH}
+    
+[INPUT]
+    Name                systemd
+    Tag                 systemd-dmesg.*
+    Systemd_Filter      _TRANSPORT=kernel
+    DB                  /var/fluent-bit/state/dmesg.db
+    Path                ${SYSTEMD_PATH}
+
+[INPUT]
+    Name                tail
+    Tag                 secure
+    Path                /var/log/secure
+    Parser              syslog
+    DB                  /var/fluent-bit/state/flb_secure.db
+    Mem_Buf_Limit       5MB
+    Skip_Long_Lines     On
+    Refresh_Interval    10
+    Read_from_Head      On
+
+[INPUT]
+    Name                tail
+    Tag                 ecs-agent.log
+    Path                /var/log/ecs/ecs-agent.log
+    DB                  /var/fluent-bit/state/flb_ecs_agent.db
+    Mem_Buf_Limit       5MB
+    Skip_Long_Lines     On
+    Refresh_Interval    10
+    Read_from_Head      On
+
+[INPUT]
+    Name                tail
+    Tag                 ecs-init.log
+    Path                /var/log/ecs/ecs-init.log
+    DB                  /var/fluent-bit/state/flb_ecs_init.db
+    Mem_Buf_Limit       5MB
+    Skip_Long_Lines     On
+    Refresh_Interval    10
+    Read_from_Head      On
+
+[INPUT]
+    Name                tail
+    Tag                 ecs-audit.log
+    Path                /var/log/ecs/audit.log
+    DB                  /var/fluent-bit/state/flb_ecs_audit.db
+    Mem_Buf_Limit       5MB
+    Skip_Long_Lines     On
+    Refresh_Interval    10
+    Read_from_Head      On
+
+[INPUT]
+    Name                tail
+    Tag                 ecs-volume-plugin.log
+    Path                /var/log/ecs/ecs-volume-plugin.log
+    DB                  /var/fluent-bit/state/flb_ecs_volume_plugin.db
+    Mem_Buf_Limit       5MB
+    Skip_Long_Lines     On
+    Refresh_Interval    10
+    Read_from_Head      On 
+
+[FILTER]
+    Name                modify
+    Match               systemd-*
+    Rename              _HOSTNAME                   hostname
+    Rename              _SYSTEMD_UNIT               systemd_unit
+    Rename              MESSAGE                     message
+    Remove_regex        ^((?!hostname|systemd_unit|message).)*$
+
+[FILTER]
+    Name                aws
+    Match               *
+    imds_version        v2
+
+[OUTPUT]
+    Name                cloudwatch_logs
+    Match               *
+    region              ${AWS_REGION}
+    log_group_name      /aws/ecs/containerinsights/${CLUSTER_NAME}/instance-logs
+    log_stream_prefix   ${INSTANCE_ID}-
+    auto_create_group   true

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/fluent-bit-ecs-instance-logs/parsers.conf
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/fluent-bit-ecs-instance-logs/parsers.conf
@@ -1,0 +1,6 @@
+[PARSER]
+    Name                syslog
+    Format              regex
+    Regex               ^(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+    Time_Key            time
+    Time_Format         %b %d %H:%M:%S


### PR DESCRIPTION
# Description of the issue

In a container environment, it is important to monitor the host for any host-level issues and/or impacting behaviour. While Container Insights allows the collection of host-level metrics using the CloudWatch agent in daemon mode, logs from the host such as Docker daemon and ECS agent logs. However, instances may sometimes be terminated, or not be configured to allow access, hence it would be impossible in these cases to access the logs and triage the issue. There is a need for an automated log collection for ECS Container Insights.

# Description of changes

This pull request introduces the capability to deploy fluent-bit as an additional daemonset to collect the logs from the host and populate them in CloudWatch in the `/aws/ecs/containerinsights/${CLUSTER_NAME}/instance-logs` log group. The below logs are collected:
* ECS agent logs
* ECS audit logs
* ECS init logs
* ECS volume plugin logs
* Docker daemon logs
* Containerd logs
* System log
* Kernel log (i.e. dmesg)
* /var/log/secure (Not collected on systems with rsyslog not installed such as AL2023. However these events are recorded in the system log)

# License
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._

# Tests

This PR does not modify the existing CloudWatch agent CFN stack and configurations, hence existing users using these stacks would experience no changes. Fluent-bit is provided as an additional configuration and CFN stack (for existing Container Insights users wanting to upgrade, or for those who simply want to deploy only one option), and there is a third stack which can deploy both CloudWatch agent and Fluent-Bit in a single stack (for new users).

The solution is confirmed to work on the below Operating Systems:

1. Amazon Linux 2
2. Amazon Linux 2023
3. Ubuntu 20.04
4. Ubuntu 22.04
5. Ubuntu 24.04
6. Red Hat Enterprise Linux (RHEL) 8
7. Red Hat Enterprise Linux (RHEL) 9
8. CentOS Stream 9



# Requirements
_Before committing the code, please verify the following:_

- If this commit includes changes to existing sample configurations, you acknowledge that you have confirmed this will not impact existing customer behavior.
- If not necessary, consider creating a new sample configuration for this change.

