### PR TITLE
Add endpointslices permissions to the cloudwatch-agent-role

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/combination/combination.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/combination/combination.yaml
@@ -44,6 +44,9 @@ rules:
     verbs: ["get","update"]
   - nonResourceURLs: ["/metrics"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "discovery.k8s.io" ]
+    resources: [ "endpointslices" ]
+    verbs: [ "list", "watch", "get" ]
 
 ---
 kind: ClusterRoleBinding

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-serviceaccount.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-serviceaccount.yaml
@@ -35,6 +35,9 @@ rules:
     verbs: ["get","update"]
   - nonResourceURLs: ["/metrics"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "discovery.k8s.io" ]
+    resources: [ "endpointslices" ]
+    verbs: [ "list", "watch", "get" ]
 
 ---
 kind: ClusterRoleBinding

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-enhanced.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-enhanced.yaml
@@ -44,6 +44,9 @@ rules:
     verbs: ["get","update"]
   - nonResourceURLs: ["/metrics"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "discovery.k8s.io" ]
+    resources: [ "endpointslices" ]
+    verbs: [ "list", "watch", "get" ]
 
 ---
 kind: ClusterRoleBinding

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
@@ -44,6 +44,9 @@ rules:
     verbs: ["get","update"]
   - nonResourceURLs: ["/metrics"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "discovery.k8s.io" ]
+    resources: [ "endpointslices" ]
+    verbs: [ "list", "watch", "get" ]
 
 ---
 kind: ClusterRoleBinding

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart-enhanced.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart-enhanced.yaml
@@ -44,6 +44,9 @@ rules:
     verbs: ["get","update"]
   - nonResourceURLs: ["/metrics"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "discovery.k8s.io" ]
+    resources: [ "endpointslices" ]
+    verbs: [ "list", "watch", "get" ]
 
 ---
 kind: ClusterRoleBinding

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
@@ -44,6 +44,9 @@ rules:
     verbs: ["get","update"]
   - nonResourceURLs: ["/metrics"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "discovery.k8s.io" ]
+    resources: [ "endpointslices" ]
+    verbs: [ "list", "watch", "get" ]
 
 ---
 kind: ClusterRoleBinding

--- a/k8s-quickstart/cwagent-operator-rendered.yaml
+++ b/k8s-quickstart/cwagent-operator-rendered.yaml
@@ -420,6 +420,9 @@ rules:
   verbs: [ "update" ]
 - nonResourceURLs: [ "/metrics" ]
   verbs: [ "get", "list", "watch" ]
+- apiGroups: ["discovery.k8s.io"]
+  resources: ["endpointslices"]
+  verbs: ["list", "watch", "get"]
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1

--- a/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-serviceaccount.yaml
+++ b/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-serviceaccount.yaml
@@ -35,6 +35,9 @@ rules:
     verbs: ["get","update"]
   - nonResourceURLs: ["/metrics"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "discovery.k8s.io" ]
+    resources: [ "endpointslices" ]
+    verbs: [ "list", "watch", "get" ]
 
 ---
 kind: ClusterRoleBinding

--- a/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml
@@ -44,6 +44,9 @@ rules:
     verbs: ["get","update"]
   - nonResourceURLs: ["/metrics"]
     verbs: ["get", "list", "watch"]
+  - apiGroups: [ "discovery.k8s.io" ]
+    resources: [ "endpointslices" ]
+    verbs: [ "list", "watch", "get" ]
 
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
# Description of changes
Update cloudwatch-agent-role to add `endpointslices` permissions to match https://github.com/aws-observability/helm-charts/pull/172.

# License
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._

# Requirements
_Before committing the code, please verify the following:_

- If this commit includes changes to existing sample configurations, you acknowledge that you have confirmed this will not impact existing customer behavior.
- If not necessary, consider creating a new sample configuration for this change.

