### PR TITLE
Added Windows Exporter sample deployments for CW Prometheus

### DIFF
--- a/container-insights-manifest-update.sh
+++ b/container-insights-manifest-update.sh
@@ -29,6 +29,8 @@ sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public\.ecr\.
 rm ${k8sPrometheusDirPrefix}/prometheus-eks-fargate.yaml.bak
 sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${k8sPrometheusDirPrefix}/prometheus-k8s.yaml
 rm ${k8sPrometheusDirPrefix}/prometheus-k8s.yaml.bak
+sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${k8sPrometheusDirPrefix}/prometheus-eks-windows-exporter.yaml
+rm ${k8sPrometheusDirPrefix}/prometheus-eks-windows-exporter.yaml.bak
 
 
 # replace agent version for ECS

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/README.md
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/README.md
@@ -8,6 +8,11 @@ kubectl apply -f https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch
 ```
 curl https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/prometheus-beta/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-k8s.yaml | sed "s/{{cluster_name}}/MyCluster/;s/{{region_name}}/region/" | kubectl apply -f -
 ```
+
+* [prometheus-eks-windows-exporter.yaml](prometheus-k8s.yaml) provides an example for deploying the CloudWatch agent with Prometheus monitoring support for K8S on EC2 in one command line:
+```
+curl https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/prometheus-beta/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-windows-exporter.yaml | sed "s/{{cluster_name}}/MyCluster/;s/{{region_name}}/region/" | kubectl apply -f -
+```
 Replace ```MyCluster``` with your cluster name, and ```region``` with the AWS region (e.g. ```us-west-2```).
 
 ### IAM permissions required by CloudWatch Agent for all features:
@@ -33,3 +38,8 @@ Both yaml files contain the default settings for the following containerized app
 |HAPROXY_INGRESS |Exposed by Helm Chart:   [incubator/haproxy-ingress](https://github.com/helm/charts/tree/master/incubator/haproxy-ingress) |
 |AWS APP MESH    |Exposed by Helm Chart:   [EKS Charts](https://github.com/aws/eks-charts/blob/master/README.md)                             |
 |JAVA/JMX        |Exposed by JMX_Exporter: [JMX_Exporter](https://github.com/prometheus/jmx_exporter)                                        |
+
+### Installing Windows Exporter and Sample .NET Application
+To install the Windows Exporter and a test .NET application, run the following command:
+- `kubectl apply -f ./sample_windows_exporter`
+- Also make sure to install the CloudWatch agent using the "prometheus-eks-windows-exporter.yaml"

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-windows-exporter.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-windows-exporter.yaml
@@ -1,0 +1,177 @@
+# create amazon-cloudwatch namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: amazon-cloudwatch
+  labels:
+    name: amazon-cloudwatch
+
+---
+# create configmap for prometheus cwagent config
+apiVersion: v1
+data:
+  # cwagent json config
+  cwagentconfig.json: |
+    {
+      "logs": {
+        "metrics_collected": {
+          "prometheus": {
+            "prometheus_config_path": "/etc/prometheusconfig/prometheus.yaml",
+            "emf_processor": {
+              "metric_declaration": [
+                {
+                  "source_labels": ["job"],
+                  "label_matcher": "^pod_exporter$",
+                  "dimensions": [["instance"]],
+                  "metric_selectors": [
+                    "^windows_cpu_time_total$"
+                  ]
+                },
+                {
+                  "source_labels": ["job"],
+                  "label_matcher": "^pod_exporter$",
+                  "dimensions": [["instance"]],
+                  "metric_selectors": [
+                    "^windows_netframework_clrmemory_allocated_bytes_total$"
+                  ]
+                },
+                {
+                  "source_labels": ["job"],
+                  "label_matcher": "^pod_exporter$",
+                  "dimensions": [["instance"]],
+                  "metric_selectors": [
+                    "^windows_netframework_clrmemory_finalization_survivors$"
+                  ]
+                },
+                {
+                  "source_labels": ["job"],
+                  "label_matcher": "^pod_exporter$",
+                  "dimensions": [["instance"]],
+                  "metric_selectors": [
+                    "^windows_netframework_clrmemory_collections_total$"
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        "force_flush_interval": 5
+      }
+    }
+kind: ConfigMap
+metadata:
+  name: prometheus-cwagentconfig
+  namespace: amazon-cloudwatch
+
+---
+# create configmap for prometheus scrape config
+apiVersion: v1
+data:
+  # prometheus config
+  prometheus.yaml: |
+    global:
+      scrape_interval: 1m
+      scrape_timeout: 10s
+    scrape_configs:
+      - job_name: pod_exporter
+        kubernetes_sd_configs:
+        - role: pod
+
+kind: ConfigMap
+metadata:
+  name: prometheus-config
+  namespace: amazon-cloudwatch
+
+---
+# create cwagent service account and role binding
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cwagent-prometheus
+  namespace: amazon-cloudwatch
+
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cwagent-prometheus-role
+rules:
+  - apiGroups: [""]
+    resources:
+    - nodes
+    - nodes/proxy
+    - services
+    - endpoints
+    - pods
+    verbs: ["get", "list", "watch"]
+  - apiGroups:
+    - extensions
+    resources:
+    - ingresses
+    verbs: ["get", "list", "watch"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cwagent-prometheus-role-binding
+subjects:
+  - kind: ServiceAccount
+    name: cwagent-prometheus
+    namespace: amazon-cloudwatch
+roleRef:
+  kind: ClusterRole
+  name: cwagent-prometheus-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# Deployment
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cwagent-prometheus
+  namespace: amazon-cloudwatch
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: cwagent-prometheus
+  template:
+    metadata:
+      labels:
+        app: cwagent-prometheus
+    spec:
+      containers:
+        - name: cloudwatch-agent
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300042.1b746
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu:  1000m
+              memory: 1000Mi
+            requests:
+              cpu: 200m
+              memory: 200Mi
+          # Please don't change below envs
+          env:
+            - name: CI_VERSION
+              value: "k8s/1.3.26"
+          # Please don't change the mountPath
+          volumeMounts:
+            - name: prometheus-cwagentconfig
+              mountPath: /etc/cwagentconfig
+            - name: prometheus-config
+              mountPath: /etc/prometheusconfig
+      nodeSelector:
+        kubernetes.io/os: linux
+      volumes:
+        - name: prometheus-cwagentconfig
+          configMap:
+            name: prometheus-cwagentconfig
+        - name: prometheus-config
+          configMap:
+            name: prometheus-config
+      terminationGracePeriodSeconds: 60
+      serviceAccountName: cwagent-prometheus

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_windows_exporter/sample-net-app.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_windows_exporter/sample-net-app.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sample-net
+  labels:
+    app: sample-net
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sample-net
+  template:
+    metadata:
+      labels:
+        app: sample-net
+    spec:
+      containers:
+      - name: sample-net
+        image: mcr.microsoft.com/dotnet/samples:aspnetapp
+        imagePullPolicy: Always
+      nodeSelector:
+        kubernetes.io/os: windows

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_windows_exporter/windows-exporter.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_windows_exporter/windows-exporter.yaml
@@ -1,0 +1,73 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: windows-monitoring
+  labels:
+    name: windows-monitoring
+---
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: windows-exporter
+  namespace: windows-monitoring
+  labels:
+    app: windows-exporter
+spec:
+  selector:
+    matchLabels:
+      app: windows-exporter
+  template:
+    metadata:
+      labels:
+        app: windows-exporter
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/scheme: http
+        prometheus.io/path: "/metrics"
+        prometheus.io/port: "9182"
+    spec:
+      securityContext:
+        windowsOptions:
+          hostProcess: true
+          runAsUserName: "NT AUTHORITY\\system"
+      hostNetwork: true
+      initContainers:
+        - name: configure-firewall
+          image: mcr.microsoft.com/powershell:lts-nanoserver-1809
+          command: ["powershell"]
+          args: ["New-NetFirewallRule", "-DisplayName", "'windows-exporter'", "-Direction", "inbound", "-Profile", "Any", "-Action", "Allow", "-LocalPort", "9182", "-Protocol", "TCP"]
+      containers:
+      - args: 
+        - --config.file=%CONTAINER_SANDBOX_MOUNT_POINT%/config.yml
+        name: windows-exporter
+        image: ghcr.io/prometheus-community/windows-exporter:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 9182
+          hostPort: 9182
+          name: http
+        volumeMounts:
+        - name:  windows-exporter-config
+          mountPath: /config.yml
+          subPath: config.yml
+      nodeSelector:
+        kubernetes.io/os: windows
+      volumes:
+      - name: windows-exporter-config
+        configMap:
+          name: windows-exporter-config
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: windows-exporter-config
+  namespace: windows-monitoring
+  labels:
+    app: windows-exporter
+data:
+  config.yml: |
+    collectors:
+      enabled: '[defaults],container,netframework_clrmemory'
+    collector:
+      service:
+        services-where: "Name='containerd' or Name='kubelet'"


### PR DESCRIPTION
# Description of the issue
Customers have expressed desire to monitor [Windows Exporter](https://github.com/prometheus-community/windows_exporter) metrics on CloudWatch in the past, though they were unsure as to how this could be achieved. This PR was created to provide customers an example of how they could successfully obtain `Windows Exporter` metrics in CloudWatch.

# Description of changes
- Added a new sample CW Agent deployment manifest, pre-configured to extract metrics commonly used .NET memory metrics from Windows Exporter
- Added a sample deployment file to enable Windows Exporter
- Added a sample ASP .NET application

# License
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._

# Tests
- Deployed new manifests files into a fresh cluster and validated that the metrics were properly processed in CloudWatch. Screenshot below:
![image](https://github.com/user-attachments/assets/89afe4c4-8f27-4b4c-bda0-cac5d0dbf1ad)

# Requirements
_Before committing the code, please verify the following:_

- If this commit includes changes to existing sample configurations, you acknowledge that you have confirmed this will not impact existing customer behavior.
- If not necessary, consider creating a new sample configuration for this change.

Create a new sample configuration, so will not affect any current customer workloads.

