### PR TITLE
Exclude FluentD logs to be shipped by FluentBit

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
@@ -64,7 +64,7 @@ data:
     [INPUT]
         Name                tail
         Tag                 application.*
-        Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*
+        Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/fluentd*
         Path                /var/log/containers/*.log
         Docker_Mode         On
         Docker_Mode_Flush   5

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-windows.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-windows.yaml
@@ -22,7 +22,7 @@ data:
     [INPUT]
         Name                tail
         Tag                 application.*
-        Exclude_Path        C:\\var\\log\\containers\\fluent-bit*, C:\\var\\log\\containers\\cloudwatch-agent*
+        Exclude_Path        C:\\var\\log\\containers\\fluent-bit*, C:\\var\\log\\containers\\cloudwatch-agent*, C:\\var\\log\\containers\\fluentd*
         Path                C:\\var\\log\\containers\\*.log
         Parser              docker
         DB                  C:\\var\\fluent-bit\\state\\flb_container.db

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
@@ -66,7 +66,7 @@ data:
     [INPUT]
         Name                tail
         Tag                 application.*
-        Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
+        Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*, /var/log/containers/fluentd*
         Path                /var/log/containers/*.log
         multiline.parser    docker, cri
         DB                  /var/fluent-bit/state/flb_container.db

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-enhanced.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-enhanced.yaml
@@ -269,7 +269,7 @@ data:
     [INPUT]
         Name                tail
         Tag                 application.*
-        Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
+        Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*, /var/log/containers/fluentd*
         Path                /var/log/containers/*.log
         multiline.parser    docker, cri
         DB                  /var/fluent-bit/state/flb_container.db

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
@@ -268,7 +268,7 @@ data:
     [INPUT]
         Name                tail
         Tag                 application.*
-        Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
+        Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*, /var/log/containers/fluentd*
         Path                /var/log/containers/*.log
         multiline.parser    docker, cri
         DB                  /var/fluent-bit/state/flb_container.db

--- a/k8s-quickstart/cwagent-operator-rendered.yaml
+++ b/k8s-quickstart/cwagent-operator-rendered.yaml
@@ -67,7 +67,7 @@ data:
     [INPUT]
         Name                tail
         Tag                 application.*
-        Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
+        Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*, /var/log/containers/fluentd*
         Path                /var/log/containers/*.log
         multiline.parser    docker, cri
         DB                  /var/fluent-bit/state/flb_container.db


### PR DESCRIPTION
# Description of the issue
When customers upgrade their K8s version to 1.24 and above, customers are being asked to move to FluentBit from FluentD which was previously recommended. Ref: https://docs.aws.amazon.com/eks/latest/userguide/dockershim-deprecation.html

The document for moving to FluentBit https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-logs-FluentBit.html recommends deploy Fluent-Bit using the yaml files from this repo without being asked to remove FluentD, this causes FluentBit to ship FluentD application logs to CW.

Older versions of FluentD struggle to parse ContainerD logs and keep throwing warnings that blow up the logs ingested into CW with customers seeing high log ingestion costs. 

# Description of changes
The yaml file is updated so that FluentD application logs are not shipped to CW.

# License
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._

# Tests
Tested it locally in a Cluster and stopped seeing the Logs getting published to CW.

Deployed a change to the Fluent-bit Config file to add the exclude path at 13:25 UTC and the logs stopped shipping after that.

<img width="1350" alt="image" src="https://github.com/user-attachments/assets/029d3e17-dc87-4f64-936a-28c99d22a22c" />


# Requirements
_Before committing the code, please verify the following:_

- If this commit includes changes to existing sample configurations, you acknowledge that you have confirmed this will not impact existing customer behavior.

Impact's the existing behavior by stop shipping mis-formed logs to CW. 

