### PR TITLE
Update prometheus-eks.yaml to include cluster_name and region_name

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
@@ -13,9 +13,14 @@ data:
   # cwagent json config
   cwagentconfig.json: |
     {
+      "agent": {
+        "region": "{{region_name}}"
+      },
       "logs": {
         "metrics_collected": {
           "prometheus": {
+            "cluster_name": "{{cluster_name}}",
+            "log_group_name": "/aws/containerinsights/{{cluster_name}}/prometheus",
             "prometheus_config_path": "/etc/prometheusconfig/prometheus.yaml",
             "emf_processor": {
               "metric_declaration": [


### PR DESCRIPTION
cluster_name and region_name not specified in the yaml. So if customers use this yaml, they'll face the below error :

~~~~
2025/02/03 11:00:06 E! Failed to generate TOML configuration validation content: [Under path : /agent/ruleRegion/ | Error : Region info is missing for mode: onPrem Under path : /logs/metrics_collected/prometheus/ | Error : ClusterName is not defined] 2025/02/03 11:00:06 Under path : /agent/ruleRegion/ | Error : Region info is missing for mode: onPrem 2025/02/03 11:00:06 Under path : /logs/metrics_collected/prometheus/ | Error : ClusterName is not defined ~~~~

# Description of the issue
_Describe the problem or feature in addition to a link to the issues._

# Description of changes
_How does this change address the problem?_

# License
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._

# Tests
_Describe what tests you have done._

# Requirements
_Before committing the code, please verify the following:_

- If this commit includes changes to existing sample configurations, you acknowledge that you have confirmed this will not impact existing customer behavior.
- If not necessary, consider creating a new sample configuration for this change.

