### PR TITLE
dev: make fluentd.yaml daemonset ref multi-arch container

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
@@ -385,7 +385,7 @@ spec:
           command: ['sh','-c','']
       containers:
         - name: fluentd-cloudwatch
-          image: fluent/fluentd-kubernetes-daemonset:v1.10.3-debian-cloudwatch-1.0
+          image: fluent/fluentd-kubernetes-daemonset:v1.18.0-debian-cloudwatch-1.1
           env:
             - name: AWS_REGION
               valueFrom:


### PR DESCRIPTION
# Description of the issue
Current example in https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-setup-logs.html does not support ARM nodes, which is caused by `fluent/fluentd-kubernetes-daemonset:v1.10.3-debian-cloudwatch-1.0` only supporting x86 from what I understand

See https://github.com/aws-samples/amazon-cloudwatch-container-insights/issues/184

# Description of changes
According to https://github.com/fluent/fluentd-kubernetes-daemonset, multi-arch is now supported.

# License
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

# Tests
`docker manifest inspect fluent/fluentd-kubernetes-daemonset:v1.10.3-debian-cloudwatch-1.0 | grep architecture` has no output

