### PR TITLE
Update k8s version to 1.3.35 and cwagent version to 1.300057.0 and use find instead prefix based lookup for version updates

### DIFF
--- a/container-insights-manifest-update.sh
+++ b/container-insights-manifest-update.sh
@@ -1,106 +1,76 @@
 #!/usr/bin/env bash
 
 cd "$(dirname "$0")"
-k8sDirPrefix="./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring"
-k8sQSDirPrefix="./k8s-quickstart"
-ecsDirPrefix="./ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric"
 
-newK8sVersion="k8s/1.3.34"
-agentVersion="public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300056.0b1123"
+# Version definitions
+newK8sVersion="k8s/1.3.35"
+agentVersion="public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161"
 fluentdVersion="fluent/fluentd-kubernetes-daemonset:v1.10.3-debian-cloudwatch-1.0"
 fluentBitVersion="public.ecr.aws/aws-observability/aws-for-fluent-bit:2.32.4"
 fluentBitWindowsVersion="public.ecr.aws/aws-observability/aws-for-fluent-bit:windowsservercore-stable"
 
-k8sPrometheusDirPrefix="./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus"
-ecsPrometheusDirPrefix="./ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus"
+# update all YAML and JSON files
+find . -type f \( -name "*.yaml" -o -name "*.json" \) -exec bash -c '
+    file="$1"
+    echo "Processing $file"
+    sed -i".bak" "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|'"$newK8sVersion"'|g;s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|'"$agentVersion"'|g" "$file"
+    rm -f "$file.bak"
+' bash {} \;
 
-# replace agent version for ECS Prometheus
-sed -i'.bak' "s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${ecsPrometheusDirPrefix}/cwagent-prometheus-task-definition.json
-rm ${ecsPrometheusDirPrefix}/cwagent-prometheus-task-definition.json.bak
-sed -i'.bak' "s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${ecsPrometheusDirPrefix}/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
-rm ${ecsPrometheusDirPrefix}/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml.bak
-sed -i'.bak' "s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${ecsPrometheusDirPrefix}/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
-rm ${ecsPrometheusDirPrefix}/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml.bak
+# update fluent-related files
+find . -type f -name "fluent*.yaml" -exec bash -c '
+    file="$1"
+    if [[ $file == *"windows"* ]]; then
+        sed -i".bak" "s|public\.ecr\.aws/aws-observability/aws-for-fluent-bit.*|'"$fluentBitWindowsVersion"'|g" "$file"
+    elif [[ $file == *"fluent-bit"* ]]; then
+        sed -i".bak" "s|public\.ecr\.aws/aws-observability/aws-for-fluent-bit.*|'"$fluentBitVersion"'|g" "$file"
+    elif [[ $file == *"fluentd"* ]]; then
+        sed -i".bak" "s|fluent/fluentd-kubernetes-daemonset:.*|'"$fluentdVersion"'|g" "$file"
+    fi
+    rm -f "$file.bak"
+' bash {} \;
 
-# replace agent and k8s version for K8s Prometheus
-sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${k8sPrometheusDirPrefix}/prometheus-eks.yaml
-rm ${k8sPrometheusDirPrefix}/prometheus-eks.yaml.bak
-sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${k8sPrometheusDirPrefix}/prometheus-eks-fargate.yaml
-rm ${k8sPrometheusDirPrefix}/prometheus-eks-fargate.yaml.bak
-sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${k8sPrometheusDirPrefix}/prometheus-k8s.yaml
-rm ${k8sPrometheusDirPrefix}/prometheus-k8s.yaml.bak
-sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${k8sPrometheusDirPrefix}/prometheus-eks-windows-exporter.yaml
-rm ${k8sPrometheusDirPrefix}/prometheus-eks-windows-exporter.yaml.bak
+# generate quickstart manifests
+k8sMonitoringPrefix="./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring"
+OUTPUT="${k8sMonitoringPrefix}/quickstart/cwagent-fluentd-quickstart.yaml"
+OUTPUT_FLUENT_BIT="${k8sMonitoringPrefix}/quickstart/cwagent-fluent-bit-quickstart.yaml"
+OUTPUT_FLUENT_BIT_WINDOWS="${k8sMonitoringPrefix}/quickstart/cwagent-fluent-bit-quickstart-windows.yaml"
 
-
-# replace agent version for ECS
-sed -i'.bak' "s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${ecsDirPrefix}/cwagent-ecs-instance-metric.json
-rm ${ecsDirPrefix}/cwagent-ecs-instance-metric.json.bak
-
-sed -i'.bak' "s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${ecsDirPrefix}/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json
-rm ${ecsDirPrefix}/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json.bak
-
-# replace agent, fluentD and fluent-bit version for K8s
-sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${k8sDirPrefix}/cwagent/cwagent-daemonset.yaml
-rm ${k8sDirPrefix}/cwagent/cwagent-daemonset.yaml.bak
-
-sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${k8sDirPrefix}/cwagent/cwagent-daemonset-windows.yaml
-rm ${k8sDirPrefix}/cwagent/cwagent-daemonset-windows.yaml.bak
-
-sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${k8sQSDirPrefix}/cwagent-operator-rendered.yaml
-rm ${k8sQSDirPrefix}/cwagent-operator-rendered.yaml.bak
-
-sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public\.ecr\.aws/cloudwatch-agent/cloudwatch-agent:[0-9]*\.[0-9]*\.[0-9a-z]*|${agentVersion}|g" ${k8sQSDirPrefix}/cwagent-version.yaml
-rm ${k8sQSDirPrefix}/cwagent-version.yaml.bak
-
-sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|fluent/fluentd-kubernetes-daemonset:.*|${fluentdVersion}|g" ${k8sDirPrefix}/fluentd/fluentd.yaml
-rm ${k8sDirPrefix}/fluentd/fluentd.yaml.bak
-
-sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public\.ecr\.aws/aws-observability/aws-for-fluent-bit.*|${fluentBitVersion}|g" ${k8sDirPrefix}/fluent-bit/fluent-bit.yaml
-rm ${k8sDirPrefix}/fluent-bit/fluent-bit.yaml.bak
-
-sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public\.ecr\.aws/aws-observability/aws-for-fluent-bit.*|${fluentBitWindowsVersion}|g" ${k8sDirPrefix}/fluent-bit/fluent-bit-windows.yaml
-rm ${k8sDirPrefix}/fluent-bit/fluent-bit-windows.yaml.bak
-
-sed -i'.bak' "s|k8s/[0-9]*\.[0-9]*\.[0-9a-z]*|${newK8sVersion}|g;s|public\.ecr\.aws/aws-observability/aws-for-fluent-bit.*|${fluentBitVersion}|g" ${k8sDirPrefix}/fluent-bit/fluent-bit-compatible.yaml
-rm ${k8sDirPrefix}/fluent-bit/fluent-bit-compatible.yaml.bak
-
-# generate quickstart manifest for K8s
-OUTPUT=${k8sDirPrefix}/quickstart/cwagent-fluentd-quickstart.yaml
-OUTPUT_FLUENT_BIT=${k8sDirPrefix}/quickstart/cwagent-fluent-bit-quickstart.yaml
-OUTPUT_FLUENT_BIT_WINDOWS=${k8sDirPrefix}/quickstart/cwagent-fluent-bit-quickstart-windows.yaml
-
-cat ${k8sDirPrefix}/cloudwatch-namespace.yaml > ${OUTPUT}
+# generate cwagent-fluentd-quickstart.yaml
+cat ${k8sMonitoringPrefix}/cloudwatch-namespace.yaml > ${OUTPUT}
 echo -e "\n---\n" >> ${OUTPUT}
-cat ${k8sDirPrefix}/cwagent/cwagent-serviceaccount.yaml >> ${OUTPUT}
+cat ${k8sMonitoringPrefix}/cwagent/cwagent-serviceaccount.yaml >> ${OUTPUT}
 echo -e "\n---\n" >> ${OUTPUT}
-cat ${k8sDirPrefix}/cwagent/cwagent-configmap.yaml | sed "s|\"logs|\"agent\": {\\
+cat ${k8sMonitoringPrefix}/cwagent/cwagent-configmap.yaml | sed "s|\"logs|\"agent\": {\\
         \"region\": \"{{region_name}}\"\\
       },\\
       \"logs|g" >> ${OUTPUT}
 echo -e "\n---\n" >> ${OUTPUT}
-cat ${k8sDirPrefix}/cwagent/cwagent-daemonset.yaml >> ${OUTPUT}
+cat ${k8sMonitoringPrefix}/cwagent/cwagent-daemonset.yaml >> ${OUTPUT}
 echo -e "\n---\n" >> ${OUTPUT}
-cat ${k8sDirPrefix}/fluentd/fluentd-configmap.yaml >> ${OUTPUT}
+cat ${k8sMonitoringPrefix}/fluentd/fluentd-configmap.yaml >> ${OUTPUT}
 echo -e "\n---\n" >> ${OUTPUT}
-cat ${k8sDirPrefix}/fluentd/fluentd.yaml >> ${OUTPUT}
+cat ${k8sMonitoringPrefix}/fluentd/fluentd.yaml >> ${OUTPUT}
 
-
-cat ${k8sDirPrefix}/cloudwatch-namespace.yaml > ${OUTPUT_FLUENT_BIT}
+# Generate cwagent-fluent-bit-quickstart.yaml
+cat ${k8sMonitoringPrefix}/cloudwatch-namespace.yaml > ${OUTPUT_FLUENT_BIT}
 echo -e "\n---\n" >> ${OUTPUT_FLUENT_BIT}
-cat ${k8sDirPrefix}/cwagent/cwagent-serviceaccount.yaml >> ${OUTPUT_FLUENT_BIT}
+cat ${k8sMonitoringPrefix}/cwagent/cwagent-serviceaccount.yaml >> ${OUTPUT_FLUENT_BIT}
 echo -e "\n---\n" >> ${OUTPUT_FLUENT_BIT}
-cat ${k8sDirPrefix}/cwagent/cwagent-configmap.yaml | sed "s|\"logs|\"agent\": {\\
+cat ${k8sMonitoringPrefix}/cwagent/cwagent-configmap.yaml | sed "s|\"logs|\"agent\": {\\
         \"region\": \"{{region_name}}\"\\
       },\\
       \"logs|g" >> ${OUTPUT_FLUENT_BIT}
 echo -e "\n---\n" >> ${OUTPUT_FLUENT_BIT}
-cat ${k8sDirPrefix}/cwagent/cwagent-daemonset.yaml >> ${OUTPUT_FLUENT_BIT}
+cat ${k8sMonitoringPrefix}/cwagent/cwagent-daemonset.yaml >> ${OUTPUT_FLUENT_BIT}
 echo -e "\n---\n" >> ${OUTPUT_FLUENT_BIT}
-cat ${k8sDirPrefix}/fluent-bit/fluent-bit-configmap.yaml >> ${OUTPUT_FLUENT_BIT}
+cat ${k8sMonitoringPrefix}/fluent-bit/fluent-bit-configmap.yaml >> ${OUTPUT_FLUENT_BIT}
 echo -e "\n---\n" >> ${OUTPUT_FLUENT_BIT}
-cat ${k8sDirPrefix}/fluent-bit/fluent-bit.yaml >> ${OUTPUT_FLUENT_BIT}
+cat ${k8sMonitoringPrefix}/fluent-bit/fluent-bit.yaml >> ${OUTPUT_FLUENT_BIT}
 
-cat ${k8sDirPrefix}/cwagent/cwagent-daemonset-windows.yaml > ${OUTPUT_FLUENT_BIT_WINDOWS}
+# Generate cwagent-fluent-bit-quickstart-windows.yaml
+cat ${k8sMonitoringPrefix}/cwagent/cwagent-daemonset-windows.yaml > ${OUTPUT_FLUENT_BIT_WINDOWS}
 echo -e "\n---\n" >> ${OUTPUT_FLUENT_BIT_WINDOWS}
-cat ${k8sDirPrefix}/fluent-bit/fluent-bit-windows.yaml >> ${OUTPUT_FLUENT_BIT_WINDOWS}
+cat ${k8sMonitoringPrefix}/fluent-bit/fluent-bit-windows.yaml >> ${OUTPUT_FLUENT_BIT_WINDOWS}
+
+echo "Version and manifest updates completed successfully!"

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json
@@ -105,7 +105,7 @@
         "ContainerDefinitions": [
           {
             "Name": "cloudwatch-agent",
-            "Image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300056.0b1123",
+            "Image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161",
             "MountPoints": [
               {
                 "ReadOnly": true,

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cwagent-ecs-instance-metric.json
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cwagent-ecs-instance-metric.json
@@ -6,7 +6,7 @@
   "containerDefinitions": [
     {
       "name": "cloudwatch-agent",
-      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300056.0b1123",
+      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161",
       "mountPoints": [
         {
           "readOnly": true,

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
@@ -224,7 +224,7 @@ Resources:
       NetworkMode: awsvpc
       ContainerDefinitions:
         - Name: cloudwatch-agent-prometheus
-          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300056.0b1123
+          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           Essential: true
           MountPoints: []
           PortMappings: []

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
@@ -219,7 +219,7 @@ Resources:
       NetworkMode: !Ref ECSNetworkMode
       ContainerDefinitions:
         - Name: cloudwatch-agent-prometheus
-          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300056.0b1123
+          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           Essential: true
           MountPoints: []
           PortMappings: []

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cwagent-prometheus-task-definition.json
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cwagent-prometheus-task-definition.json
@@ -6,7 +6,7 @@
   "containerDefinitions": [
     {
       "name": "cloudwatch-agent-prometheus",
-      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300056.0b1123",
+      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161",
       "essential": true,
       "mountPoints": [
       ],

--- a/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-ec2.json
@@ -22,7 +22,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-fargate.json
@@ -19,7 +19,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-ec2.json
@@ -22,7 +22,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-fargate.json
@@ -19,7 +19,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-ec2.json
@@ -22,7 +22,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-fargate.json
@@ -19,7 +19,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-ec2.json
@@ -27,7 +27,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-fargate.json
@@ -24,7 +24,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/combination/combination.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/combination/combination.yaml
@@ -121,7 +121,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           ports:
             - containerPort: 8125
               hostPort: 8125

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset-windows.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset-windows.yaml
@@ -20,7 +20,7 @@ spec:
       hostNetwork: true
       containers:
       - name: cloudwatch-agent
-        image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300056.0b1123
+        image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
         workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
         volumeMounts:
         - name: cwagentconfig
@@ -47,7 +47,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: CI_VERSION
-            value: "k8s/1.3.34"
+            value: "k8s/1.3.35"
           - name: CWAGENT_LOG_LEVEL
             value: DEBUG
           - name: RUN_IN_CONTAINER

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300056.0b1123
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -42,7 +42,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.34"
+              value: "k8s/1.3.35"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
@@ -320,7 +320,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: CI_VERSION
-              value: "k8s/1.3.34"
+              value: "k8s/1.3.35"
         resources:
             limits:
               memory: 200Mi

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-windows.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-windows.yaml
@@ -205,7 +205,7 @@ spec:
               apiVersion: v1
               fieldPath: metadata.name
         - name: CI_VERSION
-          value: "k8s/1.3.34"
+          value: "k8s/1.3.35"
         resources:
             limits:
               cpu: 500m

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
@@ -304,7 +304,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.name
             - name: CI_VERSION
-              value: "k8s/1.3.34"
+              value: "k8s/1.3.35"
         resources:
             limits:
               memory: 200Mi

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
@@ -398,7 +398,7 @@ spec:
                   name: cluster-info
                   key: cluster.name
             - name: CI_VERSION
-              value: "k8s/1.3.34"
+              value: "k8s/1.3.35"
             - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
               value: /^(?<time>.+) (?<stream>stdout|stderr) (?<logtag>[FP]) (?<log>.*)$/
           resources:

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-enhanced.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-enhanced.yaml
@@ -107,7 +107,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -134,7 +134,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.20"
+              value: "k8s/1.3.35"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig
@@ -510,7 +510,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.name
             - name: CI_VERSION
-              value: "k8s/1.3.20"
+              value: "k8s/1.3.35"
         resources:
             limits:
               memory: 200Mi

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-windows.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-windows.yaml
@@ -20,7 +20,7 @@ spec:
       hostNetwork: true
       containers:
       - name: cloudwatch-agent
-        image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300056.0b1123
+        image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
         workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
         volumeMounts:
         - name: cwagentconfig
@@ -47,7 +47,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: CI_VERSION
-            value: "k8s/1.3.34"
+            value: "k8s/1.3.35"
           - name: CWAGENT_LOG_LEVEL
             value: DEBUG
           - name: RUN_IN_CONTAINER
@@ -271,7 +271,7 @@ spec:
               apiVersion: v1
               fieldPath: metadata.name
         - name: CI_VERSION
-          value: "k8s/1.3.34"
+          value: "k8s/1.3.35"
         resources:
             limits:
               cpu: 500m

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
@@ -106,7 +106,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300056.0b1123
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -133,7 +133,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.34"
+              value: "k8s/1.3.35"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig
@@ -509,7 +509,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.name
             - name: CI_VERSION
-              value: "k8s/1.3.34"
+              value: "k8s/1.3.35"
         resources:
             limits:
               memory: 200Mi

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart-enhanced.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart-enhanced.yaml
@@ -107,7 +107,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -134,7 +134,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.20"
+              value: "k8s/1.3.35"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig
@@ -598,7 +598,7 @@ spec:
                   name: cluster-info
                   key: cluster.name
             - name: CI_VERSION
-              value: "k8s/1.3.20"
+              value: "k8s/1.3.35"
             - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
               value: /^(?<time>.+) (?<stream>stdout|stderr) (?<logtag>[FP]) (?<log>.*)$/
           resources:

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
@@ -106,7 +106,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300056.0b1123
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -133,7 +133,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.34"
+              value: "k8s/1.3.35"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig
@@ -597,7 +597,7 @@ spec:
                   name: cluster-info
                   key: cluster.name
             - name: CI_VERSION
-              value: "k8s/1.3.34"
+              value: "k8s/1.3.35"
             - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
               value: /^(?<time>.+) (?<stream>stdout|stderr) (?<logtag>[FP]) (?<log>.*)$/
           resources:

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-fluentd-xray/cwagent-fluentd-xray-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-fluentd-xray/cwagent-fluentd-xray-quickstart.yaml
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           ports:
             - containerPort: 25888
               hostPort: 25888

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           imagePullPolicy: Always
           ports:
             - containerPort: 31000

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-statsd/cwagent-statsd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-statsd/cwagent-statsd.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           imagePullPolicy: Always
           ports:
             # containerPort should be consistent with the listen port defined in configmap

--- a/k8s-deployment-manifest-templates/deployment-mode/service/combination/combination.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/combination/combination.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-fargate.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-fargate.yaml
@@ -398,7 +398,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300056.0b1123
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           imagePullPolicy: Always
           resources:
             limits:
@@ -410,7 +410,7 @@ spec:
           # Please don't change below envs
           env:
             - name: CI_VERSION
-              value: "k8s/1.3.34"
+              value: "k8s/1.3.35"
             - name: RUN_IN_AWS
               value: "True"
           # Please don't change the mountPath

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-windows-exporter.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-windows-exporter.yaml
@@ -145,7 +145,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300056.0b1123
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           imagePullPolicy: Always
           resources:
             limits:
@@ -157,7 +157,7 @@ spec:
           # Please don't change below envs
           env:
             - name: CI_VERSION
-              value: "k8s/1.3.34"
+              value: "k8s/1.3.35"
           # Please don't change the mountPath
           volumeMounts:
             - name: prometheus-cwagentconfig

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
@@ -449,7 +449,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300056.0b1123
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           imagePullPolicy: Always
           resources:
             limits:
@@ -461,7 +461,7 @@ spec:
           # Please don't change below envs
           env:
             - name: CI_VERSION
-              value: "k8s/1.3.34"
+              value: "k8s/1.3.35"
           # Please don't change the mountPath
           volumeMounts:
             - name: prometheus-cwagentconfig

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-k8s.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-k8s.yaml
@@ -396,7 +396,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300056.0b1123
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           imagePullPolicy: Always
           resources:
             limits:
@@ -408,7 +408,7 @@ spec:
           # Please don't change below envs
           env:
             - name: CI_VERSION
-              value: "k8s/1.3.34"
+              value: "k8s/1.3.35"
           # Please don't change the mountPath
           volumeMounts:
             - name: prometheus-cwagentconfig

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
@@ -40,7 +40,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-statsd/cwagent-statsd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-statsd/cwagent-statsd.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/combination/combination.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/combination/combination.yaml
@@ -24,7 +24,7 @@ spec:
           - name: AWS_CSM_HOST
             value: "127.0.0.1"
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf.yaml
@@ -17,7 +17,7 @@ spec:
           image: <demo-app-docker-image> # this is the your demo app docker image
           imagePullPolicy: Always
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
@@ -42,7 +42,7 @@ spec:
     - name: AWS_CSM_HOST
       value: "127.0.0.1"
   - name: cloudwatch-agent
-    image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392
+    image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
     imagePullPolicy: Always
     resources:
       limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd.yaml
@@ -19,7 +19,7 @@ spec:
           args: ["-c", "while true; do echo 'statsdTestMetric:1|c' | socat -v -t 0 - UDP:127.0.0.1:8125; sleep 1; done"]
           imagePullPolicy: Always
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-quickstart/cwagent-custom-resource-definitions.yaml
+++ b/k8s-quickstart/cwagent-custom-resource-definitions.yaml
@@ -1,13 +1,10 @@
 ---
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.12.0
-  labels:
-    app.kubernetes.io/name: amazon-cloudwatch-agent-operator
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: amazoncloudwatchagents.cloudwatch.aws.amazon.com
 spec:
   group: cloudwatch.aws.amazon.com
@@ -50,14 +47,19 @@ spec:
             API.
           properties:
             apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
               type: string
             kind:
-              description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
               type: string
             metadata:
               type: object
@@ -65,51 +67,54 @@ spec:
               description: AmazonCloudWatchAgentSpec defines the desired state of AmazonCloudWatchAgent.
               properties:
                 additionalContainers:
-                  description: "AdditionalContainers allows injecting additional containers
-                  into the Collector's pod definition. These sidecar containers can
-                  be used for authentication proxies, log shipping sidecars, agents
-                  for shipping metrics to their cloud, or in general sidecars that
-                  do not support automatic injection. This option only applies to
-                  Deployment, DaemonSet, and StatefulSet deployment modes of the collector.
-                  It does not apply to the sidecar deployment mode. More info about
-                  sidecars: https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
-                  \n Container names managed by the operator: * `otc-container` \n
-                  Overriding containers managed by the operator is outside the scope
-                  of what the maintainers will support and by doing so, you wil accept
-                  the risk of it breaking things."
+                  description: |-
+                    AdditionalContainers allows injecting additional containers into the Collector's pod definition.
+                    These sidecar containers can be used for authentication proxies, log shipping sidecars, agents for shipping
+                    metrics to their cloud, or in general sidecars that do not support automatic injection. This option only
+                    applies to Deployment, DaemonSet, and StatefulSet deployment modes of the collector. It does not apply to the sidecar
+                    deployment mode. More info about sidecars:
+                    https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/
+                    
+                    
+                    Container names managed by the operator:
+                    * `otc-container`
+                    
+                    
+                    Overriding containers managed by the operator is outside the scope of what the maintainers will support and by
+                    doing so, you wil accept the risk of it breaking things.
                   items:
                     description: A single application container that you want to run
                       within a pod.
                     properties:
                       args:
-                        description: 'Arguments to the entrypoint. The container image''s
-                        CMD is used if this is not provided. Variable references $(VAR_NAME)
-                        are expanded using the container''s environment. If a variable
-                        cannot be resolved, the reference in the input string will
-                        be unchanged. Double $$ are reduced to a single $, which allows
-                        for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                        produce the string literal "$(VAR_NAME)". Escaped references
-                        will never be expanded, regardless of whether the variable
-                        exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: |-
+                          Arguments to the entrypoint.
+                          The container image's CMD is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          of whether the variable exists or not. Cannot be updated.
+                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                         items:
                           type: string
                         type: array
                       command:
-                        description: 'Entrypoint array. Not executed within a shell.
-                        The container image''s ENTRYPOINT is used if this is not provided.
-                        Variable references $(VAR_NAME) are expanded using the container''s
-                        environment. If a variable cannot be resolved, the reference
-                        in the input string will be unchanged. Double $$ are reduced
-                        to a single $, which allows for escaping the $(VAR_NAME) syntax:
-                        i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                        Escaped references will never be expanded, regardless of whether
-                        the variable exists or not. Cannot be updated. More info:
-                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: |-
+                          Entrypoint array. Not executed within a shell.
+                          The container image's ENTRYPOINT is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          of whether the variable exists or not. Cannot be updated.
+                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                         items:
                           type: string
                         type: array
                       env:
-                        description: List of environment variables to set in the container.
+                        description: |-
+                          List of environment variables to set in the container.
                           Cannot be updated.
                         items:
                           description: EnvVar represents an environment variable present
@@ -120,16 +125,16 @@ spec:
                                 a C_IDENTIFIER.
                               type: string
                             value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                              using the previously defined environment variables in
-                              the container and any service environment variables.
-                              If a variable cannot be resolved, the reference in the
-                              input string will be unchanged. Double $$ are reduced
-                              to a single $, which allows for escaping the $(VAR_NAME)
-                              syntax: i.e. "$$(VAR_NAME)" will produce the string
-                              literal "$(VAR_NAME)". Escaped references will never
-                              be expanded, regardless of whether the variable exists
-                              or not. Defaults to "".'
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -142,10 +147,10 @@ spec:
                                       description: The key to select.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: Specify whether the ConfigMap or
@@ -156,11 +161,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                  spec.serviceAccountName, status.hostIP, status.podIP,
-                                  status.podIPs.'
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
                                       description: Version of the schema the FieldPath
@@ -175,11 +178,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                  only resources limits and requests (limits.cpu,
-                                  limits.memory, limits.ephemeral-storage, requests.cpu,
-                                  requests.memory and requests.ephemeral-storage)
-                                  are currently supported.'
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
                                       description: 'Container name: required for volumes,
@@ -209,10 +210,10 @@ spec:
                                         be a valid secret key.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: Specify whether the Secret or its
@@ -228,13 +229,13 @@ spec:
                           type: object
                         type: array
                       envFrom:
-                        description: List of sources to populate environment variables
-                          in the container. The keys defined within a source must be
-                          a C_IDENTIFIER. All invalid keys will be reported as an event
-                          when the container is starting. When a key exists in multiple
-                          sources, the value associated with the last source will take
-                          precedence. Values defined by an Env with a duplicate key
-                          will take precedence. Cannot be updated.
+                        description: |-
+                          List of sources to populate environment variables in the container.
+                          The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                          will be reported as an event when the container is starting. When a key exists in multiple
+                          sources, the value associated with the last source will take precedence.
+                          Values defined by an Env with a duplicate key will take precedence.
+                          Cannot be updated.
                         items:
                           description: EnvFromSource represents the source of a set
                             of ConfigMaps
@@ -243,9 +244,10 @@ spec:
                               description: The ConfigMap to select from
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: Specify whether the ConfigMap must be
@@ -261,9 +263,10 @@ spec:
                               description: The Secret to select from
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: Specify whether the Secret must be defined
@@ -273,40 +276,42 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                        This field is optional to allow higher level config management
-                        to default or override container images in workload controllers
-                        like Deployments and StatefulSets.'
+                        description: |-
+                          Container image name.
+                          More info: https://kubernetes.io/docs/concepts/containers/images
+                          This field is optional to allow higher level config management to default or override
+                          container images in workload controllers like Deployments and StatefulSets.
                         type: string
                       imagePullPolicy:
-                        description: 'Image pull policy. One of Always, Never, IfNotPresent.
-                        Defaults to Always if :latest tag is specified, or IfNotPresent
-                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                        description: |-
+                          Image pull policy.
+                          One of Always, Never, IfNotPresent.
+                          Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                         type: string
                       lifecycle:
-                        description: Actions that the management system should take
-                          in response to container lifecycle events. Cannot be updated.
+                        description: |-
+                          Actions that the management system should take in response to container lifecycle events.
+                          Cannot be updated.
                         properties:
                           postStart:
-                            description: 'PostStart is called immediately after a container
-                            is created. If the handler fails, the container is terminated
-                            and restarted according to its restart policy. Other management
-                            of the container blocks until the hook completes. More
-                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            description: |-
+                              PostStart is called immediately after a container is created. If the handler fails,
+                              the container is terminated and restarted according to its restart policy.
+                              Other management of the container blocks until the hook completes.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                             properties:
                               exec:
                                 description: Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
@@ -315,9 +320,9 @@ spec:
                                 description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
                                     type: string
                                   httpHeaders:
                                     description: Custom headers to set in the request.
@@ -327,9 +332,9 @@ spec:
                                         to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name. This will
-                                            be canonicalized upon output, so case-variant
-                                            names will be understood as the same header.
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                           type: string
                                         value:
                                           description: The header field value
@@ -346,13 +351,15 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
@@ -370,10 +377,10 @@ spec:
                                   - seconds
                                 type: object
                               tcpSocket:
-                                description: Deprecated. TCPSocket is NOT supported
-                                  as a LifecycleHandler and kept for the backward compatibility.
-                                  There are no validation of this field and lifecycle
-                                  hooks will fail in runtime when tcp handler is specified.
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for the backward compatibility. There are no validation of this field and
+                                  lifecycle hooks will fail in runtime when tcp handler is specified.
                                 properties:
                                   host:
                                     description: 'Optional: Host name to connect to,
@@ -383,40 +390,37 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                             type: object
                           preStop:
-                            description: 'PreStop is called immediately before a container
-                            is terminated due to an API request or management event
-                            such as liveness/startup probe failure, preemption, resource
-                            contention, etc. The handler is not called if the container
-                            crashes or exits. The Pod''s termination grace period
-                            countdown begins before the PreStop hook is executed.
-                            Regardless of the outcome of the handler, the container
-                            will eventually terminate within the Pod''s termination
-                            grace period (unless delayed by finalizers). Other management
-                            of the container blocks until the hook completes or until
-                            the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            description: |-
+                              PreStop is called immediately before a container is terminated due to an
+                              API request or management event such as liveness/startup probe failure,
+                              preemption, resource contention, etc. The handler is not called if the
+                              container crashes or exits. The Pod's termination grace period countdown begins before the
+                              PreStop hook is executed. Regardless of the outcome of the handler, the
+                              container will eventually terminate within the Pod's termination grace
+                              period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                              or until the termination grace period is reached.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                             properties:
                               exec:
                                 description: Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
@@ -425,9 +429,9 @@ spec:
                                 description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
                                     type: string
                                   httpHeaders:
                                     description: Custom headers to set in the request.
@@ -437,9 +441,9 @@ spec:
                                         to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name. This will
-                                            be canonicalized upon output, so case-variant
-                                            names will be understood as the same header.
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                           type: string
                                         value:
                                           description: The header field value
@@ -456,13 +460,15 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
@@ -480,10 +486,10 @@ spec:
                                   - seconds
                                 type: object
                               tcpSocket:
-                                description: Deprecated. TCPSocket is NOT supported
-                                  as a LifecycleHandler and kept for the backward compatibility.
-                                  There are no validation of this field and lifecycle
-                                  hooks will fail in runtime when tcp handler is specified.
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for the backward compatibility. There are no validation of this field and
+                                  lifecycle hooks will fail in runtime when tcp handler is specified.
                                 properties:
                                   host:
                                     description: 'Optional: Host name to connect to,
@@ -493,9 +499,10 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
@@ -503,30 +510,30 @@ spec:
                             type: object
                         type: object
                       livenessProbe:
-                        description: 'Periodic probe of container liveness. Container
-                        will be restarted if the probe fails. Cannot be updated. More
-                        info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        description: |-
+                          Periodic probe of container liveness.
+                          Container will be restarted if the probe fails.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
                             description: Exec specifies the action to take.
                             properties:
                               command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|', etc)
-                                  won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
                           grpc:
@@ -538,10 +545,12 @@ spec:
                                 format: int32
                                 type: integer
                               service:
-                                description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                  
+                                  
+                                  If this is not specified, the default behavior is defined by gRPC.
                                 type: string
                             required:
                               - port
@@ -550,9 +559,9 @@ spec:
                             description: HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description: Host name to connect to, defaults to the
-                                  pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
                                 description: Custom headers to set in the request. HTTP
@@ -562,9 +571,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name. This will
-                                        be canonicalized upon output, so case-variant
-                                        names will be understood as the same header.
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -581,33 +590,35 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Name or number of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description: Scheme to use for connecting to the host.
+                                description: |-
+                                  Scheme to use for connecting to the host.
                                   Defaults to HTTP.
                                 type: string
                             required:
                               - port
                             type: object
                           initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                           periodSeconds:
-                            description: How often (in seconds) to perform the probe.
+                            description: |-
+                              How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                             format: int32
                             type: integer
                           successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                             format: int32
                             type: integer
                           tcpSocket:
@@ -622,78 +633,82 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Number or name of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                               - port
                             type: object
                           terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully upon probe failure. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and the
-                              time when the processes are forcibly halted with a kill
-                              signal. Set this value longer than the expected cleanup
-                              time for your process. If this value is nil, the pod's
-                              terminationGracePeriodSeconds will be used. Otherwise,
-                              this value overrides the value provided by the pod spec.
-                              Value must be non-negative integer. The value zero indicates
-                              stop immediately via the kill signal (no opportunity to
-                              shut down). This is a beta field and requires enabling
-                              ProbeTerminationGracePeriod feature gate. Minimum value
-                              is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            description: |-
+                              Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                              The grace period is the duration in seconds after the processes running in the pod are sent
+                              a termination signal and the time when the processes are forcibly halted with a kill signal.
+                              Set this value longer than the expected cleanup time for your process.
+                              If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                              value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates stop immediately via
+                              the kill signal (no opportunity to shut down).
+                              This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                              Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                             format: int64
                             type: integer
                           timeoutSeconds:
-                            description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                         type: object
                       name:
-                        description: Name of the container specified as a DNS_LABEL.
+                        description: |-
+                          Name of the container specified as a DNS_LABEL.
                           Each container in a pod must have a unique name (DNS_LABEL).
                           Cannot be updated.
                         type: string
                       ports:
-                        description: List of ports to expose from the container. Not
-                          specifying a port here DOES NOT prevent that port from being
-                          exposed. Any port which is listening on the default "0.0.0.0"
-                          address inside a container will be accessible from the network.
-                          Modifying this array with strategic merge patch may corrupt
-                          the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                        description: |-
+                          List of ports to expose from the container. Not specifying a port here
+                          DOES NOT prevent that port from being exposed. Any port which is
+                          listening on the default "0.0.0.0" address inside a container will be
+                          accessible from the network.
+                          Modifying this array with strategic merge patch may corrupt the data.
+                          For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                           Cannot be updated.
                         items:
                           description: ContainerPort represents a network port in a
                             single container.
                           properties:
                             containerPort:
-                              description: Number of port to expose on the pod's IP
-                                address. This must be a valid port number, 0 < x < 65536.
+                              description: |-
+                                Number of port to expose on the pod's IP address.
+                                This must be a valid port number, 0 < x < 65536.
                               format: int32
                               type: integer
                             hostIP:
                               description: What host IP to bind the external port to.
                               type: string
                             hostPort:
-                              description: Number of port to expose on the host. If
-                                specified, this must be a valid port number, 0 < x <
-                                65536. If HostNetwork is specified, this must match
-                                ContainerPort. Most containers do not need this.
+                              description: |-
+                                Number of port to expose on the host.
+                                If specified, this must be a valid port number, 0 < x < 65536.
+                                If HostNetwork is specified, this must match ContainerPort.
+                                Most containers do not need this.
                               format: int32
                               type: integer
                             name:
-                              description: If specified, this must be an IANA_SVC_NAME
-                                and unique within the pod. Each named port in a pod
-                                must have a unique name. Name for the port that can
-                                be referred to by services.
+                              description: |-
+                                If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                named port in a pod must have a unique name. Name for the port that can be
+                                referred to by services.
                               type: string
                             protocol:
                               default: TCP
-                              description: Protocol for port. Must be UDP, TCP, or SCTP.
+                              description: |-
+                                Protocol for port. Must be UDP, TCP, or SCTP.
                                 Defaults to "TCP".
                               type: string
                           required:
@@ -705,30 +720,30 @@ spec:
                           - protocol
                         x-kubernetes-list-type: map
                       readinessProbe:
-                        description: 'Periodic probe of container service readiness.
-                        Container will be removed from service endpoints if the probe
-                        fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        description: |-
+                          Periodic probe of container service readiness.
+                          Container will be removed from service endpoints if the probe fails.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
                             description: Exec specifies the action to take.
                             properties:
                               command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|', etc)
-                                  won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
                           grpc:
@@ -740,10 +755,12 @@ spec:
                                 format: int32
                                 type: integer
                               service:
-                                description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                  
+                                  
+                                  If this is not specified, the default behavior is defined by gRPC.
                                 type: string
                             required:
                               - port
@@ -752,9 +769,9 @@ spec:
                             description: HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description: Host name to connect to, defaults to the
-                                  pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
                                 description: Custom headers to set in the request. HTTP
@@ -764,9 +781,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name. This will
-                                        be canonicalized upon output, so case-variant
-                                        names will be understood as the same header.
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -783,33 +800,35 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Name or number of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description: Scheme to use for connecting to the host.
+                                description: |-
+                                  Scheme to use for connecting to the host.
                                   Defaults to HTTP.
                                 type: string
                             required:
                               - port
                             type: object
                           initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                           periodSeconds:
-                            description: How often (in seconds) to perform the probe.
+                            description: |-
+                              How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                             format: int32
                             type: integer
                           successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                             format: int32
                             type: integer
                           tcpSocket:
@@ -824,34 +843,33 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Number or name of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                               - port
                             type: object
                           terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully upon probe failure. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and the
-                              time when the processes are forcibly halted with a kill
-                              signal. Set this value longer than the expected cleanup
-                              time for your process. If this value is nil, the pod's
-                              terminationGracePeriodSeconds will be used. Otherwise,
-                              this value overrides the value provided by the pod spec.
-                              Value must be non-negative integer. The value zero indicates
-                              stop immediately via the kill signal (no opportunity to
-                              shut down). This is a beta field and requires enabling
-                              ProbeTerminationGracePeriod feature gate. Minimum value
-                              is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            description: |-
+                              Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                              The grace period is the duration in seconds after the processes running in the pod are sent
+                              a termination signal and the time when the processes are forcibly halted with a kill signal.
+                              Set this value longer than the expected cleanup time for your process.
+                              If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                              value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates stop immediately via
+                              the kill signal (no opportunity to shut down).
+                              This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                              Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                             format: int64
                             type: integer
                           timeoutSeconds:
-                            description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                         type: object
@@ -862,12 +880,14 @@ spec:
                             policy for the container.
                           properties:
                             resourceName:
-                              description: 'Name of the resource to which this resource
-                              resize policy applies. Supported values: cpu, memory.'
+                              description: |-
+                                Name of the resource to which this resource resize policy applies.
+                                Supported values: cpu, memory.
                               type: string
                             restartPolicy:
-                              description: Restart policy to apply when specified resource
-                                is resized. If not specified, it defaults to NotRequired.
+                              description: |-
+                                Restart policy to apply when specified resource is resized.
+                                If not specified, it defaults to NotRequired.
                               type: string
                           required:
                             - resourceName
@@ -876,22 +896,29 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       resources:
-                        description: 'Compute Resources required by this container.
-                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this container.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                            in spec.resourceClaims, that are used by this container.
-                            \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                            feature gate. \n This field is immutable. It can only
-                            be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+                              
+                              
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+                              
+                              
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -908,8 +935,9 @@ spec:
                                 - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -918,52 +946,52 @@ spec:
                                 - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests
-                            cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       restartPolicy:
-                        description: 'RestartPolicy defines the restart behavior of
-                        individual containers in a pod. This field may only be set
-                        for init containers, and the only allowed value is "Always".
-                        For non-init containers or when this field is not specified,
-                        the restart behavior is defined by the Pod''s restart policy
-                        and the container type. Setting the RestartPolicy as "Always"
-                        for the init container will have the following effect: this
-                        init container will be continually restarted on exit until
-                        all regular containers have terminated. Once all regular containers
-                        have completed, all init containers with restartPolicy "Always"
-                        will be shut down. This lifecycle differs from normal init
-                        containers and is often referred to as a "sidecar" container.
-                        Although this init container still starts in the init container
-                        sequence, it does not wait for the container to complete before
-                        proceeding to the next init container. Instead, the next init
-                        container starts immediately after this init container is
-                        started, or after any startupProbe has successfully completed.'
+                        description: |-
+                          RestartPolicy defines the restart behavior of individual containers in a pod.
+                          This field may only be set for init containers, and the only allowed value is "Always".
+                          For non-init containers or when this field is not specified,
+                          the restart behavior is defined by the Pod's restart policy and the container type.
+                          Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                          this init container will be continually restarted on
+                          exit until all regular containers have terminated. Once all regular
+                          containers have completed, all init containers with restartPolicy "Always"
+                          will be shut down. This lifecycle differs from normal init containers and
+                          is often referred to as a "sidecar" container. Although this init
+                          container still starts in the init container sequence, it does not wait
+                          for the container to complete before proceeding to the next init
+                          container. Instead, the next init container starts immediately after this
+                          init container is started, or after any startupProbe has successfully
+                          completed.
                         type: string
                       securityContext:
-                        description: 'SecurityContext defines the security options the
-                        container should be run with. If set, the fields of SecurityContext
-                        override the equivalent fields of PodSecurityContext. More
-                        info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                        description: |-
+                          SecurityContext defines the security options the container should be run with.
+                          If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                         properties:
                           allowPrivilegeEscalation:
-                            description: 'AllowPrivilegeEscalation controls whether
-                            a process can gain more privileges than its parent process.
-                            This bool directly controls if the no_new_privs flag will
-                            be set on the container process. AllowPrivilegeEscalation
-                            is true always when the container is: 1) run as Privileged
-                            2) has CAP_SYS_ADMIN Note that this field cannot be set
-                            when spec.os.name is windows.'
+                            description: |-
+                              AllowPrivilegeEscalation controls whether a process can gain more
+                              privileges than its parent process. This bool directly controls if
+                              the no_new_privs flag will be set on the container process.
+                              AllowPrivilegeEscalation is true always when the container is:
+                              1) run as Privileged
+                              2) has CAP_SYS_ADMIN
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           capabilities:
-                            description: The capabilities to add/drop when running containers.
-                              Defaults to the default set of capabilities granted by
-                              the container runtime. Note that this field cannot be
-                              set when spec.os.name is windows.
+                            description: |-
+                              The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the container runtime.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               add:
                                 description: Added capabilities
@@ -981,60 +1009,60 @@ spec:
                                 type: array
                             type: object
                           privileged:
-                            description: Run container in privileged mode. Processes
-                              in privileged containers are essentially equivalent to
-                              root on the host. Defaults to false. Note that this field
-                              cannot be set when spec.os.name is windows.
+                            description: |-
+                              Run container in privileged mode.
+                              Processes in privileged containers are essentially equivalent to root on the host.
+                              Defaults to false.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           procMount:
-                            description: procMount denotes the type of proc mount to
-                              use for the containers. The default is DefaultProcMount
-                              which uses the container runtime defaults for readonly
-                              paths and masked paths. This requires the ProcMountType
-                              feature flag to be enabled. Note that this field cannot
-                              be set when spec.os.name is windows.
+                            description: |-
+                              procMount denotes the type of proc mount to use for the containers.
+                              The default is DefaultProcMount which uses the container runtime defaults for
+                              readonly paths and masked paths.
+                              This requires the ProcMountType feature flag to be enabled.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
-                            description: Whether this container has a read-only root
-                              filesystem. Default is false. Note that this field cannot
-                              be set when spec.os.name is windows.
+                            description: |-
+                              Whether this container has a read-only root filesystem.
+                              Default is false.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           runAsGroup:
-                            description: The GID to run the entrypoint of the container
-                              process. Uses runtime default if unset. May also be set
-                              in PodSecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence. Note that this field cannot be set when
-                              spec.os.name is windows.
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           runAsNonRoot:
-                            description: Indicates that the container must run as a
-                              non-root user. If true, the Kubelet will validate the
-                              image at runtime to ensure that it does not run as UID
-                              0 (root) and fail to start the container if it does. If
-                              unset or false, no such validation will be performed.
-                              May also be set in PodSecurityContext.  If set in both
-                              SecurityContext and PodSecurityContext, the value specified
-                              in SecurityContext takes precedence.
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: boolean
                           runAsUser:
-                            description: The UID to run the entrypoint of the container
-                              process. Defaults to user specified in image metadata
-                              if unspecified. May also be set in PodSecurityContext.  If
-                              set in both SecurityContext and PodSecurityContext, the
-                              value specified in SecurityContext takes precedence. Note
-                              that this field cannot be set when spec.os.name is windows.
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           seLinuxOptions:
-                            description: The SELinux context to be applied to the container.
-                              If unspecified, the container runtime will allocate a
-                              random SELinux context for each container.  May also be
-                              set in PodSecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence. Note that this field cannot be set when
-                              spec.os.name is windows.
+                            description: |-
+                              The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random SELinux context for each
+                              container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               level:
                                 description: Level is SELinux level label that applies
@@ -1054,98 +1082,93 @@ spec:
                                 type: string
                             type: object
                           seccompProfile:
-                            description: The seccomp options to use by this container.
-                              If seccomp options are provided at both the pod & container
-                              level, the container options override the pod options.
-                              Note that this field cannot be set when spec.os.name is
-                              windows.
+                            description: |-
+                              The seccomp options to use by this container. If seccomp options are
+                              provided at both the pod & container level, the container options
+                              override the pod options.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               localhostProfile:
-                                description: localhostProfile indicates a profile defined
-                                  in a file on the node should be used. The profile
-                                  must be preconfigured on the node to work. Must be
-                                  a descending path, relative to the kubelet's configured
-                                  seccomp profile location. Must be set if type is "Localhost".
-                                  Must NOT be set for any other type.
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must be set if type is "Localhost". Must NOT be set for any other type.
                                 type: string
                               type:
-                                description: "type indicates which kind of seccomp profile
-                                will be applied. Valid options are: \n Localhost -
-                                a profile defined in a file on the node should be
-                                used. RuntimeDefault - the container runtime default
-                                profile should be used. Unconfined - no profile should
-                                be applied."
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+                                  
+                                  
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
                                 type: string
                             required:
                               - type
                             type: object
                           windowsOptions:
-                            description: The Windows specific settings applied to all
-                              containers. If unspecified, the options from the PodSecurityContext
-                              will be used. If set in both SecurityContext and PodSecurityContext,
-                              the value specified in SecurityContext takes precedence.
-                              Note that this field cannot be set when spec.os.name is
-                              linux.
+                            description: |-
+                              The Windows specific settings applied to all containers.
+                              If unspecified, the options from the PodSecurityContext will be used.
+                              If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is linux.
                             properties:
                               gmsaCredentialSpec:
-                                description: GMSACredentialSpec is where the GMSA admission
-                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                  inlines the contents of the GMSA credential spec named
-                                  by the GMSACredentialSpecName field.
+                                description: |-
+                                  GMSACredentialSpec is where the GMSA admission webhook
+                                  (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                  GMSA credential spec named by the GMSACredentialSpecName field.
                                 type: string
                               gmsaCredentialSpecName:
                                 description: GMSACredentialSpecName is the name of the
                                   GMSA credential spec to use.
                                 type: string
                               hostProcess:
-                                description: HostProcess determines if a container should
-                                  be run as a 'Host Process' container. All of a Pod's
-                                  containers must have the same effective HostProcess
-                                  value (it is not allowed to have a mix of HostProcess
-                                  containers and non-HostProcess containers). In addition,
-                                  if HostProcess is true then HostNetwork must also
-                                  be set to true.
+                                description: |-
+                                  HostProcess determines if a container should be run as a 'Host Process' container.
+                                  All of a Pod's containers must have the same effective HostProcess value
+                                  (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork must also be set to true.
                                 type: boolean
                               runAsUserName:
-                                description: The UserName in Windows to run the entrypoint
-                                  of the container process. Defaults to the user specified
-                                  in image metadata if unspecified. May also be set
-                                  in PodSecurityContext. If set in both SecurityContext
-                                  and PodSecurityContext, the value specified in SecurityContext
-                                  takes precedence.
+                                description: |-
+                                  The UserName in Windows to run the entrypoint of the container process.
+                                  Defaults to the user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: string
                             type: object
                         type: object
                       startupProbe:
-                        description: 'StartupProbe indicates that the Pod has successfully
-                        initialized. If specified, no other probes are executed until
-                        this completes successfully. If this probe fails, the Pod
-                        will be restarted, just as if the livenessProbe failed. This
-                        can be used to provide different probe parameters at the beginning
-                        of a Pod''s lifecycle, when it might take a long time to load
-                        data or warm a cache, than during steady-state operation.
-                        This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        description: |-
+                          StartupProbe indicates that the Pod has successfully initialized.
+                          If specified, no other probes are executed until this completes successfully.
+                          If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                          This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                          when it might take a long time to load data or warm a cache, than during steady-state operation.
+                          This cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
                             description: Exec specifies the action to take.
                             properties:
                               command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|', etc)
-                                  won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
                           grpc:
@@ -1157,10 +1180,12 @@ spec:
                                 format: int32
                                 type: integer
                               service:
-                                description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                  
+                                  
+                                  If this is not specified, the default behavior is defined by gRPC.
                                 type: string
                             required:
                               - port
@@ -1169,9 +1194,9 @@ spec:
                             description: HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description: Host name to connect to, defaults to the
-                                  pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
                                 description: Custom headers to set in the request. HTTP
@@ -1181,9 +1206,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name. This will
-                                        be canonicalized upon output, so case-variant
-                                        names will be understood as the same header.
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -1200,33 +1225,35 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Name or number of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description: Scheme to use for connecting to the host.
+                                description: |-
+                                  Scheme to use for connecting to the host.
                                   Defaults to HTTP.
                                 type: string
                             required:
                               - port
                             type: object
                           initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                           periodSeconds:
-                            description: How often (in seconds) to perform the probe.
+                            description: |-
+                              How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                             format: int32
                             type: integer
                           successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                             format: int32
                             type: integer
                           tcpSocket:
@@ -1241,77 +1268,76 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Number or name of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                               - port
                             type: object
                           terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully upon probe failure. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and the
-                              time when the processes are forcibly halted with a kill
-                              signal. Set this value longer than the expected cleanup
-                              time for your process. If this value is nil, the pod's
-                              terminationGracePeriodSeconds will be used. Otherwise,
-                              this value overrides the value provided by the pod spec.
-                              Value must be non-negative integer. The value zero indicates
-                              stop immediately via the kill signal (no opportunity to
-                              shut down). This is a beta field and requires enabling
-                              ProbeTerminationGracePeriod feature gate. Minimum value
-                              is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            description: |-
+                              Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                              The grace period is the duration in seconds after the processes running in the pod are sent
+                              a termination signal and the time when the processes are forcibly halted with a kill signal.
+                              Set this value longer than the expected cleanup time for your process.
+                              If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                              value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates stop immediately via
+                              the kill signal (no opportunity to shut down).
+                              This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                              Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                             format: int64
                             type: integer
                           timeoutSeconds:
-                            description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                         type: object
                       stdin:
-                        description: Whether this container should allocate a buffer
-                          for stdin in the container runtime. If this is not set, reads
-                          from stdin in the container will always result in EOF. Default
-                          is false.
+                        description: |-
+                          Whether this container should allocate a buffer for stdin in the container runtime. If this
+                          is not set, reads from stdin in the container will always result in EOF.
+                          Default is false.
                         type: boolean
                       stdinOnce:
-                        description: Whether the container runtime should close the
-                          stdin channel after it has been opened by a single attach.
-                          When stdin is true the stdin stream will remain open across
-                          multiple attach sessions. If stdinOnce is set to true, stdin
-                          is opened on container start, is empty until the first client
-                          attaches to stdin, and then remains open and accepts data
-                          until the client disconnects, at which time stdin is closed
-                          and remains closed until the container is restarted. If this
-                          flag is false, a container processes that reads from stdin
-                          will never receive an EOF. Default is false
+                        description: |-
+                          Whether the container runtime should close the stdin channel after it has been opened by
+                          a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                          sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                          first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                          at which time stdin is closed and remains closed until the container is restarted. If this
+                          flag is false, a container processes that reads from stdin will never receive an EOF.
+                          Default is false
                         type: boolean
                       terminationMessagePath:
-                        description: 'Optional: Path at which the file to which the
-                        container''s termination message will be written is mounted
-                        into the container''s filesystem. Message written is intended
-                        to be brief final status, such as an assertion failure message.
-                        Will be truncated by the node if greater than 4096 bytes.
-                        The total message length across all containers will be limited
-                        to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                        description: |-
+                          Optional: Path at which the file to which the container's termination message
+                          will be written is mounted into the container's filesystem.
+                          Message written is intended to be brief final status, such as an assertion failure message.
+                          Will be truncated by the node if greater than 4096 bytes. The total message length across
+                          all containers will be limited to 12kb.
+                          Defaults to /dev/termination-log.
+                          Cannot be updated.
                         type: string
                       terminationMessagePolicy:
-                        description: Indicate how the termination message should be
-                          populated. File will use the contents of terminationMessagePath
-                          to populate the container status message on both success and
-                          failure. FallbackToLogsOnError will use the last chunk of
-                          container log output if the termination message file is empty
-                          and the container exited with an error. The log output is
-                          limited to 2048 bytes or 80 lines, whichever is smaller. Defaults
-                          to File. Cannot be updated.
+                        description: |-
+                          Indicate how the termination message should be populated. File will use the contents of
+                          terminationMessagePath to populate the container status message on both success and failure.
+                          FallbackToLogsOnError will use the last chunk of container log output if the termination
+                          message file is empty and the container exited with an error.
+                          The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                          Defaults to File.
+                          Cannot be updated.
                         type: string
                       tty:
-                        description: Whether this container should allocate a TTY for
-                          itself, also requires 'stdin' to be true. Default is false.
+                        description: |-
+                          Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                          Default is false.
                         type: boolean
                       volumeDevices:
                         description: volumeDevices is the list of block devices to be
@@ -1334,40 +1360,44 @@ spec:
                           type: object
                         type: array
                       volumeMounts:
-                        description: Pod volumes to mount into the container's filesystem.
+                        description: |-
+                          Pod volumes to mount into the container's filesystem.
                           Cannot be updated.
                         items:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
                           properties:
                             mountPath:
-                              description: Path within the container at which the volume
-                                should be mounted.  Must not contain ':'.
+                              description: |-
+                                Path within the container at which the volume should be mounted.  Must
+                                not contain ':'.
                               type: string
                             mountPropagation:
-                              description: mountPropagation determines how mounts are
-                                propagated from the host to container and the other
-                                way around. When not set, MountPropagationNone is used.
+                              description: |-
+                                mountPropagation determines how mounts are propagated from the host
+                                to container and the other way around.
+                                When not set, MountPropagationNone is used.
                                 This field is beta in 1.10.
                               type: string
                             name:
                               description: This must match the Name of a Volume.
                               type: string
                             readOnly:
-                              description: Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
+                              description: |-
+                                Mounted read-only if true, read-write otherwise (false or unspecified).
+                                Defaults to false.
                               type: boolean
                             subPath:
-                              description: Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's root).
+                              description: |-
+                                Path within the volume from which the container's volume should be mounted.
+                                Defaults to "" (volume's root).
                               type: string
                             subPathExpr:
-                              description: Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves similarly
-                                to SubPath but environment variable references $(VAR_NAME)
-                                are expanded using the container's environment. Defaults
-                                to "" (volume's root). SubPathExpr and SubPath are mutually
-                                exclusive.
+                              description: |-
+                                Expanded path within the volume from which the container's volume should be mounted.
+                                Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                Defaults to "" (volume's root).
+                                SubPathExpr and SubPath are mutually exclusive.
                               type: string
                           required:
                             - mountPath
@@ -1375,9 +1405,11 @@ spec:
                           type: object
                         type: array
                       workingDir:
-                        description: Container's working directory. If not specified,
-                          the container runtime's default will be used, which might
-                          be configured in the container image. Cannot be updated.
+                        description: |-
+                          Container's working directory.
+                          If not specified, the container runtime's default will be used, which
+                          might be configured in the container image.
+                          Cannot be updated.
                         type: string
                     required:
                       - name
@@ -1391,22 +1423,20 @@ spec:
                         pod.
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to
-                            nodes that satisfy the affinity expressions specified by
-                            this field, but it may choose a node that violates one or
-                            more of the expressions. The node that is most preferred
-                            is the one with the greatest sum of weights, i.e. for each
-                            node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements of
-                            this field and adding "weight" to the sum if the node matches
-                            the corresponding matchExpressions; the node(s) with the
-                            highest sum are the most preferred.
+                          description: |-
+                            The scheduler will prefer to schedule pods to nodes that satisfy
+                            the affinity expressions specified by this field, but it may choose
+                            a node that violates one or more of the expressions. The node that is
+                            most preferred is the one with the greatest sum of weights, i.e.
+                            for each node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling affinity expressions, etc.),
+                            compute a sum by iterating through the elements of this field and adding
+                            "weight" to the sum if the node matches the corresponding matchExpressions; the
+                            node(s) with the highest sum are the most preferred.
                           items:
-                            description: An empty preferred scheduling term matches
-                              all objects with implicit weight 0 (i.e. it's a no-op).
-                              A null preferred scheduling term matches no objects (i.e.
-                              is also a no-op).
+                            description: |-
+                              An empty preferred scheduling term matches all objects with implicit weight 0
+                              (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
                             properties:
                               preference:
                                 description: A node selector term, associated with the
@@ -1416,30 +1446,26 @@ spec:
                                     description: A list of node selector requirements
                                       by node's labels.
                                     items:
-                                      description: A node selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
                                       properties:
                                         key:
                                           description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
                                         values:
-                                          description: An array of string values. If
-                                            the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values array
-                                            must be empty. If the operator is Gt or
-                                            Lt, the values array must have a single
-                                            element, which will be interpreted as an
-                                            integer. This array is replaced during a
-                                            strategic merge patch.
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -1452,30 +1478,26 @@ spec:
                                     description: A list of node selector requirements
                                       by node's fields.
                                     items:
-                                      description: A node selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
                                       properties:
                                         key:
                                           description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
                                         values:
-                                          description: An array of string values. If
-                                            the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values array
-                                            must be empty. If the operator is Gt or
-                                            Lt, the values array must have a single
-                                            element, which will be interpreted as an
-                                            integer. This array is replaced during a
-                                            strategic merge patch.
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -1497,50 +1519,46 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not be
-                            scheduled onto the node. If the affinity requirements specified
-                            by this field cease to be met at some point during pod execution
-                            (e.g. due to an update), the system may or may not try to
-                            eventually evict the pod from its node.
+                          description: |-
+                            If the affinity requirements specified by this field are not met at
+                            scheduling time, the pod will not be scheduled onto the node.
+                            If the affinity requirements specified by this field cease to be met
+                            at some point during pod execution (e.g. due to an update), the system
+                            may or may not try to eventually evict the pod from its node.
                           properties:
                             nodeSelectorTerms:
                               description: Required. A list of node selector terms.
                                 The terms are ORed.
                               items:
-                                description: A null or empty node selector term matches
-                                  no objects. The requirements of them are ANDed. The
-                                  TopologySelectorTerm type implements a subset of the
-                                  NodeSelectorTerm.
+                                description: |-
+                                  A null or empty node selector term matches no objects. The requirements of
+                                  them are ANDed.
+                                  The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
                                 properties:
                                   matchExpressions:
                                     description: A list of node selector requirements
                                       by node's labels.
                                     items:
-                                      description: A node selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
                                       properties:
                                         key:
                                           description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
                                         values:
-                                          description: An array of string values. If
-                                            the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values array
-                                            must be empty. If the operator is Gt or
-                                            Lt, the values array must have a single
-                                            element, which will be interpreted as an
-                                            integer. This array is replaced during a
-                                            strategic merge patch.
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -1553,30 +1571,26 @@ spec:
                                     description: A list of node selector requirements
                                       by node's fields.
                                     items:
-                                      description: A node selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A node selector requirement is a selector that contains values, a key, and an operator
+                                        that relates the key and values.
                                       properties:
                                         key:
                                           description: The label key that the selector
                                             applies to.
                                           type: string
                                         operator:
-                                          description: Represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists, DoesNotExist. Gt, and
-                                            Lt.
+                                          description: |-
+                                            Represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
                                           type: string
                                         values:
-                                          description: An array of string values. If
-                                            the operator is In or NotIn, the values
-                                            array must be non-empty. If the operator
-                                            is Exists or DoesNotExist, the values array
-                                            must be empty. If the operator is Gt or
-                                            Lt, the values array must have a single
-                                            element, which will be interpreted as an
-                                            integer. This array is replaced during a
-                                            strategic merge patch.
+                                          description: |-
+                                            An array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. If the operator is Gt or Lt, the values
+                                            array must have a single element, which will be interpreted as an integer.
+                                            This array is replaced during a strategic merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -1598,16 +1612,15 @@ spec:
                         this pod in the same node, zone, etc. as some other pod(s)).
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to
-                            nodes that satisfy the affinity expressions specified by
-                            this field, but it may choose a node that violates one or
-                            more of the expressions. The node that is most preferred
-                            is the one with the greatest sum of weights, i.e. for each
-                            node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling affinity expressions,
-                            etc.), compute a sum by iterating through the elements of
-                            this field and adding "weight" to the sum if the node has
-                            pods which matches the corresponding podAffinityTerm; the
+                          description: |-
+                            The scheduler will prefer to schedule pods to nodes that satisfy
+                            the affinity expressions specified by this field, but it may choose
+                            a node that violates one or more of the expressions. The node that is
+                            most preferred is the one with the greatest sum of weights, i.e.
+                            for each node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling affinity expressions, etc.),
+                            compute a sum by iterating through the elements of this field and adding
+                            "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                             node(s) with the highest sum are the most preferred.
                           items:
                             description: The weights of all of the matched WeightedPodAffinityTerm
@@ -1618,37 +1631,33 @@ spec:
                                   with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods. If it's null, this PodAffinityTerm
-                                      matches with no Pods.
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label
                                           selector requirements. The requirements are
                                           ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -1661,89 +1670,74 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label
-                                      keys to select which pods will be taken into consideration.
-                                      The keys are used to lookup values from the incoming
-                                      pod labels, those key-value labels are merged
-                                      with `LabelSelector` as `key in (value)` to select
-                                      the group of existing pods which pods will be
-                                      taken into consideration for the incoming pod's
-                                      pod (anti) affinity. Keys that don't exist in
-                                      the incoming pod labels will be ignored. The default
-                                      value is empty. The same key is forbidden to exist
-                                      in both MatchLabelKeys and LabelSelector. Also,
-                                      MatchLabelKeys cannot be set when LabelSelector
-                                      isn't set. This is an alpha field and requires
-                                      enabling MatchLabelKeysInPodAffinity feature gate.
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                      Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label
-                                      keys to select which pods will be taken into consideration.
-                                      The keys are used to lookup values from the incoming
-                                      pod labels, those key-value labels are merged
-                                      with `LabelSelector` as `key notin (value)` to
-                                      select the group of existing pods which pods will
-                                      be taken into consideration for the incoming pod's
-                                      pod (anti) affinity. Keys that don't exist in
-                                      the incoming pod labels will be ignored. The default
-                                      value is empty. The same key is forbidden to exist
-                                      in both MismatchLabelKeys and LabelSelector. Also,
-                                      MismatchLabelKeys cannot be set when LabelSelector
-                                      isn't set. This is an alpha field and requires
-                                      enabling MatchLabelKeysInPodAffinity feature gate.
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                      Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces
-                                      that the term applies to. The term is applied
-                                      to the union of the namespaces selected by this
-                                      field and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list
-                                      means "this pod's namespace". An empty selector
-                                      ({}) matches all namespaces.
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label
                                           selector requirements. The requirements are
                                           ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -1756,40 +1750,37 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list
-                                      of namespace names that the term applies to. The
-                                      term is applied to the union of the namespaces
-                                      listed in this field and the ones selected by
-                                      namespaceSelector. null or empty namespaces list
-                                      and null namespaceSelector means "this pod's namespace".
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
                                 type: object
                               weight:
-                                description: weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
+                                description: |-
+                                  weight associated with matching the corresponding podAffinityTerm,
+                                  in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -1798,53 +1789,51 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the affinity requirements specified by this
-                            field are not met at scheduling time, the pod will not be
-                            scheduled onto the node. If the affinity requirements specified
-                            by this field cease to be met at some point during pod execution
-                            (e.g. due to a pod label update), the system may or may
-                            not try to eventually evict the pod from its node. When
-                            there are multiple elements, the lists of nodes corresponding
-                            to each podAffinityTerm are intersected, i.e. all terms
-                            must be satisfied.
+                          description: |-
+                            If the affinity requirements specified by this field are not met at
+                            scheduling time, the pod will not be scheduled onto the node.
+                            If the affinity requirements specified by this field cease to be met
+                            at some point during pod execution (e.g. due to a pod label update), the
+                            system may or may not try to eventually evict the pod from its node.
+                            When there are multiple elements, the lists of nodes corresponding to each
+                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
                           items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not co-located
-                              (anti-affinity) with, where co-located is defined as running
-                              on a node whose value of the label with key <topologyKey>
-                              matches that of any node on which a pod of the set of
-                              pods is running
+                            description: |-
+                              Defines a set of pods (namely those matching the labelSelector
+                              relative to the given namespace(s)) that this pod should be
+                              co-located (affinity) or not co-located (anti-affinity) with,
+                              where co-located is defined as running on a node whose value of
+                              the label with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
                             properties:
                               labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods. If it's null, this PodAffinityTerm
-                                  matches with no Pods.
+                                description: |-
+                                  A label query over a set of resources, in this case pods.
+                                  If it's null, this PodAffinityTerm matches with no Pods.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
                                       selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
                                       properties:
                                         key:
                                           description: key is the label key that the
                                             selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists and DoesNotExist.
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist, the
-                                            values array must be empty. This array is
-                                            replaced during a strategic merge patch.
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -1856,84 +1845,74 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value". The
-                                      requirements are ANDed.
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys
-                                  to select which pods will be taken into consideration.
-                                  The keys are used to lookup values from the incoming
-                                  pod labels, those key-value labels are merged with
-                                  `LabelSelector` as `key in (value)` to select the
-                                  group of existing pods which pods will be taken into
-                                  consideration for the incoming pod's pod (anti) affinity.
-                                  Keys that don't exist in the incoming pod labels will
-                                  be ignored. The default value is empty. The same key
-                                  is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                  Also, MatchLabelKeys cannot be set when LabelSelector
-                                  isn't set. This is an alpha field and requires enabling
-                                  MatchLabelKeysInPodAffinity feature gate.
+                                description: |-
+                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                  Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               mismatchLabelKeys:
-                                description: MismatchLabelKeys is a set of pod label
-                                  keys to select which pods will be taken into consideration.
-                                  The keys are used to lookup values from the incoming
-                                  pod labels, those key-value labels are merged with
-                                  `LabelSelector` as `key notin (value)` to select the
-                                  group of existing pods which pods will be taken into
-                                  consideration for the incoming pod's pod (anti) affinity.
-                                  Keys that don't exist in the incoming pod labels will
-                                  be ignored. The default value is empty. The same key
-                                  is forbidden to exist in both MismatchLabelKeys and
-                                  LabelSelector. Also, MismatchLabelKeys cannot be set
-                                  when LabelSelector isn't set. This is an alpha field
-                                  and requires enabling MatchLabelKeysInPodAffinity
-                                  feature gate.
+                                description: |-
+                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                  Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces
-                                  that the term applies to. The term is applied to the
-                                  union of the namespaces selected by this field and
-                                  the ones listed in the namespaces field. null selector
-                                  and null or empty namespaces list means "this pod's
-                                  namespace". An empty selector ({}) matches all namespaces.
+                                description: |-
+                                  A label query over the set of namespaces that the term applies to.
+                                  The term is applied to the union of the namespaces selected by this field
+                                  and the ones listed in the namespaces field.
+                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                  An empty selector ({}) matches all namespaces.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
                                       selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
                                       properties:
                                         key:
                                           description: key is the label key that the
                                             selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists and DoesNotExist.
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist, the
-                                            values array must be empty. This array is
-                                            replaced during a strategic merge patch.
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -1945,32 +1924,28 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value". The
-                                      requirements are ANDed.
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace
-                                  names that the term applies to. The term is applied
-                                  to the union of the namespaces listed in this field
-                                  and the ones selected by namespaceSelector. null or
-                                  empty namespaces list and null namespaceSelector means
-                                  "this pod's namespace".
+                                description: |-
+                                  namespaces specifies a static list of namespace names that the term applies to.
+                                  The term is applied to the union of the namespaces listed in this field
+                                  and the ones selected by namespaceSelector.
+                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods matching
-                                  the labelSelector in the specified namespaces, where
-                                  co-located is defined as running on a node whose value
-                                  of the label with key topologyKey matches that of
-                                  any node on which any of the selected pods is running.
+                                description: |-
+                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                  selected pods is running.
                                   Empty topologyKey is not allowed.
                                 type: string
                             required:
@@ -1984,16 +1959,15 @@ spec:
                         other pod(s)).
                       properties:
                         preferredDuringSchedulingIgnoredDuringExecution:
-                          description: The scheduler will prefer to schedule pods to
-                            nodes that satisfy the anti-affinity expressions specified
-                            by this field, but it may choose a node that violates one
-                            or more of the expressions. The node that is most preferred
-                            is the one with the greatest sum of weights, i.e. for each
-                            node that meets all of the scheduling requirements (resource
-                            request, requiredDuringScheduling anti-affinity expressions,
-                            etc.), compute a sum by iterating through the elements of
-                            this field and adding "weight" to the sum if the node has
-                            pods which matches the corresponding podAffinityTerm; the
+                          description: |-
+                            The scheduler will prefer to schedule pods to nodes that satisfy
+                            the anti-affinity expressions specified by this field, but it may choose
+                            a node that violates one or more of the expressions. The node that is
+                            most preferred is the one with the greatest sum of weights, i.e.
+                            for each node that meets all of the scheduling requirements (resource
+                            request, requiredDuringScheduling anti-affinity expressions, etc.),
+                            compute a sum by iterating through the elements of this field and adding
+                            "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
                             node(s) with the highest sum are the most preferred.
                           items:
                             description: The weights of all of the matched WeightedPodAffinityTerm
@@ -2004,37 +1978,33 @@ spec:
                                   with the corresponding weight.
                                 properties:
                                   labelSelector:
-                                    description: A label query over a set of resources,
-                                      in this case pods. If it's null, this PodAffinityTerm
-                                      matches with no Pods.
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label
                                           selector requirements. The requirements are
                                           ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -2047,89 +2017,74 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   matchLabelKeys:
-                                    description: MatchLabelKeys is a set of pod label
-                                      keys to select which pods will be taken into consideration.
-                                      The keys are used to lookup values from the incoming
-                                      pod labels, those key-value labels are merged
-                                      with `LabelSelector` as `key in (value)` to select
-                                      the group of existing pods which pods will be
-                                      taken into consideration for the incoming pod's
-                                      pod (anti) affinity. Keys that don't exist in
-                                      the incoming pod labels will be ignored. The default
-                                      value is empty. The same key is forbidden to exist
-                                      in both MatchLabelKeys and LabelSelector. Also,
-                                      MatchLabelKeys cannot be set when LabelSelector
-                                      isn't set. This is an alpha field and requires
-                                      enabling MatchLabelKeysInPodAffinity feature gate.
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                      Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   mismatchLabelKeys:
-                                    description: MismatchLabelKeys is a set of pod label
-                                      keys to select which pods will be taken into consideration.
-                                      The keys are used to lookup values from the incoming
-                                      pod labels, those key-value labels are merged
-                                      with `LabelSelector` as `key notin (value)` to
-                                      select the group of existing pods which pods will
-                                      be taken into consideration for the incoming pod's
-                                      pod (anti) affinity. Keys that don't exist in
-                                      the incoming pod labels will be ignored. The default
-                                      value is empty. The same key is forbidden to exist
-                                      in both MismatchLabelKeys and LabelSelector. Also,
-                                      MismatchLabelKeys cannot be set when LabelSelector
-                                      isn't set. This is an alpha field and requires
-                                      enabling MatchLabelKeysInPodAffinity feature gate.
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                      Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                     items:
                                       type: string
                                     type: array
                                     x-kubernetes-list-type: atomic
                                   namespaceSelector:
-                                    description: A label query over the set of namespaces
-                                      that the term applies to. The term is applied
-                                      to the union of the namespaces selected by this
-                                      field and the ones listed in the namespaces field.
-                                      null selector and null or empty namespaces list
-                                      means "this pod's namespace". An empty selector
-                                      ({}) matches all namespaces.
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label
                                           selector requirements. The requirements are
                                           ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -2142,40 +2097,37 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   namespaces:
-                                    description: namespaces specifies a static list
-                                      of namespace names that the term applies to. The
-                                      term is applied to the union of the namespaces
-                                      listed in this field and the ones selected by
-                                      namespaceSelector. null or empty namespaces list
-                                      and null namespaceSelector means "this pod's namespace".
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                     items:
                                       type: string
                                     type: array
                                   topologyKey:
-                                    description: This pod should be co-located (affinity)
-                                      or not co-located (anti-affinity) with the pods
-                                      matching the labelSelector in the specified namespaces,
-                                      where co-located is defined as running on a node
-                                      whose value of the label with key topologyKey
-                                      matches that of any node on which any of the selected
-                                      pods is running. Empty topologyKey is not allowed.
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
                                     type: string
                                 required:
                                   - topologyKey
                                 type: object
                               weight:
-                                description: weight associated with matching the corresponding
-                                  podAffinityTerm, in the range 1-100.
+                                description: |-
+                                  weight associated with matching the corresponding podAffinityTerm,
+                                  in the range 1-100.
                                 format: int32
                                 type: integer
                             required:
@@ -2184,53 +2136,51 @@ spec:
                             type: object
                           type: array
                         requiredDuringSchedulingIgnoredDuringExecution:
-                          description: If the anti-affinity requirements specified by
-                            this field are not met at scheduling time, the pod will
-                            not be scheduled onto the node. If the anti-affinity requirements
-                            specified by this field cease to be met at some point during
-                            pod execution (e.g. due to a pod label update), the system
-                            may or may not try to eventually evict the pod from its
-                            node. When there are multiple elements, the lists of nodes
-                            corresponding to each podAffinityTerm are intersected, i.e.
-                            all terms must be satisfied.
+                          description: |-
+                            If the anti-affinity requirements specified by this field are not met at
+                            scheduling time, the pod will not be scheduled onto the node.
+                            If the anti-affinity requirements specified by this field cease to be met
+                            at some point during pod execution (e.g. due to a pod label update), the
+                            system may or may not try to eventually evict the pod from its node.
+                            When there are multiple elements, the lists of nodes corresponding to each
+                            podAffinityTerm are intersected, i.e. all terms must be satisfied.
                           items:
-                            description: Defines a set of pods (namely those matching
-                              the labelSelector relative to the given namespace(s))
-                              that this pod should be co-located (affinity) or not co-located
-                              (anti-affinity) with, where co-located is defined as running
-                              on a node whose value of the label with key <topologyKey>
-                              matches that of any node on which a pod of the set of
-                              pods is running
+                            description: |-
+                              Defines a set of pods (namely those matching the labelSelector
+                              relative to the given namespace(s)) that this pod should be
+                              co-located (affinity) or not co-located (anti-affinity) with,
+                              where co-located is defined as running on a node whose value of
+                              the label with key <topologyKey> matches that of any node on which
+                              a pod of the set of pods is running
                             properties:
                               labelSelector:
-                                description: A label query over a set of resources,
-                                  in this case pods. If it's null, this PodAffinityTerm
-                                  matches with no Pods.
+                                description: |-
+                                  A label query over a set of resources, in this case pods.
+                                  If it's null, this PodAffinityTerm matches with no Pods.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
                                       selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
                                       properties:
                                         key:
                                           description: key is the label key that the
                                             selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists and DoesNotExist.
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist, the
-                                            values array must be empty. This array is
-                                            replaced during a strategic merge patch.
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -2242,84 +2192,74 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value". The
-                                      requirements are ANDed.
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               matchLabelKeys:
-                                description: MatchLabelKeys is a set of pod label keys
-                                  to select which pods will be taken into consideration.
-                                  The keys are used to lookup values from the incoming
-                                  pod labels, those key-value labels are merged with
-                                  `LabelSelector` as `key in (value)` to select the
-                                  group of existing pods which pods will be taken into
-                                  consideration for the incoming pod's pod (anti) affinity.
-                                  Keys that don't exist in the incoming pod labels will
-                                  be ignored. The default value is empty. The same key
-                                  is forbidden to exist in both MatchLabelKeys and LabelSelector.
-                                  Also, MatchLabelKeys cannot be set when LabelSelector
-                                  isn't set. This is an alpha field and requires enabling
-                                  MatchLabelKeysInPodAffinity feature gate.
+                                description: |-
+                                  MatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                  Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               mismatchLabelKeys:
-                                description: MismatchLabelKeys is a set of pod label
-                                  keys to select which pods will be taken into consideration.
-                                  The keys are used to lookup values from the incoming
-                                  pod labels, those key-value labels are merged with
-                                  `LabelSelector` as `key notin (value)` to select the
-                                  group of existing pods which pods will be taken into
-                                  consideration for the incoming pod's pod (anti) affinity.
-                                  Keys that don't exist in the incoming pod labels will
-                                  be ignored. The default value is empty. The same key
-                                  is forbidden to exist in both MismatchLabelKeys and
-                                  LabelSelector. Also, MismatchLabelKeys cannot be set
-                                  when LabelSelector isn't set. This is an alpha field
-                                  and requires enabling MatchLabelKeysInPodAffinity
-                                  feature gate.
+                                description: |-
+                                  MismatchLabelKeys is a set of pod label keys to select which pods will
+                                  be taken into consideration. The keys are used to lookup values from the
+                                  incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                  to select the group of existing pods which pods will be taken into consideration
+                                  for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                  pod labels will be ignored. The default value is empty.
+                                  The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                  Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                  This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
                                 items:
                                   type: string
                                 type: array
                                 x-kubernetes-list-type: atomic
                               namespaceSelector:
-                                description: A label query over the set of namespaces
-                                  that the term applies to. The term is applied to the
-                                  union of the namespaces selected by this field and
-                                  the ones listed in the namespaces field. null selector
-                                  and null or empty namespaces list means "this pod's
-                                  namespace". An empty selector ({}) matches all namespaces.
+                                description: |-
+                                  A label query over the set of namespaces that the term applies to.
+                                  The term is applied to the union of the namespaces selected by this field
+                                  and the ones listed in the namespaces field.
+                                  null selector and null or empty namespaces list means "this pod's namespace".
+                                  An empty selector ({}) matches all namespaces.
                                 properties:
                                   matchExpressions:
                                     description: matchExpressions is a list of label
                                       selector requirements. The requirements are ANDed.
                                     items:
-                                      description: A label selector requirement is a
-                                        selector that contains values, a key, and an
-                                        operator that relates the key and values.
+                                      description: |-
+                                        A label selector requirement is a selector that contains values, a key, and an operator that
+                                        relates the key and values.
                                       properties:
                                         key:
                                           description: key is the label key that the
                                             selector applies to.
                                           type: string
                                         operator:
-                                          description: operator represents a key's relationship
-                                            to a set of values. Valid operators are
-                                            In, NotIn, Exists and DoesNotExist.
+                                          description: |-
+                                            operator represents a key's relationship to a set of values.
+                                            Valid operators are In, NotIn, Exists and DoesNotExist.
                                           type: string
                                         values:
-                                          description: values is an array of string
-                                            values. If the operator is In or NotIn,
-                                            the values array must be non-empty. If the
-                                            operator is Exists or DoesNotExist, the
-                                            values array must be empty. This array is
-                                            replaced during a strategic merge patch.
+                                          description: |-
+                                            values is an array of string values. If the operator is In or NotIn,
+                                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                            the values array must be empty. This array is replaced during a strategic
+                                            merge patch.
                                           items:
                                             type: string
                                           type: array
@@ -2331,32 +2271,28 @@ spec:
                                   matchLabels:
                                     additionalProperties:
                                       type: string
-                                    description: matchLabels is a map of {key,value}
-                                      pairs. A single {key,value} in the matchLabels
-                                      map is equivalent to an element of matchExpressions,
-                                      whose key field is "key", the operator is "In",
-                                      and the values array contains only "value". The
-                                      requirements are ANDed.
+                                    description: |-
+                                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                                     type: object
                                 type: object
                                 x-kubernetes-map-type: atomic
                               namespaces:
-                                description: namespaces specifies a static list of namespace
-                                  names that the term applies to. The term is applied
-                                  to the union of the namespaces listed in this field
-                                  and the ones selected by namespaceSelector. null or
-                                  empty namespaces list and null namespaceSelector means
-                                  "this pod's namespace".
+                                description: |-
+                                  namespaces specifies a static list of namespace names that the term applies to.
+                                  The term is applied to the union of the namespaces listed in this field
+                                  and the ones selected by namespaceSelector.
+                                  null or empty namespaces list and null namespaceSelector means "this pod's namespace".
                                 items:
                                   type: string
                                 type: array
                               topologyKey:
-                                description: This pod should be co-located (affinity)
-                                  or not co-located (anti-affinity) with the pods matching
-                                  the labelSelector in the specified namespaces, where
-                                  co-located is defined as running on a node whose value
-                                  of the label with key topologyKey matches that of
-                                  any node on which any of the selected pods is running.
+                                description: |-
+                                  This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                  the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                  whose value of the label with key topologyKey matches that of any node on which any of the
+                                  selected pods is running.
                                   Empty topologyKey is not allowed.
                                 type: string
                             required:
@@ -2372,35 +2308,34 @@ spec:
                     Collector binary
                   type: object
                 autoscaler:
-                  description: Autoscaler specifies the pod autoscaling configuration
-                    to use for the AmazonCloudWatchAgent workload.
+                  description: |-
+                    Autoscaler specifies the pod autoscaling configuration to use
+                    for the AmazonCloudWatchAgent workload.
                   properties:
                     behavior:
-                      description: HorizontalPodAutoscalerBehavior configures the scaling
-                        behavior of the target in both Up and Down directions (scaleUp
-                        and scaleDown fields respectively).
+                      description: |-
+                        HorizontalPodAutoscalerBehavior configures the scaling behavior of the target
+                        in both Up and Down directions (scaleUp and scaleDown fields respectively).
                       properties:
                         scaleDown:
-                          description: scaleDown is scaling policy for scaling Down.
-                            If not set, the default value is to allow to scale down
-                            to minReplicas pods, with a 300 second stabilization window
-                            (i.e., the highest recommendation for the last 300sec is
-                            used).
+                          description: |-
+                            scaleDown is scaling policy for scaling Down.
+                            If not set, the default value is to allow to scale down to minReplicas pods, with a
+                            300 second stabilization window (i.e., the highest recommendation for
+                            the last 300sec is used).
                           properties:
                             policies:
-                              description: policies is a list of potential scaling polices
-                                which can be used during scaling. At least one policy
-                                must be specified, otherwise the HPAScalingRules will
-                                be discarded as invalid
+                              description: |-
+                                policies is a list of potential scaling polices which can be used during scaling.
+                                At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
                               items:
                                 description: HPAScalingPolicy is a single policy which
                                   must hold true for a specified past interval.
                                 properties:
                                   periodSeconds:
-                                    description: periodSeconds specifies the window
-                                      of time for which the policy should hold true.
-                                      PeriodSeconds must be greater than zero and less
-                                      than or equal to 1800 (30 min).
+                                    description: |-
+                                      periodSeconds specifies the window of time for which the policy should hold true.
+                                      PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
                                     format: int32
                                     type: integer
                                   type:
@@ -2408,9 +2343,9 @@ spec:
                                       policy.
                                     type: string
                                   value:
-                                    description: value contains the amount of change
-                                      which is permitted by the policy. It must be greater
-                                      than zero
+                                    description: |-
+                                      value contains the amount of change which is permitted by the policy.
+                                      It must be greater than zero
                                     format: int32
                                     type: integer
                                 required:
@@ -2421,42 +2356,41 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             selectPolicy:
-                              description: selectPolicy is used to specify which policy
-                                should be used. If not set, the default value Max is
-                                used.
+                              description: |-
+                                selectPolicy is used to specify which policy should be used.
+                                If not set, the default value Max is used.
                               type: string
                             stabilizationWindowSeconds:
-                              description: 'stabilizationWindowSeconds is the number
-                              of seconds for which past recommendations should be
-                              considered while scaling up or scaling down. StabilizationWindowSeconds
-                              must be greater than or equal to zero and less than
-                              or equal to 3600 (one hour). If not set, use the default
-                              values: - For scale up: 0 (i.e. no stabilization is
-                              done). - For scale down: 300 (i.e. the stabilization
-                              window is 300 seconds long).'
+                              description: |-
+                                stabilizationWindowSeconds is the number of seconds for which past recommendations should be
+                                considered while scaling up or scaling down.
+                                StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
+                                If not set, use the default values:
+                                - For scale up: 0 (i.e. no stabilization is done).
+                                - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
                               format: int32
                               type: integer
                           type: object
                         scaleUp:
-                          description: 'scaleUp is scaling policy for scaling Up. If
-                          not set, the default value is the higher of: * increase
-                          no more than 4 pods per 60 seconds * double the number of
-                          pods per 60 seconds No stabilization is used.'
+                          description: |-
+                            scaleUp is scaling policy for scaling Up.
+                            If not set, the default value is the higher of:
+                              * increase no more than 4 pods per 60 seconds
+                              * double the number of pods per 60 seconds
+                            No stabilization is used.
                           properties:
                             policies:
-                              description: policies is a list of potential scaling polices
-                                which can be used during scaling. At least one policy
-                                must be specified, otherwise the HPAScalingRules will
-                                be discarded as invalid
+                              description: |-
+                                policies is a list of potential scaling polices which can be used during scaling.
+                                At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
                               items:
                                 description: HPAScalingPolicy is a single policy which
                                   must hold true for a specified past interval.
                                 properties:
                                   periodSeconds:
-                                    description: periodSeconds specifies the window
-                                      of time for which the policy should hold true.
-                                      PeriodSeconds must be greater than zero and less
-                                      than or equal to 1800 (30 min).
+                                    description: |-
+                                      periodSeconds specifies the window of time for which the policy should hold true.
+                                      PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
                                     format: int32
                                     type: integer
                                   type:
@@ -2464,9 +2398,9 @@ spec:
                                       policy.
                                     type: string
                                   value:
-                                    description: value contains the amount of change
-                                      which is permitted by the policy. It must be greater
-                                      than zero
+                                    description: |-
+                                      value contains the amount of change which is permitted by the policy.
+                                      It must be greater than zero
                                     format: int32
                                     type: integer
                                 required:
@@ -2477,19 +2411,18 @@ spec:
                               type: array
                               x-kubernetes-list-type: atomic
                             selectPolicy:
-                              description: selectPolicy is used to specify which policy
-                                should be used. If not set, the default value Max is
-                                used.
+                              description: |-
+                                selectPolicy is used to specify which policy should be used.
+                                If not set, the default value Max is used.
                               type: string
                             stabilizationWindowSeconds:
-                              description: 'stabilizationWindowSeconds is the number
-                              of seconds for which past recommendations should be
-                              considered while scaling up or scaling down. StabilizationWindowSeconds
-                              must be greater than or equal to zero and less than
-                              or equal to 3600 (one hour). If not set, use the default
-                              values: - For scale up: 0 (i.e. no stabilization is
-                              done). - For scale down: 300 (i.e. the stabilization
-                              window is 300 seconds long).'
+                              description: |-
+                                stabilizationWindowSeconds is the number of seconds for which past recommendations should be
+                                considered while scaling up or scaling down.
+                                StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
+                                If not set, use the default values:
+                                - For scale up: 0 (i.e. no stabilization is done).
+                                - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
                               format: int32
                               type: integer
                           type: object
@@ -2500,22 +2433,22 @@ spec:
                       format: int32
                       type: integer
                     metrics:
-                      description: Metrics is meant to provide a customizable way to
-                        configure HPA metrics. currently the only supported custom metrics
-                        is type=Pod. Use TargetCPUUtilization or TargetMemoryUtilization
-                        instead if scaling on these common resource metrics.
+                      description: |-
+                        Metrics is meant to provide a customizable way to configure HPA metrics.
+                        currently the only supported custom metrics is type=Pod.
+                        Use TargetCPUUtilization or TargetMemoryUtilization instead if scaling on these common resource metrics.
                       items:
-                        description: MetricSpec defines a subset of metrics to be defined
-                          for the HPA's metric array more metric type can be supported
-                          as needed. See https://pkg.go.dev/k8s.io/api/autoscaling/v2#MetricSpec
-                          for reference.
+                        description: |-
+                          MetricSpec defines a subset of metrics to be defined for the HPA's metric array
+                          more metric type can be supported as needed.
+                          See https://pkg.go.dev/k8s.io/api/autoscaling/v2#MetricSpec for reference.
                         properties:
                           pods:
-                            description: PodsMetricSource indicates how to scale on
-                              a metric describing each pod in the current scale target
-                              (for example, transactions-processed-per-second). The
-                              values will be averaged together before being compared
-                              to the target value.
+                            description: |-
+                              PodsMetricSource indicates how to scale on a metric describing each pod in
+                              the current scale target (for example, transactions-processed-per-second).
+                              The values will be averaged together before being compared to the target
+                              value.
                             properties:
                               metric:
                                 description: metric identifies the target metric by
@@ -2525,40 +2458,34 @@ spec:
                                     description: name is the name of the given metric
                                     type: string
                                   selector:
-                                    description: selector is the string-encoded form
-                                      of a standard kubernetes label selector for the
-                                      given metric When set, it is passed as an additional
-                                      parameter to the metrics server for more specific
-                                      metrics scoping. When unset, just the metricName
-                                      will be used to gather metrics.
+                                    description: |-
+                                      selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                      When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                      When unset, just the metricName will be used to gather metrics.
                                     properties:
                                       matchExpressions:
                                         description: matchExpressions is a list of label
                                           selector requirements. The requirements are
                                           ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -2571,12 +2498,10 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
@@ -2588,21 +2513,20 @@ spec:
                                   given metric
                                 properties:
                                   averageUtilization:
-                                    description: averageUtilization is the target value
-                                      of the average of the resource metric across all
-                                      relevant pods, represented as a percentage of
+                                    description: |-
+                                      averageUtilization is the target value of the average of the
+                                      resource metric across all relevant pods, represented as a percentage of
                                       the requested value of the resource for the pods.
-                                      Currently only valid for Resource metric source
-                                      type
+                                      Currently only valid for Resource metric source type
                                     format: int32
                                     type: integer
                                   averageValue:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: averageValue is the target value of
-                                      the average of the metric across all relevant
-                                      pods (as a quantity)
+                                    description: |-
+                                      averageValue is the target value of the average of the
+                                      metric across all relevant pods (as a quantity)
                                     pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                     x-kubernetes-int-or-string: true
                                   type:
@@ -2638,9 +2562,9 @@ spec:
                       format: int32
                       type: integer
                     targetCPUUtilization:
-                      description: TargetCPUUtilization sets the target average CPU
-                        used across all replicas. If average CPU exceeds this value,
-                        the HPA will scale up. Defaults to 90 percent.
+                      description: |-
+                        TargetCPUUtilization sets the target average CPU used across all replicas.
+                        If average CPU exceeds this value, the HPA will scale up. Defaults to 90 percent.
                       format: int32
                       type: integer
                     targetMemoryUtilization:
@@ -2655,10 +2579,10 @@ spec:
                     for details.
                   type: string
                 configmaps:
-                  description: ConfigMaps is a list of ConfigMaps in the same namespace
-                    as the AmazonCloudWatchAgent object, which shall be mounted into
-                    the Collector Pods. Each ConfigMap will be added to the Collector's
-                    Deployments as a volume named `configmap-<configmap-name>`.
+                  description: |-
+                    ConfigMaps is a list of ConfigMaps in the same namespace as the AmazonCloudWatchAgent
+                    object, which shall be mounted into the Collector Pods.
+                    Each ConfigMap will be added to the Collector's Deployments as a volume named `configmap-<configmap-name>`.
                   items:
                     properties:
                       mountpath:
@@ -2673,9 +2597,9 @@ spec:
                     type: object
                   type: array
                 env:
-                  description: ENV vars to set on the OpenTelemetry Collector's Pods.
-                    These can then in certain cases be consumed in the config file for
-                    the Collector.
+                  description: |-
+                    ENV vars to set on the OpenTelemetry Collector's Pods. These can then in certain cases be
+                    consumed in the config file for the Collector.
                   items:
                     description: EnvVar represents an environment variable present in
                       a Container.
@@ -2684,15 +2608,16 @@ spec:
                         description: Name of the environment variable. Must be a C_IDENTIFIER.
                         type: string
                       value:
-                        description: 'Variable references $(VAR_NAME) are expanded using
-                        the previously defined environment variables in the container
-                        and any service environment variables. If a variable cannot
-                        be resolved, the reference in the input string will be unchanged.
-                        Double $$ are reduced to a single $, which allows for escaping
-                        the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will produce the
-                        string literal "$(VAR_NAME)". Escaped references will never
-                        be expanded, regardless of whether the variable exists or
-                        not. Defaults to "".'
+                        description: |-
+                          Variable references $(VAR_NAME) are expanded
+                          using the previously defined environment variables in the container and
+                          any service environment variables. If a variable cannot be resolved,
+                          the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                          "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                          Escaped references will never be expanded, regardless of whether the variable
+                          exists or not.
+                          Defaults to "".
                         type: string
                       valueFrom:
                         description: Source for the environment variable's value. Cannot
@@ -2705,8 +2630,10 @@ spec:
                                 description: The key to select.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                               optional:
                                 description: Specify whether the ConfigMap or its key
@@ -2717,10 +2644,9 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           fieldRef:
-                            description: 'Selects a field of the pod: supports metadata.name,
-                            metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`,
-                            spec.nodeName, spec.serviceAccountName, status.hostIP,
-                            status.podIP, status.podIPs.'
+                            description: |-
+                              Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                              spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                             properties:
                               apiVersion:
                                 description: Version of the schema the FieldPath is
@@ -2735,10 +2661,9 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           resourceFieldRef:
-                            description: 'Selects a resource of the container: only
-                            resources limits and requests (limits.cpu, limits.memory,
-                            limits.ephemeral-storage, requests.cpu, requests.memory
-                            and requests.ephemeral-storage) are currently supported.'
+                            description: |-
+                              Selects a resource of the container: only resources limits and requests
+                              (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                             properties:
                               containerName:
                                 description: 'Container name: required for volumes,
@@ -2767,8 +2692,10 @@ spec:
                                   be a valid secret key.
                                 type: string
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                               optional:
                                 description: Specify whether the Secret or its key must
@@ -2784,9 +2711,9 @@ spec:
                     type: object
                   type: array
                 envFrom:
-                  description: List of sources to populate environment variables on
-                    the OpenTelemetry Collector's Pods. These can then in certain cases
-                    be consumed in the config file for the Collector.
+                  description: |-
+                    List of sources to populate environment variables on the OpenTelemetry Collector's Pods.
+                    These can then in certain cases be consumed in the config file for the Collector.
                   items:
                     description: EnvFromSource represents the source of a set of ConfigMaps
                     properties:
@@ -2794,8 +2721,10 @@ spec:
                         description: The ConfigMap to select from
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
                             description: Specify whether the ConfigMap must be defined
@@ -2810,8 +2739,10 @@ spec:
                         description: The Secret to select from
                         properties:
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
                             description: Specify whether the Secret must be defined
@@ -2833,27 +2764,31 @@ spec:
                     for retrieving the container image (Always, Never, IfNotPresent)
                   type: string
                 ingress:
-                  description: 'Ingress is used to specify how OpenTelemetry Collector
-                  is exposed. This functionality is only available if one of the valid
-                  modes is set. Valid modes are: deployment, daemonset and statefulset.'
+                  description: |-
+                    Ingress is used to specify how OpenTelemetry Collector is exposed. This
+                    functionality is only available if one of the valid modes is set.
+                    Valid modes are: deployment, daemonset and statefulset.
                   properties:
                     annotations:
                       additionalProperties:
                         type: string
-                      description: 'Annotations to add to ingress. e.g. ''cert-manager.io/cluster-issuer:
-                      "letsencrypt"'''
+                      description: |-
+                        Annotations to add to ingress.
+                        e.g. 'cert-manager.io/cluster-issuer: "letsencrypt"'
                       type: object
                     hostname:
                       description: Hostname by which the ingress proxy can be reached.
                       type: string
                     ingressClassName:
-                      description: IngressClassName is the name of an IngressClass cluster
-                        resource. Ingress controller implementations use this field
-                        to know whether they should be serving this Ingress resource.
+                      description: |-
+                        IngressClassName is the name of an IngressClass cluster resource. Ingress
+                        controller implementations use this field to know whether they should be
+                        serving this Ingress resource.
                       type: string
                     route:
-                      description: Route is an OpenShift specific section that is only
-                        considered when type "route" is used.
+                      description: |-
+                        Route is an OpenShift specific section that is only considered when
+                        type "route" is used.
                       properties:
                         termination:
                           description: Termination indicates termination type. By default
@@ -2866,11 +2801,11 @@ spec:
                           type: string
                       type: object
                     ruleType:
-                      description: RuleType defines how Ingress exposes collector receivers.
-                        IngressRuleTypePath ("path") exposes each receiver port on a
-                        unique path on single domain defined in Hostname. IngressRuleTypeSubdomain
-                        ("subdomain") exposes each receiver port on a unique subdomain
-                        of Hostname. Default is IngressRuleTypePath ("path").
+                      description: |-
+                        RuleType defines how Ingress exposes collector receivers.
+                        IngressRuleTypePath ("path") exposes each receiver port on a unique path on single domain defined in Hostname.
+                        IngressRuleTypeSubdomain ("subdomain") exposes each receiver port on a unique subdomain of Hostname.
+                        Default is IngressRuleTypePath ("path").
                       enum:
                         - path
                         - subdomain
@@ -2882,74 +2817,74 @@ spec:
                           associated with an ingress.
                         properties:
                           hosts:
-                            description: hosts is a list of hosts included in the TLS
-                              certificate. The values in this list must match the name/s
-                              used in the tlsSecret. Defaults to the wildcard host setting
-                              for the loadbalancer controller fulfilling this Ingress,
-                              if left unspecified.
+                            description: |-
+                              hosts is a list of hosts included in the TLS certificate. The values in
+                              this list must match the name/s used in the tlsSecret. Defaults to the
+                              wildcard host setting for the loadbalancer controller fulfilling this
+                              Ingress, if left unspecified.
                             items:
                               type: string
                             type: array
                             x-kubernetes-list-type: atomic
                           secretName:
-                            description: secretName is the name of the secret used to
-                              terminate TLS traffic on port 443. Field is left optional
-                              to allow TLS routing based on SNI hostname alone. If the
-                              SNI host in a listener conflicts with the "Host" header
-                              field used by an IngressRule, the SNI host is used for
-                              termination and value of the "Host" header is used for
-                              routing.
+                            description: |-
+                              secretName is the name of the secret used to terminate TLS traffic on
+                              port 443. Field is left optional to allow TLS routing based on SNI
+                              hostname alone. If the SNI host in a listener conflicts with the "Host"
+                              header field used by an IngressRule, the SNI host is used for termination
+                              and value of the "Host" header is used for routing.
                             type: string
                         type: object
                       type: array
                     type:
-                      description: 'Type default value is: "" Supported types are: ingress,
-                      route'
+                      description: |-
+                        Type default value is: ""
+                        Supported types are: ingress, route
                       enum:
                         - ingress
                         - route
                       type: string
                   type: object
                 initContainers:
-                  description: 'InitContainers allows injecting initContainers to the
-                  Collector''s pod definition. These init containers can be used to
-                  fetch secrets for injection into the configuration from external
-                  sources, run added checks, etc. Any errors during the execution
-                  of an initContainer will lead to a restart of the Pod. More info:
-                  https://kubernetes.io/docs/concepts/workloads/pods/init-containers/'
+                  description: |-
+                    InitContainers allows injecting initContainers to the Collector's pod definition.
+                    These init containers can be used to fetch secrets for injection into the
+                    configuration from external sources, run added checks, etc. Any errors during the execution of
+                    an initContainer will lead to a restart of the Pod. More info:
+                    https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
                   items:
                     description: A single application container that you want to run
                       within a pod.
                     properties:
                       args:
-                        description: 'Arguments to the entrypoint. The container image''s
-                        CMD is used if this is not provided. Variable references $(VAR_NAME)
-                        are expanded using the container''s environment. If a variable
-                        cannot be resolved, the reference in the input string will
-                        be unchanged. Double $$ are reduced to a single $, which allows
-                        for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
-                        produce the string literal "$(VAR_NAME)". Escaped references
-                        will never be expanded, regardless of whether the variable
-                        exists or not. Cannot be updated. More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: |-
+                          Arguments to the entrypoint.
+                          The container image's CMD is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          of whether the variable exists or not. Cannot be updated.
+                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                         items:
                           type: string
                         type: array
                       command:
-                        description: 'Entrypoint array. Not executed within a shell.
-                        The container image''s ENTRYPOINT is used if this is not provided.
-                        Variable references $(VAR_NAME) are expanded using the container''s
-                        environment. If a variable cannot be resolved, the reference
-                        in the input string will be unchanged. Double $$ are reduced
-                        to a single $, which allows for escaping the $(VAR_NAME) syntax:
-                        i.e. "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
-                        Escaped references will never be expanded, regardless of whether
-                        the variable exists or not. Cannot be updated. More info:
-                        https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell'
+                        description: |-
+                          Entrypoint array. Not executed within a shell.
+                          The container image's ENTRYPOINT is used if this is not provided.
+                          Variable references $(VAR_NAME) are expanded using the container's environment. If a variable
+                          cannot be resolved, the reference in the input string will be unchanged. Double $$ are reduced
+                          to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e. "$$(VAR_NAME)" will
+                          produce the string literal "$(VAR_NAME)". Escaped references will never be expanded, regardless
+                          of whether the variable exists or not. Cannot be updated.
+                          More info: https://kubernetes.io/docs/tasks/inject-data-application/define-command-argument-container/#running-a-command-in-a-shell
                         items:
                           type: string
                         type: array
                       env:
-                        description: List of environment variables to set in the container.
+                        description: |-
+                          List of environment variables to set in the container.
                           Cannot be updated.
                         items:
                           description: EnvVar represents an environment variable present
@@ -2960,16 +2895,16 @@ spec:
                                 a C_IDENTIFIER.
                               type: string
                             value:
-                              description: 'Variable references $(VAR_NAME) are expanded
-                              using the previously defined environment variables in
-                              the container and any service environment variables.
-                              If a variable cannot be resolved, the reference in the
-                              input string will be unchanged. Double $$ are reduced
-                              to a single $, which allows for escaping the $(VAR_NAME)
-                              syntax: i.e. "$$(VAR_NAME)" will produce the string
-                              literal "$(VAR_NAME)". Escaped references will never
-                              be expanded, regardless of whether the variable exists
-                              or not. Defaults to "".'
+                              description: |-
+                                Variable references $(VAR_NAME) are expanded
+                                using the previously defined environment variables in the container and
+                                any service environment variables. If a variable cannot be resolved,
+                                the reference in the input string will be unchanged. Double $$ are reduced
+                                to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                                "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                                Escaped references will never be expanded, regardless of whether the variable
+                                exists or not.
+                                Defaults to "".
                               type: string
                             valueFrom:
                               description: Source for the environment variable's value.
@@ -2982,10 +2917,10 @@ spec:
                                       description: The key to select.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: Specify whether the ConfigMap or
@@ -2996,11 +2931,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 fieldRef:
-                                  description: 'Selects a field of the pod: supports
-                                  metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`,
-                                  `metadata.annotations[''<KEY>'']`, spec.nodeName,
-                                  spec.serviceAccountName, status.hostIP, status.podIP,
-                                  status.podIPs.'
+                                  description: |-
+                                    Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                    spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
                                   properties:
                                     apiVersion:
                                       description: Version of the schema the FieldPath
@@ -3015,11 +2948,9 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                  only resources limits and requests (limits.cpu,
-                                  limits.memory, limits.ephemeral-storage, requests.cpu,
-                                  requests.memory and requests.ephemeral-storage)
-                                  are currently supported.'
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
                                   properties:
                                     containerName:
                                       description: 'Container name: required for volumes,
@@ -3049,10 +2980,10 @@ spec:
                                         be a valid secret key.
                                       type: string
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: Specify whether the Secret or its
@@ -3068,13 +2999,13 @@ spec:
                           type: object
                         type: array
                       envFrom:
-                        description: List of sources to populate environment variables
-                          in the container. The keys defined within a source must be
-                          a C_IDENTIFIER. All invalid keys will be reported as an event
-                          when the container is starting. When a key exists in multiple
-                          sources, the value associated with the last source will take
-                          precedence. Values defined by an Env with a duplicate key
-                          will take precedence. Cannot be updated.
+                        description: |-
+                          List of sources to populate environment variables in the container.
+                          The keys defined within a source must be a C_IDENTIFIER. All invalid keys
+                          will be reported as an event when the container is starting. When a key exists in multiple
+                          sources, the value associated with the last source will take precedence.
+                          Values defined by an Env with a duplicate key will take precedence.
+                          Cannot be updated.
                         items:
                           description: EnvFromSource represents the source of a set
                             of ConfigMaps
@@ -3083,9 +3014,10 @@ spec:
                               description: The ConfigMap to select from
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: Specify whether the ConfigMap must be
@@ -3101,9 +3033,10 @@ spec:
                               description: The Secret to select from
                               properties:
                                 name:
-                                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                  TODO: Add other useful fields. apiVersion, kind,
-                                  uid?'
+                                  description: |-
+                                    Name of the referent.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                    TODO: Add other useful fields. apiVersion, kind, uid?
                                   type: string
                                 optional:
                                   description: Specify whether the Secret must be defined
@@ -3113,40 +3046,42 @@ spec:
                           type: object
                         type: array
                       image:
-                        description: 'Container image name. More info: https://kubernetes.io/docs/concepts/containers/images
-                        This field is optional to allow higher level config management
-                        to default or override container images in workload controllers
-                        like Deployments and StatefulSets.'
+                        description: |-
+                          Container image name.
+                          More info: https://kubernetes.io/docs/concepts/containers/images
+                          This field is optional to allow higher level config management to default or override
+                          container images in workload controllers like Deployments and StatefulSets.
                         type: string
                       imagePullPolicy:
-                        description: 'Image pull policy. One of Always, Never, IfNotPresent.
-                        Defaults to Always if :latest tag is specified, or IfNotPresent
-                        otherwise. Cannot be updated. More info: https://kubernetes.io/docs/concepts/containers/images#updating-images'
+                        description: |-
+                          Image pull policy.
+                          One of Always, Never, IfNotPresent.
+                          Defaults to Always if :latest tag is specified, or IfNotPresent otherwise.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/containers/images#updating-images
                         type: string
                       lifecycle:
-                        description: Actions that the management system should take
-                          in response to container lifecycle events. Cannot be updated.
+                        description: |-
+                          Actions that the management system should take in response to container lifecycle events.
+                          Cannot be updated.
                         properties:
                           postStart:
-                            description: 'PostStart is called immediately after a container
-                            is created. If the handler fails, the container is terminated
-                            and restarted according to its restart policy. Other management
-                            of the container blocks until the hook completes. More
-                            info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            description: |-
+                              PostStart is called immediately after a container is created. If the handler fails,
+                              the container is terminated and restarted according to its restart policy.
+                              Other management of the container blocks until the hook completes.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                             properties:
                               exec:
                                 description: Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
@@ -3155,9 +3090,9 @@ spec:
                                 description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
                                     type: string
                                   httpHeaders:
                                     description: Custom headers to set in the request.
@@ -3167,9 +3102,9 @@ spec:
                                         to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name. This will
-                                            be canonicalized upon output, so case-variant
-                                            names will be understood as the same header.
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                           type: string
                                         value:
                                           description: The header field value
@@ -3186,13 +3121,15 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
@@ -3210,10 +3147,10 @@ spec:
                                   - seconds
                                 type: object
                               tcpSocket:
-                                description: Deprecated. TCPSocket is NOT supported
-                                  as a LifecycleHandler and kept for the backward compatibility.
-                                  There are no validation of this field and lifecycle
-                                  hooks will fail in runtime when tcp handler is specified.
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for the backward compatibility. There are no validation of this field and
+                                  lifecycle hooks will fail in runtime when tcp handler is specified.
                                 properties:
                                   host:
                                     description: 'Optional: Host name to connect to,
@@ -3223,40 +3160,37 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
                                 type: object
                             type: object
                           preStop:
-                            description: 'PreStop is called immediately before a container
-                            is terminated due to an API request or management event
-                            such as liveness/startup probe failure, preemption, resource
-                            contention, etc. The handler is not called if the container
-                            crashes or exits. The Pod''s termination grace period
-                            countdown begins before the PreStop hook is executed.
-                            Regardless of the outcome of the handler, the container
-                            will eventually terminate within the Pod''s termination
-                            grace period (unless delayed by finalizers). Other management
-                            of the container blocks until the hook completes or until
-                            the termination grace period is reached. More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                            description: |-
+                              PreStop is called immediately before a container is terminated due to an
+                              API request or management event such as liveness/startup probe failure,
+                              preemption, resource contention, etc. The handler is not called if the
+                              container crashes or exits. The Pod's termination grace period countdown begins before the
+                              PreStop hook is executed. Regardless of the outcome of the handler, the
+                              container will eventually terminate within the Pod's termination grace
+                              period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                              or until the termination grace period is reached.
+                              More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                             properties:
                               exec:
                                 description: Exec specifies the action to take.
                                 properties:
                                   command:
-                                    description: Command is the command line to execute
-                                      inside the container, the working directory for
-                                      the command  is root ('/') in the container's
-                                      filesystem. The command is simply exec'd, it is
-                                      not run inside a shell, so traditional shell instructions
-                                      ('|', etc) won't work. To use a shell, you need
-                                      to explicitly call out to that shell. Exit status
-                                      of 0 is treated as live/healthy and non-zero is
-                                      unhealthy.
+                                    description: |-
+                                      Command is the command line to execute inside the container, the working directory for the
+                                      command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                      not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                      a shell, you need to explicitly call out to that shell.
+                                      Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                     items:
                                       type: string
                                     type: array
@@ -3265,9 +3199,9 @@ spec:
                                 description: HTTPGet specifies the http request to perform.
                                 properties:
                                   host:
-                                    description: Host name to connect to, defaults to
-                                      the pod IP. You probably want to set "Host" in
-                                      httpHeaders instead.
+                                    description: |-
+                                      Host name to connect to, defaults to the pod IP. You probably want to set
+                                      "Host" in httpHeaders instead.
                                     type: string
                                   httpHeaders:
                                     description: Custom headers to set in the request.
@@ -3277,9 +3211,9 @@ spec:
                                         to be used in HTTP probes
                                       properties:
                                         name:
-                                          description: The header field name. This will
-                                            be canonicalized upon output, so case-variant
-                                            names will be understood as the same header.
+                                          description: |-
+                                            The header field name.
+                                            This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                           type: string
                                         value:
                                           description: The header field value
@@ -3296,13 +3230,15 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Name or number of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: |-
+                                      Name or number of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                   scheme:
-                                    description: Scheme to use for connecting to the
-                                      host. Defaults to HTTP.
+                                    description: |-
+                                      Scheme to use for connecting to the host.
+                                      Defaults to HTTP.
                                     type: string
                                 required:
                                   - port
@@ -3320,10 +3256,10 @@ spec:
                                   - seconds
                                 type: object
                               tcpSocket:
-                                description: Deprecated. TCPSocket is NOT supported
-                                  as a LifecycleHandler and kept for the backward compatibility.
-                                  There are no validation of this field and lifecycle
-                                  hooks will fail in runtime when tcp handler is specified.
+                                description: |-
+                                  Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                                  for the backward compatibility. There are no validation of this field and
+                                  lifecycle hooks will fail in runtime when tcp handler is specified.
                                 properties:
                                   host:
                                     description: 'Optional: Host name to connect to,
@@ -3333,9 +3269,10 @@ spec:
                                     anyOf:
                                       - type: integer
                                       - type: string
-                                    description: Number or name of the port to access
-                                      on the container. Number must be in the range
-                                      1 to 65535. Name must be an IANA_SVC_NAME.
+                                    description: |-
+                                      Number or name of the port to access on the container.
+                                      Number must be in the range 1 to 65535.
+                                      Name must be an IANA_SVC_NAME.
                                     x-kubernetes-int-or-string: true
                                 required:
                                   - port
@@ -3343,30 +3280,30 @@ spec:
                             type: object
                         type: object
                       livenessProbe:
-                        description: 'Periodic probe of container liveness. Container
-                        will be restarted if the probe fails. Cannot be updated. More
-                        info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        description: |-
+                          Periodic probe of container liveness.
+                          Container will be restarted if the probe fails.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
                             description: Exec specifies the action to take.
                             properties:
                               command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|', etc)
-                                  won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
                           grpc:
@@ -3378,10 +3315,12 @@ spec:
                                 format: int32
                                 type: integer
                               service:
-                                description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                  
+                                  
+                                  If this is not specified, the default behavior is defined by gRPC.
                                 type: string
                             required:
                               - port
@@ -3390,9 +3329,9 @@ spec:
                             description: HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description: Host name to connect to, defaults to the
-                                  pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
                                 description: Custom headers to set in the request. HTTP
@@ -3402,9 +3341,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name. This will
-                                        be canonicalized upon output, so case-variant
-                                        names will be understood as the same header.
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -3421,33 +3360,35 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Name or number of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description: Scheme to use for connecting to the host.
+                                description: |-
+                                  Scheme to use for connecting to the host.
                                   Defaults to HTTP.
                                 type: string
                             required:
                               - port
                             type: object
                           initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                           periodSeconds:
-                            description: How often (in seconds) to perform the probe.
+                            description: |-
+                              How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                             format: int32
                             type: integer
                           successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                             format: int32
                             type: integer
                           tcpSocket:
@@ -3462,78 +3403,82 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Number or name of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                               - port
                             type: object
                           terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully upon probe failure. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and the
-                              time when the processes are forcibly halted with a kill
-                              signal. Set this value longer than the expected cleanup
-                              time for your process. If this value is nil, the pod's
-                              terminationGracePeriodSeconds will be used. Otherwise,
-                              this value overrides the value provided by the pod spec.
-                              Value must be non-negative integer. The value zero indicates
-                              stop immediately via the kill signal (no opportunity to
-                              shut down). This is a beta field and requires enabling
-                              ProbeTerminationGracePeriod feature gate. Minimum value
-                              is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            description: |-
+                              Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                              The grace period is the duration in seconds after the processes running in the pod are sent
+                              a termination signal and the time when the processes are forcibly halted with a kill signal.
+                              Set this value longer than the expected cleanup time for your process.
+                              If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                              value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates stop immediately via
+                              the kill signal (no opportunity to shut down).
+                              This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                              Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                             format: int64
                             type: integer
                           timeoutSeconds:
-                            description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                         type: object
                       name:
-                        description: Name of the container specified as a DNS_LABEL.
+                        description: |-
+                          Name of the container specified as a DNS_LABEL.
                           Each container in a pod must have a unique name (DNS_LABEL).
                           Cannot be updated.
                         type: string
                       ports:
-                        description: List of ports to expose from the container. Not
-                          specifying a port here DOES NOT prevent that port from being
-                          exposed. Any port which is listening on the default "0.0.0.0"
-                          address inside a container will be accessible from the network.
-                          Modifying this array with strategic merge patch may corrupt
-                          the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255.
+                        description: |-
+                          List of ports to expose from the container. Not specifying a port here
+                          DOES NOT prevent that port from being exposed. Any port which is
+                          listening on the default "0.0.0.0" address inside a container will be
+                          accessible from the network.
+                          Modifying this array with strategic merge patch may corrupt the data.
+                          For more information See https://github.com/kubernetes/kubernetes/issues/108255.
                           Cannot be updated.
                         items:
                           description: ContainerPort represents a network port in a
                             single container.
                           properties:
                             containerPort:
-                              description: Number of port to expose on the pod's IP
-                                address. This must be a valid port number, 0 < x < 65536.
+                              description: |-
+                                Number of port to expose on the pod's IP address.
+                                This must be a valid port number, 0 < x < 65536.
                               format: int32
                               type: integer
                             hostIP:
                               description: What host IP to bind the external port to.
                               type: string
                             hostPort:
-                              description: Number of port to expose on the host. If
-                                specified, this must be a valid port number, 0 < x <
-                                65536. If HostNetwork is specified, this must match
-                                ContainerPort. Most containers do not need this.
+                              description: |-
+                                Number of port to expose on the host.
+                                If specified, this must be a valid port number, 0 < x < 65536.
+                                If HostNetwork is specified, this must match ContainerPort.
+                                Most containers do not need this.
                               format: int32
                               type: integer
                             name:
-                              description: If specified, this must be an IANA_SVC_NAME
-                                and unique within the pod. Each named port in a pod
-                                must have a unique name. Name for the port that can
-                                be referred to by services.
+                              description: |-
+                                If specified, this must be an IANA_SVC_NAME and unique within the pod. Each
+                                named port in a pod must have a unique name. Name for the port that can be
+                                referred to by services.
                               type: string
                             protocol:
                               default: TCP
-                              description: Protocol for port. Must be UDP, TCP, or SCTP.
+                              description: |-
+                                Protocol for port. Must be UDP, TCP, or SCTP.
                                 Defaults to "TCP".
                               type: string
                           required:
@@ -3545,30 +3490,30 @@ spec:
                           - protocol
                         x-kubernetes-list-type: map
                       readinessProbe:
-                        description: 'Periodic probe of container service readiness.
-                        Container will be removed from service endpoints if the probe
-                        fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        description: |-
+                          Periodic probe of container service readiness.
+                          Container will be removed from service endpoints if the probe fails.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
                             description: Exec specifies the action to take.
                             properties:
                               command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|', etc)
-                                  won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
                           grpc:
@@ -3580,10 +3525,12 @@ spec:
                                 format: int32
                                 type: integer
                               service:
-                                description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                  
+                                  
+                                  If this is not specified, the default behavior is defined by gRPC.
                                 type: string
                             required:
                               - port
@@ -3592,9 +3539,9 @@ spec:
                             description: HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description: Host name to connect to, defaults to the
-                                  pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
                                 description: Custom headers to set in the request. HTTP
@@ -3604,9 +3551,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name. This will
-                                        be canonicalized upon output, so case-variant
-                                        names will be understood as the same header.
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -3623,33 +3570,35 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Name or number of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description: Scheme to use for connecting to the host.
+                                description: |-
+                                  Scheme to use for connecting to the host.
                                   Defaults to HTTP.
                                 type: string
                             required:
                               - port
                             type: object
                           initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                           periodSeconds:
-                            description: How often (in seconds) to perform the probe.
+                            description: |-
+                              How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                             format: int32
                             type: integer
                           successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                             format: int32
                             type: integer
                           tcpSocket:
@@ -3664,34 +3613,33 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Number or name of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                               - port
                             type: object
                           terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully upon probe failure. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and the
-                              time when the processes are forcibly halted with a kill
-                              signal. Set this value longer than the expected cleanup
-                              time for your process. If this value is nil, the pod's
-                              terminationGracePeriodSeconds will be used. Otherwise,
-                              this value overrides the value provided by the pod spec.
-                              Value must be non-negative integer. The value zero indicates
-                              stop immediately via the kill signal (no opportunity to
-                              shut down). This is a beta field and requires enabling
-                              ProbeTerminationGracePeriod feature gate. Minimum value
-                              is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            description: |-
+                              Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                              The grace period is the duration in seconds after the processes running in the pod are sent
+                              a termination signal and the time when the processes are forcibly halted with a kill signal.
+                              Set this value longer than the expected cleanup time for your process.
+                              If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                              value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates stop immediately via
+                              the kill signal (no opportunity to shut down).
+                              This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                              Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                             format: int64
                             type: integer
                           timeoutSeconds:
-                            description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                         type: object
@@ -3702,12 +3650,14 @@ spec:
                             policy for the container.
                           properties:
                             resourceName:
-                              description: 'Name of the resource to which this resource
-                              resize policy applies. Supported values: cpu, memory.'
+                              description: |-
+                                Name of the resource to which this resource resize policy applies.
+                                Supported values: cpu, memory.
                               type: string
                             restartPolicy:
-                              description: Restart policy to apply when specified resource
-                                is resized. If not specified, it defaults to NotRequired.
+                              description: |-
+                                Restart policy to apply when specified resource is resized.
+                                If not specified, it defaults to NotRequired.
                               type: string
                           required:
                             - resourceName
@@ -3716,22 +3666,29 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       resources:
-                        description: 'Compute Resources required by this container.
-                        Cannot be updated. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                        description: |-
+                          Compute Resources required by this container.
+                          Cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         properties:
                           claims:
-                            description: "Claims lists the names of resources, defined
-                            in spec.resourceClaims, that are used by this container.
-                            \n This is an alpha field and requires enabling the DynamicResourceAllocation
-                            feature gate. \n This field is immutable. It can only
-                            be set for containers."
+                            description: |-
+                              Claims lists the names of resources, defined in spec.resourceClaims,
+                              that are used by this container.
+                              
+                              
+                              This is an alpha field and requires enabling the
+                              DynamicResourceAllocation feature gate.
+                              
+                              
+                              This field is immutable. It can only be set for containers.
                             items:
                               description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                               properties:
                                 name:
-                                  description: Name must match the name of one entry
-                                    in pod.spec.resourceClaims of the Pod where this
-                                    field is used. It makes that resource available
+                                  description: |-
+                                    Name must match the name of one entry in pod.spec.resourceClaims of
+                                    the Pod where this field is used. It makes that resource available
                                     inside a container.
                                   type: string
                               required:
@@ -3748,8 +3705,9 @@ spec:
                                 - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Limits describes the maximum amount of compute
-                            resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Limits describes the maximum amount of compute resources allowed.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                           requests:
                             additionalProperties:
@@ -3758,52 +3716,52 @@ spec:
                                 - type: string
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
-                            description: 'Requests describes the minimum amount of compute
-                            resources required. If Requests is omitted for a container,
-                            it defaults to Limits if that is explicitly specified,
-                            otherwise to an implementation-defined value. Requests
-                            cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                            description: |-
+                              Requests describes the minimum amount of compute resources required.
+                              If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                              otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                              More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
                       restartPolicy:
-                        description: 'RestartPolicy defines the restart behavior of
-                        individual containers in a pod. This field may only be set
-                        for init containers, and the only allowed value is "Always".
-                        For non-init containers or when this field is not specified,
-                        the restart behavior is defined by the Pod''s restart policy
-                        and the container type. Setting the RestartPolicy as "Always"
-                        for the init container will have the following effect: this
-                        init container will be continually restarted on exit until
-                        all regular containers have terminated. Once all regular containers
-                        have completed, all init containers with restartPolicy "Always"
-                        will be shut down. This lifecycle differs from normal init
-                        containers and is often referred to as a "sidecar" container.
-                        Although this init container still starts in the init container
-                        sequence, it does not wait for the container to complete before
-                        proceeding to the next init container. Instead, the next init
-                        container starts immediately after this init container is
-                        started, or after any startupProbe has successfully completed.'
+                        description: |-
+                          RestartPolicy defines the restart behavior of individual containers in a pod.
+                          This field may only be set for init containers, and the only allowed value is "Always".
+                          For non-init containers or when this field is not specified,
+                          the restart behavior is defined by the Pod's restart policy and the container type.
+                          Setting the RestartPolicy as "Always" for the init container will have the following effect:
+                          this init container will be continually restarted on
+                          exit until all regular containers have terminated. Once all regular
+                          containers have completed, all init containers with restartPolicy "Always"
+                          will be shut down. This lifecycle differs from normal init containers and
+                          is often referred to as a "sidecar" container. Although this init
+                          container still starts in the init container sequence, it does not wait
+                          for the container to complete before proceeding to the next init
+                          container. Instead, the next init container starts immediately after this
+                          init container is started, or after any startupProbe has successfully
+                          completed.
                         type: string
                       securityContext:
-                        description: 'SecurityContext defines the security options the
-                        container should be run with. If set, the fields of SecurityContext
-                        override the equivalent fields of PodSecurityContext. More
-                        info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/'
+                        description: |-
+                          SecurityContext defines the security options the container should be run with.
+                          If set, the fields of SecurityContext override the equivalent fields of PodSecurityContext.
+                          More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
                         properties:
                           allowPrivilegeEscalation:
-                            description: 'AllowPrivilegeEscalation controls whether
-                            a process can gain more privileges than its parent process.
-                            This bool directly controls if the no_new_privs flag will
-                            be set on the container process. AllowPrivilegeEscalation
-                            is true always when the container is: 1) run as Privileged
-                            2) has CAP_SYS_ADMIN Note that this field cannot be set
-                            when spec.os.name is windows.'
+                            description: |-
+                              AllowPrivilegeEscalation controls whether a process can gain more
+                              privileges than its parent process. This bool directly controls if
+                              the no_new_privs flag will be set on the container process.
+                              AllowPrivilegeEscalation is true always when the container is:
+                              1) run as Privileged
+                              2) has CAP_SYS_ADMIN
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           capabilities:
-                            description: The capabilities to add/drop when running containers.
-                              Defaults to the default set of capabilities granted by
-                              the container runtime. Note that this field cannot be
-                              set when spec.os.name is windows.
+                            description: |-
+                              The capabilities to add/drop when running containers.
+                              Defaults to the default set of capabilities granted by the container runtime.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               add:
                                 description: Added capabilities
@@ -3821,60 +3779,60 @@ spec:
                                 type: array
                             type: object
                           privileged:
-                            description: Run container in privileged mode. Processes
-                              in privileged containers are essentially equivalent to
-                              root on the host. Defaults to false. Note that this field
-                              cannot be set when spec.os.name is windows.
+                            description: |-
+                              Run container in privileged mode.
+                              Processes in privileged containers are essentially equivalent to root on the host.
+                              Defaults to false.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           procMount:
-                            description: procMount denotes the type of proc mount to
-                              use for the containers. The default is DefaultProcMount
-                              which uses the container runtime defaults for readonly
-                              paths and masked paths. This requires the ProcMountType
-                              feature flag to be enabled. Note that this field cannot
-                              be set when spec.os.name is windows.
+                            description: |-
+                              procMount denotes the type of proc mount to use for the containers.
+                              The default is DefaultProcMount which uses the container runtime defaults for
+                              readonly paths and masked paths.
+                              This requires the ProcMountType feature flag to be enabled.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: string
                           readOnlyRootFilesystem:
-                            description: Whether this container has a read-only root
-                              filesystem. Default is false. Note that this field cannot
-                              be set when spec.os.name is windows.
+                            description: |-
+                              Whether this container has a read-only root filesystem.
+                              Default is false.
+                              Note that this field cannot be set when spec.os.name is windows.
                             type: boolean
                           runAsGroup:
-                            description: The GID to run the entrypoint of the container
-                              process. Uses runtime default if unset. May also be set
-                              in PodSecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence. Note that this field cannot be set when
-                              spec.os.name is windows.
+                            description: |-
+                              The GID to run the entrypoint of the container process.
+                              Uses runtime default if unset.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           runAsNonRoot:
-                            description: Indicates that the container must run as a
-                              non-root user. If true, the Kubelet will validate the
-                              image at runtime to ensure that it does not run as UID
-                              0 (root) and fail to start the container if it does. If
-                              unset or false, no such validation will be performed.
-                              May also be set in PodSecurityContext.  If set in both
-                              SecurityContext and PodSecurityContext, the value specified
-                              in SecurityContext takes precedence.
+                            description: |-
+                              Indicates that the container must run as a non-root user.
+                              If true, the Kubelet will validate the image at runtime to ensure that it
+                              does not run as UID 0 (root) and fail to start the container if it does.
+                              If unset or false, no such validation will be performed.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
                             type: boolean
                           runAsUser:
-                            description: The UID to run the entrypoint of the container
-                              process. Defaults to user specified in image metadata
-                              if unspecified. May also be set in PodSecurityContext.  If
-                              set in both SecurityContext and PodSecurityContext, the
-                              value specified in SecurityContext takes precedence. Note
-                              that this field cannot be set when spec.os.name is windows.
+                            description: |-
+                              The UID to run the entrypoint of the container process.
+                              Defaults to user specified in image metadata if unspecified.
+                              May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             format: int64
                             type: integer
                           seLinuxOptions:
-                            description: The SELinux context to be applied to the container.
-                              If unspecified, the container runtime will allocate a
-                              random SELinux context for each container.  May also be
-                              set in PodSecurityContext.  If set in both SecurityContext
-                              and PodSecurityContext, the value specified in SecurityContext
-                              takes precedence. Note that this field cannot be set when
-                              spec.os.name is windows.
+                            description: |-
+                              The SELinux context to be applied to the container.
+                              If unspecified, the container runtime will allocate a random SELinux context for each
+                              container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                              PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               level:
                                 description: Level is SELinux level label that applies
@@ -3894,98 +3852,93 @@ spec:
                                 type: string
                             type: object
                           seccompProfile:
-                            description: The seccomp options to use by this container.
-                              If seccomp options are provided at both the pod & container
-                              level, the container options override the pod options.
-                              Note that this field cannot be set when spec.os.name is
-                              windows.
+                            description: |-
+                              The seccomp options to use by this container. If seccomp options are
+                              provided at both the pod & container level, the container options
+                              override the pod options.
+                              Note that this field cannot be set when spec.os.name is windows.
                             properties:
                               localhostProfile:
-                                description: localhostProfile indicates a profile defined
-                                  in a file on the node should be used. The profile
-                                  must be preconfigured on the node to work. Must be
-                                  a descending path, relative to the kubelet's configured
-                                  seccomp profile location. Must be set if type is "Localhost".
-                                  Must NOT be set for any other type.
+                                description: |-
+                                  localhostProfile indicates a profile defined in a file on the node should be used.
+                                  The profile must be preconfigured on the node to work.
+                                  Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                  Must be set if type is "Localhost". Must NOT be set for any other type.
                                 type: string
                               type:
-                                description: "type indicates which kind of seccomp profile
-                                will be applied. Valid options are: \n Localhost -
-                                a profile defined in a file on the node should be
-                                used. RuntimeDefault - the container runtime default
-                                profile should be used. Unconfined - no profile should
-                                be applied."
+                                description: |-
+                                  type indicates which kind of seccomp profile will be applied.
+                                  Valid options are:
+                                  
+                                  
+                                  Localhost - a profile defined in a file on the node should be used.
+                                  RuntimeDefault - the container runtime default profile should be used.
+                                  Unconfined - no profile should be applied.
                                 type: string
                             required:
                               - type
                             type: object
                           windowsOptions:
-                            description: The Windows specific settings applied to all
-                              containers. If unspecified, the options from the PodSecurityContext
-                              will be used. If set in both SecurityContext and PodSecurityContext,
-                              the value specified in SecurityContext takes precedence.
-                              Note that this field cannot be set when spec.os.name is
-                              linux.
+                            description: |-
+                              The Windows specific settings applied to all containers.
+                              If unspecified, the options from the PodSecurityContext will be used.
+                              If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              Note that this field cannot be set when spec.os.name is linux.
                             properties:
                               gmsaCredentialSpec:
-                                description: GMSACredentialSpec is where the GMSA admission
-                                  webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                                  inlines the contents of the GMSA credential spec named
-                                  by the GMSACredentialSpecName field.
+                                description: |-
+                                  GMSACredentialSpec is where the GMSA admission webhook
+                                  (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                  GMSA credential spec named by the GMSACredentialSpecName field.
                                 type: string
                               gmsaCredentialSpecName:
                                 description: GMSACredentialSpecName is the name of the
                                   GMSA credential spec to use.
                                 type: string
                               hostProcess:
-                                description: HostProcess determines if a container should
-                                  be run as a 'Host Process' container. All of a Pod's
-                                  containers must have the same effective HostProcess
-                                  value (it is not allowed to have a mix of HostProcess
-                                  containers and non-HostProcess containers). In addition,
-                                  if HostProcess is true then HostNetwork must also
-                                  be set to true.
+                                description: |-
+                                  HostProcess determines if a container should be run as a 'Host Process' container.
+                                  All of a Pod's containers must have the same effective HostProcess value
+                                  (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                  In addition, if HostProcess is true then HostNetwork must also be set to true.
                                 type: boolean
                               runAsUserName:
-                                description: The UserName in Windows to run the entrypoint
-                                  of the container process. Defaults to the user specified
-                                  in image metadata if unspecified. May also be set
-                                  in PodSecurityContext. If set in both SecurityContext
-                                  and PodSecurityContext, the value specified in SecurityContext
-                                  takes precedence.
+                                description: |-
+                                  The UserName in Windows to run the entrypoint of the container process.
+                                  Defaults to the user specified in image metadata if unspecified.
+                                  May also be set in PodSecurityContext. If set in both SecurityContext and
+                                  PodSecurityContext, the value specified in SecurityContext takes precedence.
                                 type: string
                             type: object
                         type: object
                       startupProbe:
-                        description: 'StartupProbe indicates that the Pod has successfully
-                        initialized. If specified, no other probes are executed until
-                        this completes successfully. If this probe fails, the Pod
-                        will be restarted, just as if the livenessProbe failed. This
-                        can be used to provide different probe parameters at the beginning
-                        of a Pod''s lifecycle, when it might take a long time to load
-                        data or warm a cache, than during steady-state operation.
-                        This cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                        description: |-
+                          StartupProbe indicates that the Pod has successfully initialized.
+                          If specified, no other probes are executed until this completes successfully.
+                          If this probe fails, the Pod will be restarted, just as if the livenessProbe failed.
+                          This can be used to provide different probe parameters at the beginning of a Pod's lifecycle,
+                          when it might take a long time to load data or warm a cache, than during steady-state operation.
+                          This cannot be updated.
+                          More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                         properties:
                           exec:
                             description: Exec specifies the action to take.
                             properties:
                               command:
-                                description: Command is the command line to execute
-                                  inside the container, the working directory for the
-                                  command  is root ('/') in the container's filesystem.
-                                  The command is simply exec'd, it is not run inside
-                                  a shell, so traditional shell instructions ('|', etc)
-                                  won't work. To use a shell, you need to explicitly
-                                  call out to that shell. Exit status of 0 is treated
-                                  as live/healthy and non-zero is unhealthy.
+                                description: |-
+                                  Command is the command line to execute inside the container, the working directory for the
+                                  command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                  not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                  a shell, you need to explicitly call out to that shell.
+                                  Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                                 items:
                                   type: string
                                 type: array
                             type: object
                           failureThreshold:
-                            description: Minimum consecutive failures for the probe
-                              to be considered failed after having succeeded. Defaults
-                              to 3. Minimum value is 1.
+                            description: |-
+                              Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                              Defaults to 3. Minimum value is 1.
                             format: int32
                             type: integer
                           grpc:
@@ -3997,10 +3950,12 @@ spec:
                                 format: int32
                                 type: integer
                               service:
-                                description: "Service is the name of the service to
-                                place in the gRPC HealthCheckRequest (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
-                                \n If this is not specified, the default behavior
-                                is defined by gRPC."
+                                description: |-
+                                  Service is the name of the service to place in the gRPC HealthCheckRequest
+                                  (see https://github.com/grpc/grpc/blob/master/doc/health-checking.md).
+                                  
+                                  
+                                  If this is not specified, the default behavior is defined by gRPC.
                                 type: string
                             required:
                               - port
@@ -4009,9 +3964,9 @@ spec:
                             description: HTTPGet specifies the http request to perform.
                             properties:
                               host:
-                                description: Host name to connect to, defaults to the
-                                  pod IP. You probably want to set "Host" in httpHeaders
-                                  instead.
+                                description: |-
+                                  Host name to connect to, defaults to the pod IP. You probably want to set
+                                  "Host" in httpHeaders instead.
                                 type: string
                               httpHeaders:
                                 description: Custom headers to set in the request. HTTP
@@ -4021,9 +3976,9 @@ spec:
                                     to be used in HTTP probes
                                   properties:
                                     name:
-                                      description: The header field name. This will
-                                        be canonicalized upon output, so case-variant
-                                        names will be understood as the same header.
+                                      description: |-
+                                        The header field name.
+                                        This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                       type: string
                                     value:
                                       description: The header field value
@@ -4040,33 +3995,35 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Name or number of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Name or number of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                               scheme:
-                                description: Scheme to use for connecting to the host.
+                                description: |-
+                                  Scheme to use for connecting to the host.
                                   Defaults to HTTP.
                                 type: string
                             required:
                               - port
                             type: object
                           initialDelaySeconds:
-                            description: 'Number of seconds after the container has
-                            started before liveness probes are initiated. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after the container has started before liveness probes are initiated.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                           periodSeconds:
-                            description: How often (in seconds) to perform the probe.
+                            description: |-
+                              How often (in seconds) to perform the probe.
                               Default to 10 seconds. Minimum value is 1.
                             format: int32
                             type: integer
                           successThreshold:
-                            description: Minimum consecutive successes for the probe
-                              to be considered successful after having failed. Defaults
-                              to 1. Must be 1 for liveness and startup. Minimum value
-                              is 1.
+                            description: |-
+                              Minimum consecutive successes for the probe to be considered successful after having failed.
+                              Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                             format: int32
                             type: integer
                           tcpSocket:
@@ -4081,77 +4038,76 @@ spec:
                                 anyOf:
                                   - type: integer
                                   - type: string
-                                description: Number or name of the port to access on
-                                  the container. Number must be in the range 1 to 65535.
+                                description: |-
+                                  Number or name of the port to access on the container.
+                                  Number must be in the range 1 to 65535.
                                   Name must be an IANA_SVC_NAME.
                                 x-kubernetes-int-or-string: true
                             required:
                               - port
                             type: object
                           terminationGracePeriodSeconds:
-                            description: Optional duration in seconds the pod needs
-                              to terminate gracefully upon probe failure. The grace
-                              period is the duration in seconds after the processes
-                              running in the pod are sent a termination signal and the
-                              time when the processes are forcibly halted with a kill
-                              signal. Set this value longer than the expected cleanup
-                              time for your process. If this value is nil, the pod's
-                              terminationGracePeriodSeconds will be used. Otherwise,
-                              this value overrides the value provided by the pod spec.
-                              Value must be non-negative integer. The value zero indicates
-                              stop immediately via the kill signal (no opportunity to
-                              shut down). This is a beta field and requires enabling
-                              ProbeTerminationGracePeriod feature gate. Minimum value
-                              is 1. spec.terminationGracePeriodSeconds is used if unset.
+                            description: |-
+                              Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                              The grace period is the duration in seconds after the processes running in the pod are sent
+                              a termination signal and the time when the processes are forcibly halted with a kill signal.
+                              Set this value longer than the expected cleanup time for your process.
+                              If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                              value overrides the value provided by the pod spec.
+                              Value must be non-negative integer. The value zero indicates stop immediately via
+                              the kill signal (no opportunity to shut down).
+                              This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                              Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                             format: int64
                             type: integer
                           timeoutSeconds:
-                            description: 'Number of seconds after which the probe times
-                            out. Defaults to 1 second. Minimum value is 1. More info:
-                            https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                            description: |-
+                              Number of seconds after which the probe times out.
+                              Defaults to 1 second. Minimum value is 1.
+                              More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                             format: int32
                             type: integer
                         type: object
                       stdin:
-                        description: Whether this container should allocate a buffer
-                          for stdin in the container runtime. If this is not set, reads
-                          from stdin in the container will always result in EOF. Default
-                          is false.
+                        description: |-
+                          Whether this container should allocate a buffer for stdin in the container runtime. If this
+                          is not set, reads from stdin in the container will always result in EOF.
+                          Default is false.
                         type: boolean
                       stdinOnce:
-                        description: Whether the container runtime should close the
-                          stdin channel after it has been opened by a single attach.
-                          When stdin is true the stdin stream will remain open across
-                          multiple attach sessions. If stdinOnce is set to true, stdin
-                          is opened on container start, is empty until the first client
-                          attaches to stdin, and then remains open and accepts data
-                          until the client disconnects, at which time stdin is closed
-                          and remains closed until the container is restarted. If this
-                          flag is false, a container processes that reads from stdin
-                          will never receive an EOF. Default is false
+                        description: |-
+                          Whether the container runtime should close the stdin channel after it has been opened by
+                          a single attach. When stdin is true the stdin stream will remain open across multiple attach
+                          sessions. If stdinOnce is set to true, stdin is opened on container start, is empty until the
+                          first client attaches to stdin, and then remains open and accepts data until the client disconnects,
+                          at which time stdin is closed and remains closed until the container is restarted. If this
+                          flag is false, a container processes that reads from stdin will never receive an EOF.
+                          Default is false
                         type: boolean
                       terminationMessagePath:
-                        description: 'Optional: Path at which the file to which the
-                        container''s termination message will be written is mounted
-                        into the container''s filesystem. Message written is intended
-                        to be brief final status, such as an assertion failure message.
-                        Will be truncated by the node if greater than 4096 bytes.
-                        The total message length across all containers will be limited
-                        to 12kb. Defaults to /dev/termination-log. Cannot be updated.'
+                        description: |-
+                          Optional: Path at which the file to which the container's termination message
+                          will be written is mounted into the container's filesystem.
+                          Message written is intended to be brief final status, such as an assertion failure message.
+                          Will be truncated by the node if greater than 4096 bytes. The total message length across
+                          all containers will be limited to 12kb.
+                          Defaults to /dev/termination-log.
+                          Cannot be updated.
                         type: string
                       terminationMessagePolicy:
-                        description: Indicate how the termination message should be
-                          populated. File will use the contents of terminationMessagePath
-                          to populate the container status message on both success and
-                          failure. FallbackToLogsOnError will use the last chunk of
-                          container log output if the termination message file is empty
-                          and the container exited with an error. The log output is
-                          limited to 2048 bytes or 80 lines, whichever is smaller. Defaults
-                          to File. Cannot be updated.
+                        description: |-
+                          Indicate how the termination message should be populated. File will use the contents of
+                          terminationMessagePath to populate the container status message on both success and failure.
+                          FallbackToLogsOnError will use the last chunk of container log output if the termination
+                          message file is empty and the container exited with an error.
+                          The log output is limited to 2048 bytes or 80 lines, whichever is smaller.
+                          Defaults to File.
+                          Cannot be updated.
                         type: string
                       tty:
-                        description: Whether this container should allocate a TTY for
-                          itself, also requires 'stdin' to be true. Default is false.
+                        description: |-
+                          Whether this container should allocate a TTY for itself, also requires 'stdin' to be true.
+                          Default is false.
                         type: boolean
                       volumeDevices:
                         description: volumeDevices is the list of block devices to be
@@ -4174,40 +4130,44 @@ spec:
                           type: object
                         type: array
                       volumeMounts:
-                        description: Pod volumes to mount into the container's filesystem.
+                        description: |-
+                          Pod volumes to mount into the container's filesystem.
                           Cannot be updated.
                         items:
                           description: VolumeMount describes a mounting of a Volume
                             within a container.
                           properties:
                             mountPath:
-                              description: Path within the container at which the volume
-                                should be mounted.  Must not contain ':'.
+                              description: |-
+                                Path within the container at which the volume should be mounted.  Must
+                                not contain ':'.
                               type: string
                             mountPropagation:
-                              description: mountPropagation determines how mounts are
-                                propagated from the host to container and the other
-                                way around. When not set, MountPropagationNone is used.
+                              description: |-
+                                mountPropagation determines how mounts are propagated from the host
+                                to container and the other way around.
+                                When not set, MountPropagationNone is used.
                                 This field is beta in 1.10.
                               type: string
                             name:
                               description: This must match the Name of a Volume.
                               type: string
                             readOnly:
-                              description: Mounted read-only if true, read-write otherwise
-                                (false or unspecified). Defaults to false.
+                              description: |-
+                                Mounted read-only if true, read-write otherwise (false or unspecified).
+                                Defaults to false.
                               type: boolean
                             subPath:
-                              description: Path within the volume from which the container's
-                                volume should be mounted. Defaults to "" (volume's root).
+                              description: |-
+                                Path within the volume from which the container's volume should be mounted.
+                                Defaults to "" (volume's root).
                               type: string
                             subPathExpr:
-                              description: Expanded path within the volume from which
-                                the container's volume should be mounted. Behaves similarly
-                                to SubPath but environment variable references $(VAR_NAME)
-                                are expanded using the container's environment. Defaults
-                                to "" (volume's root). SubPathExpr and SubPath are mutually
-                                exclusive.
+                              description: |-
+                                Expanded path within the volume from which the container's volume should be mounted.
+                                Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                                Defaults to "" (volume's root).
+                                SubPathExpr and SubPath are mutually exclusive.
                               type: string
                           required:
                             - mountPath
@@ -4215,9 +4175,11 @@ spec:
                           type: object
                         type: array
                       workingDir:
-                        description: Container's working directory. If not specified,
-                          the container runtime's default will be used, which might
-                          be configured in the container image. Cannot be updated.
+                        description: |-
+                          Container's working directory.
+                          If not specified, the container runtime's default will be used, which
+                          might be configured in the container image.
+                          Cannot be updated.
                         type: string
                     required:
                       - name
@@ -4228,24 +4190,22 @@ spec:
                     to container lifecycle events. Cannot be updated.
                   properties:
                     postStart:
-                      description: 'PostStart is called immediately after a container
-                      is created. If the handler fails, the container is terminated
-                      and restarted according to its restart policy. Other management
-                      of the container blocks until the hook completes. More info:
-                      https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      description: |-
+                        PostStart is called immediately after a container is created. If the handler fails,
+                        the container is terminated and restarted according to its restart policy.
+                        Other management of the container blocks until the hook completes.
+                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                       properties:
                         exec:
                           description: Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute inside
-                                the container, the working directory for the command  is
-                                root ('/') in the container's filesystem. The command
-                                is simply exec'd, it is not run inside a shell, so traditional
-                                shell instructions ('|', etc) won't work. To use a shell,
-                                you need to explicitly call out to that shell. Exit
-                                status of 0 is treated as live/healthy and non-zero
-                                is unhealthy.
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                a shell, you need to explicitly call out to that shell.
+                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
@@ -4254,9 +4214,9 @@ spec:
                           description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
                               description: Custom headers to set in the request. HTTP
@@ -4266,9 +4226,9 @@ spec:
                                   be used in HTTP probes
                                 properties:
                                   name:
-                                    description: The header field name. This will be
-                                      canonicalized upon output, so case-variant names
-                                      will be understood as the same header.
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
                                     description: The header field value
@@ -4285,12 +4245,14 @@ spec:
                               anyOf:
                                 - type: integer
                                 - type: string
-                              description: Name or number of the port to access on the
-                                container. Number must be in the range 1 to 65535. Name
-                                must be an IANA_SVC_NAME.
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host.
+                              description: |-
+                                Scheme to use for connecting to the host.
                                 Defaults to HTTP.
                               type: string
                           required:
@@ -4308,10 +4270,10 @@ spec:
                             - seconds
                           type: object
                         tcpSocket:
-                          description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler
-                            and kept for the backward compatibility. There are no validation
-                            of this field and lifecycle hooks will fail in runtime when
-                            tcp handler is specified.
+                          description: |-
+                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                            for the backward compatibility. There are no validation of this field and
+                            lifecycle hooks will fail in runtime when tcp handler is specified.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults
@@ -4321,39 +4283,37 @@ spec:
                               anyOf:
                                 - type: integer
                                 - type: string
-                              description: Number or name of the port to access on the
-                                container. Number must be in the range 1 to 65535. Name
-                                must be an IANA_SVC_NAME.
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                             - port
                           type: object
                       type: object
                     preStop:
-                      description: 'PreStop is called immediately before a container
-                      is terminated due to an API request or management event such
-                      as liveness/startup probe failure, preemption, resource contention,
-                      etc. The handler is not called if the container crashes or exits.
-                      The Pod''s termination grace period countdown begins before
-                      the PreStop hook is executed. Regardless of the outcome of the
-                      handler, the container will eventually terminate within the
-                      Pod''s termination grace period (unless delayed by finalizers).
-                      Other management of the container blocks until the hook completes
-                      or until the termination grace period is reached. More info:
-                      https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks'
+                      description: |-
+                        PreStop is called immediately before a container is terminated due to an
+                        API request or management event such as liveness/startup probe failure,
+                        preemption, resource contention, etc. The handler is not called if the
+                        container crashes or exits. The Pod's termination grace period countdown begins before the
+                        PreStop hook is executed. Regardless of the outcome of the handler, the
+                        container will eventually terminate within the Pod's termination grace
+                        period (unless delayed by finalizers). Other management of the container blocks until the hook completes
+                        or until the termination grace period is reached.
+                        More info: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks
                       properties:
                         exec:
                           description: Exec specifies the action to take.
                           properties:
                             command:
-                              description: Command is the command line to execute inside
-                                the container, the working directory for the command  is
-                                root ('/') in the container's filesystem. The command
-                                is simply exec'd, it is not run inside a shell, so traditional
-                                shell instructions ('|', etc) won't work. To use a shell,
-                                you need to explicitly call out to that shell. Exit
-                                status of 0 is treated as live/healthy and non-zero
-                                is unhealthy.
+                              description: |-
+                                Command is the command line to execute inside the container, the working directory for the
+                                command  is root ('/') in the container's filesystem. The command is simply exec'd, it is
+                                not run inside a shell, so traditional shell instructions ('|', etc) won't work. To use
+                                a shell, you need to explicitly call out to that shell.
+                                Exit status of 0 is treated as live/healthy and non-zero is unhealthy.
                               items:
                                 type: string
                               type: array
@@ -4362,9 +4322,9 @@ spec:
                           description: HTTPGet specifies the http request to perform.
                           properties:
                             host:
-                              description: Host name to connect to, defaults to the
-                                pod IP. You probably want to set "Host" in httpHeaders
-                                instead.
+                              description: |-
+                                Host name to connect to, defaults to the pod IP. You probably want to set
+                                "Host" in httpHeaders instead.
                               type: string
                             httpHeaders:
                               description: Custom headers to set in the request. HTTP
@@ -4374,9 +4334,9 @@ spec:
                                   be used in HTTP probes
                                 properties:
                                   name:
-                                    description: The header field name. This will be
-                                      canonicalized upon output, so case-variant names
-                                      will be understood as the same header.
+                                    description: |-
+                                      The header field name.
+                                      This will be canonicalized upon output, so case-variant names will be understood as the same header.
                                     type: string
                                   value:
                                     description: The header field value
@@ -4393,12 +4353,14 @@ spec:
                               anyOf:
                                 - type: integer
                                 - type: string
-                              description: Name or number of the port to access on the
-                                container. Number must be in the range 1 to 65535. Name
-                                must be an IANA_SVC_NAME.
+                              description: |-
+                                Name or number of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                             scheme:
-                              description: Scheme to use for connecting to the host.
+                              description: |-
+                                Scheme to use for connecting to the host.
                                 Defaults to HTTP.
                               type: string
                           required:
@@ -4416,10 +4378,10 @@ spec:
                             - seconds
                           type: object
                         tcpSocket:
-                          description: Deprecated. TCPSocket is NOT supported as a LifecycleHandler
-                            and kept for the backward compatibility. There are no validation
-                            of this field and lifecycle hooks will fail in runtime when
-                            tcp handler is specified.
+                          description: |-
+                            Deprecated. TCPSocket is NOT supported as a LifecycleHandler and kept
+                            for the backward compatibility. There are no validation of this field and
+                            lifecycle hooks will fail in runtime when tcp handler is specified.
                           properties:
                             host:
                               description: 'Optional: Host name to connect to, defaults
@@ -4429,9 +4391,10 @@ spec:
                               anyOf:
                                 - type: integer
                                 - type: string
-                              description: Number or name of the port to access on the
-                                container. Number must be in the range 1 to 65535. Name
-                                must be an IANA_SVC_NAME.
+                              description: |-
+                                Number or name of the port to access on the container.
+                                Number must be in the range 1 to 65535.
+                                Name must be an IANA_SVC_NAME.
                               x-kubernetes-int-or-string: true
                           required:
                             - port
@@ -4439,74 +4402,76 @@ spec:
                       type: object
                   type: object
                 livenessProbe:
-                  description: Liveness config for the OpenTelemetry Collector except
-                    the probe handler which is auto generated from the health extension
-                    of the collector. It is only effective when healthcheckextension
-                    is configured in the OpenTelemetry Collector pipeline.
+                  description: |-
+                    Liveness config for the OpenTelemetry Collector except the probe handler which is auto generated from the health extension of the collector.
+                    It is only effective when healthcheckextension is configured in the OpenTelemetry Collector pipeline.
                   properties:
                     failureThreshold:
-                      description: Minimum consecutive failures for the probe to be
-                        considered failed after having succeeded. Defaults to 3. Minimum
-                        value is 1.
+                      description: |-
+                        Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                        Defaults to 3. Minimum value is 1.
                       format: int32
                       type: integer
                     initialDelaySeconds:
-                      description: 'Number of seconds after the container has started
-                      before liveness probes are initiated. Defaults to 0 seconds.
-                      Minimum value is 0. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      description: |-
+                        Number of seconds after the container has started before liveness probes are initiated.
+                        Defaults to 0 seconds. Minimum value is 0.
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       format: int32
                       type: integer
                     periodSeconds:
-                      description: How often (in seconds) to perform the probe. Default
-                        to 10 seconds. Minimum value is 1.
+                      description: |-
+                        How often (in seconds) to perform the probe.
+                        Default to 10 seconds. Minimum value is 1.
                       format: int32
                       type: integer
                     successThreshold:
-                      description: Minimum consecutive successes for the probe to be
-                        considered successful after having failed. Defaults to 1. Must
-                        be 1 for liveness and startup. Minimum value is 1.
+                      description: |-
+                        Minimum consecutive successes for the probe to be considered successful after having failed.
+                        Defaults to 1. Must be 1 for liveness and startup. Minimum value is 1.
                       format: int32
                       type: integer
                     terminationGracePeriodSeconds:
-                      description: Optional duration in seconds the pod needs to terminate
-                        gracefully upon probe failure. The grace period is the duration
-                        in seconds after the processes running in the pod are sent a
-                        termination signal and the time when the processes are forcibly
-                        halted with a kill signal. Set this value longer than the expected
-                        cleanup time for your process. If this value is nil, the pod's
-                        terminationGracePeriodSeconds will be used. Otherwise, this
-                        value overrides the value provided by the pod spec. Value must
-                        be non-negative integer. The value zero indicates stop immediately
-                        via the kill signal (no opportunity to shut down). This is a
-                        beta field and requires enabling ProbeTerminationGracePeriod
-                        feature gate. Minimum value is 1. spec.terminationGracePeriodSeconds
-                        is used if unset.
+                      description: |-
+                        Optional duration in seconds the pod needs to terminate gracefully upon probe failure.
+                        The grace period is the duration in seconds after the processes running in the pod are sent
+                        a termination signal and the time when the processes are forcibly halted with a kill signal.
+                        Set this value longer than the expected cleanup time for your process.
+                        If this value is nil, the pod's terminationGracePeriodSeconds will be used. Otherwise, this
+                        value overrides the value provided by the pod spec.
+                        Value must be non-negative integer. The value zero indicates stop immediately via
+                        the kill signal (no opportunity to shut down).
+                        This is a beta field and requires enabling ProbeTerminationGracePeriod feature gate.
+                        Minimum value is 1. spec.terminationGracePeriodSeconds is used if unset.
                       format: int64
                       type: integer
                     timeoutSeconds:
-                      description: 'Number of seconds after which the probe times out.
-                      Defaults to 1 second. Minimum value is 1. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes'
+                      description: |-
+                        Number of seconds after which the probe times out.
+                        Defaults to 1 second. Minimum value is 1.
+                        More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes
                       format: int32
                       type: integer
                   type: object
                 managementState:
                   default: managed
-                  description: ManagementState defines if the CR should be managed by
-                    the operator or not. Default is managed.
+                  description: |-
+                    ManagementState defines if the CR should be managed by the operator or not.
+                    Default is managed.
                   enum:
                     - managed
                     - unmanaged
                   type: string
                 maxReplicas:
-                  description: 'MaxReplicas sets an upper bound to the autoscaling feature.
-                  If MaxReplicas is set autoscaling is enabled. Deprecated: use "AmazonCloudWatchAgent.Spec.Autoscaler.MaxReplicas"
-                  instead.'
+                  description: |-
+                    MaxReplicas sets an upper bound to the autoscaling feature. If MaxReplicas is set autoscaling is enabled.
+                    Deprecated: use "AmazonCloudWatchAgent.Spec.Autoscaler.MaxReplicas" instead.
                   format: int32
                   type: integer
                 minReplicas:
-                  description: 'MinReplicas sets a lower bound to the autoscaling feature.  Set
-                  this if you are using autoscaling. It must be at least 1 Deprecated:
-                  use "AmazonCloudWatchAgent.Spec.Autoscaler.MinReplicas" instead.'
+                  description: |-
+                    MinReplicas sets a lower bound to the autoscaling feature.  Set this if you are using autoscaling. It must be at least 1
+                    Deprecated: use "AmazonCloudWatchAgent.Spec.Autoscaler.MinReplicas" instead.
                   format: int32
                   type: integer
                 mode:
@@ -4521,9 +4486,9 @@ spec:
                 nodeSelector:
                   additionalProperties:
                     type: string
-                  description: NodeSelector to schedule OpenTelemetry Collector pods.
-                    This is only relevant to daemonset, statefulset, and deployment
-                    mode
+                  description: |-
+                    NodeSelector to schedule OpenTelemetry Collector pods.
+                    This is only relevant to daemonset, statefulset, and deployment mode
                   type: object
                 observability:
                   description: ObservabilitySpec defines how telemetry data gets handled.
@@ -4532,104 +4497,121 @@ spec:
                       description: Metrics defines the metrics configuration for operands.
                       properties:
                         enableMetrics:
-                          description: EnableMetrics specifies if ServiceMonitor or
-                            PodMonitor(for sidecar mode) should be created for the service
-                            managed by the OpenTelemetry Operator. The operator.observability.prometheus
-                            feature gate must be enabled to use this feature.
+                          description: |-
+                            EnableMetrics specifies if ServiceMonitor or PodMonitor(for sidecar mode) should be created for the service managed by the OpenTelemetry Operator.
+                            The operator.observability.prometheus feature gate must be enabled to use this feature.
                           type: boolean
                       type: object
                   type: object
+                otelConfig:
+                  description: Config is the raw YAML to be used as the collector's
+                    configuration. Refer to the OpenTelemetry Collector documentation
+                    for details.
+                  type: string
                 podAnnotations:
                   additionalProperties:
                     type: string
-                  description: PodAnnotations is the set of annotations that will be
-                    attached to Collector and Target Allocator pods.
+                  description: |-
+                    PodAnnotations is the set of annotations that will be attached to
+                    Collector and Target Allocator pods.
                   type: object
                 podDisruptionBudget:
-                  description: PodDisruptionBudget specifies the pod disruption budget
-                    configuration to use for the AmazonCloudWatchAgent workload.
+                  description: |-
+                    PodDisruptionBudget specifies the pod disruption budget configuration to use
+                    for the AmazonCloudWatchAgent workload.
                   properties:
                     maxUnavailable:
                       anyOf:
                         - type: integer
                         - type: string
-                      description: An eviction is allowed if at most "maxUnavailable"
-                        pods selected by "selector" are unavailable after the eviction,
-                        i.e. even in absence of the evicted pod. For example, one can
-                        prevent all voluntary evictions by specifying 0. This is a mutually
-                        exclusive setting with "minAvailable".
+                      description: |-
+                        An eviction is allowed if at most "maxUnavailable" pods selected by
+                        "selector" are unavailable after the eviction, i.e. even in absence of
+                        the evicted pod. For example, one can prevent all voluntary evictions
+                        by specifying 0. This is a mutually exclusive setting with "minAvailable".
                       x-kubernetes-int-or-string: true
                     minAvailable:
                       anyOf:
                         - type: integer
                         - type: string
-                      description: An eviction is allowed if at least "minAvailable"
-                        pods selected by "selector" will still be available after the
-                        eviction, i.e. even in the absence of the evicted pod.  So for
-                        example you can prevent all voluntary evictions by specifying
-                        "100%".
+                      description: |-
+                        An eviction is allowed if at least "minAvailable" pods selected by
+                        "selector" will still be available after the eviction, i.e. even in the
+                        absence of the evicted pod.  So for example you can prevent all voluntary
+                        evictions by specifying "100%".
                       x-kubernetes-int-or-string: true
                   type: object
                 podSecurityContext:
-                  description: "PodSecurityContext configures the pod security context
-                  for the opentelemetry-collector pod, when running as a deployment,
-                  daemonset, or statefulset. \n In sidecar mode, the amazon-cloudwatch-agent-operator
-                  will ignore this setting."
+                  description: |-
+                    PodSecurityContext configures the pod security context for the
+                    amazon-cloudwatch-agent pod, when running as a deployment, daemonset,
+                    or statefulset.
+                    
+                    
+                    In sidecar mode, the amazon-cloudwatch-agent-operator will ignore this setting.
                   properties:
                     fsGroup:
-                      description: "A special supplemental group that applies to all
-                      containers in a pod. Some volume types allow the Kubelet to
-                      change the ownership of that volume to be owned by the pod:
-                      \n 1. The owning GID will be the FSGroup 2. The setgid bit is
-                      set (new files created in the volume will be owned by FSGroup)
-                      3. The permission bits are OR'd with rw-rw---- \n If unset,
-                      the Kubelet will not modify the ownership and permissions of
-                      any volume. Note that this field cannot be set when spec.os.name
-                      is windows."
+                      description: |-
+                        A special supplemental group that applies to all containers in a pod.
+                        Some volume types allow the Kubelet to change the ownership of that volume
+                        to be owned by the pod:
+                        
+                        
+                        1. The owning GID will be the FSGroup
+                        2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                        3. The permission bits are OR'd with rw-rw----
+                        
+                        
+                        If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                        Note that this field cannot be set when spec.os.name is windows.
                       format: int64
                       type: integer
                     fsGroupChangePolicy:
-                      description: 'fsGroupChangePolicy defines behavior of changing
-                      ownership and permission of the volume before being exposed
-                      inside Pod. This field will only apply to volume types which
-                      support fsGroup based ownership(and permissions). It will have
-                      no effect on ephemeral volume types such as: secret, configmaps
-                      and emptydir. Valid values are "OnRootMismatch" and "Always".
-                      If not specified, "Always" is used. Note that this field cannot
-                      be set when spec.os.name is windows.'
+                      description: |-
+                        fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                        before being exposed inside Pod. This field will only apply to
+                        volume types which support fsGroup based ownership(and permissions).
+                        It will have no effect on ephemeral volume types such as: secret, configmaps
+                        and emptydir.
+                        Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                        Note that this field cannot be set when spec.os.name is windows.
                       type: string
                     runAsGroup:
-                      description: The GID to run the entrypoint of the container process.
-                        Uses runtime default if unset. May also be set in SecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence for that container.
+                      description: |-
+                        The GID to run the entrypoint of the container process.
+                        Uses runtime default if unset.
+                        May also be set in SecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence
+                        for that container.
                         Note that this field cannot be set when spec.os.name is windows.
                       format: int64
                       type: integer
                     runAsNonRoot:
-                      description: Indicates that the container must run as a non-root
-                        user. If true, the Kubelet will validate the image at runtime
-                        to ensure that it does not run as UID 0 (root) and fail to start
-                        the container if it does. If unset or false, no such validation
-                        will be performed. May also be set in SecurityContext.  If set
-                        in both SecurityContext and PodSecurityContext, the value specified
-                        in SecurityContext takes precedence.
+                      description: |-
+                        Indicates that the container must run as a non-root user.
+                        If true, the Kubelet will validate the image at runtime to ensure that it
+                        does not run as UID 0 (root) and fail to start the container if it does.
+                        If unset or false, no such validation will be performed.
+                        May also be set in SecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                       type: boolean
                     runAsUser:
-                      description: The UID to run the entrypoint of the container process.
+                      description: |-
+                        The UID to run the entrypoint of the container process.
                         Defaults to user specified in image metadata if unspecified.
-                        May also be set in SecurityContext.  If set in both SecurityContext
-                        and PodSecurityContext, the value specified in SecurityContext
-                        takes precedence for that container. Note that this field cannot
-                        be set when spec.os.name is windows.
+                        May also be set in SecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence
+                        for that container.
+                        Note that this field cannot be set when spec.os.name is windows.
                       format: int64
                       type: integer
                     seLinuxOptions:
-                      description: The SELinux context to be applied to all containers.
-                        If unspecified, the container runtime will allocate a random
-                        SELinux context for each container.  May also be set in SecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence for that container.
+                      description: |-
+                        The SELinux context to be applied to all containers.
+                        If unspecified, the container runtime will allocate a random SELinux context for each
+                        container.  May also be set in SecurityContext.  If set in
+                        both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence for that container.
                         Note that this field cannot be set when spec.os.name is windows.
                       properties:
                         level:
@@ -4650,47 +4632,48 @@ spec:
                           type: string
                       type: object
                     seccompProfile:
-                      description: The seccomp options to use by the containers in this
-                        pod. Note that this field cannot be set when spec.os.name is
-                        windows.
+                      description: |-
+                        The seccomp options to use by the containers in this pod.
+                        Note that this field cannot be set when spec.os.name is windows.
                       properties:
                         localhostProfile:
-                          description: localhostProfile indicates a profile defined
-                            in a file on the node should be used. The profile must be
-                            preconfigured on the node to work. Must be a descending
-                            path, relative to the kubelet's configured seccomp profile
-                            location. Must be set if type is "Localhost". Must NOT be
-                            set for any other type.
+                          description: |-
+                            localhostProfile indicates a profile defined in a file on the node should be used.
+                            The profile must be preconfigured on the node to work.
+                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                            Must be set if type is "Localhost". Must NOT be set for any other type.
                           type: string
                         type:
-                          description: "type indicates which kind of seccomp profile
-                          will be applied. Valid options are: \n Localhost - a profile
-                          defined in a file on the node should be used. RuntimeDefault
-                          - the container runtime default profile should be used.
-                          Unconfined - no profile should be applied."
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied.
+                            Valid options are:
+                            
+                            
+                            Localhost - a profile defined in a file on the node should be used.
+                            RuntimeDefault - the container runtime default profile should be used.
+                            Unconfined - no profile should be applied.
                           type: string
                       required:
                         - type
                       type: object
                     supplementalGroups:
-                      description: A list of groups applied to the first process run
-                        in each container, in addition to the container's primary GID,
-                        the fsGroup (if specified), and group memberships defined in
-                        the container image for the uid of the container process. If
-                        unspecified, no additional groups are added to any container.
-                        Note that group memberships defined in the container image for
-                        the uid of the container process are still effective, even if
-                        they are not included in this list. Note that this field cannot
-                        be set when spec.os.name is windows.
+                      description: |-
+                        A list of groups applied to the first process run in each container, in addition
+                        to the container's primary GID, the fsGroup (if specified), and group memberships
+                        defined in the container image for the uid of the container process. If unspecified,
+                        no additional groups are added to any container. Note that group memberships
+                        defined in the container image for the uid of the container process are still effective,
+                        even if they are not included in this list.
+                        Note that this field cannot be set when spec.os.name is windows.
                       items:
                         format: int64
                         type: integer
                       type: array
                     sysctls:
-                      description: Sysctls hold a list of namespaced sysctls used for
-                        the pod. Pods with unsupported sysctls (by the container runtime)
-                        might fail to launch. Note that this field cannot be set when
-                        spec.os.name is windows.
+                      description: |-
+                        Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                        sysctls (by the container runtime) might fail to launch.
+                        Note that this field cannot be set when spec.os.name is windows.
                       items:
                         description: Sysctl defines a kernel parameter to be set
                         properties:
@@ -4706,80 +4689,86 @@ spec:
                         type: object
                       type: array
                     windowsOptions:
-                      description: The Windows specific settings applied to all containers.
-                        If unspecified, the options within a container's SecurityContext
-                        will be used. If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence. Note
-                        that this field cannot be set when spec.os.name is linux.
+                      description: |-
+                        The Windows specific settings applied to all containers.
+                        If unspecified, the options within a container's SecurityContext will be used.
+                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is linux.
                       properties:
                         gmsaCredentialSpec:
-                          description: GMSACredentialSpec is where the GMSA admission
-                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                            inlines the contents of the GMSA credential spec named by
-                            the GMSACredentialSpecName field.
+                          description: |-
+                            GMSACredentialSpec is where the GMSA admission webhook
+                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                            GMSA credential spec named by the GMSACredentialSpecName field.
                           type: string
                         gmsaCredentialSpecName:
                           description: GMSACredentialSpecName is the name of the GMSA
                             credential spec to use.
                           type: string
                         hostProcess:
-                          description: HostProcess determines if a container should
-                            be run as a 'Host Process' container. All of a Pod's containers
-                            must have the same effective HostProcess value (it is not
-                            allowed to have a mix of HostProcess containers and non-HostProcess
-                            containers). In addition, if HostProcess is true then HostNetwork
-                            must also be set to true.
+                          description: |-
+                            HostProcess determines if a container should be run as a 'Host Process' container.
+                            All of a Pod's containers must have the same effective HostProcess value
+                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                            In addition, if HostProcess is true then HostNetwork must also be set to true.
                           type: boolean
                         runAsUserName:
-                          description: The UserName in Windows to run the entrypoint
-                            of the container process. Defaults to the user specified
-                            in image metadata if unspecified. May also be set in PodSecurityContext.
-                            If set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
+                          description: |-
+                            The UserName in Windows to run the entrypoint of the container process.
+                            Defaults to the user specified in image metadata if unspecified.
+                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                           type: string
                       type: object
                   type: object
                 ports:
-                  description: Ports allows a set of ports to be exposed by the underlying
-                    v1.Service. By default, the operator will attempt to infer the required
-                    ports by parsing the .Spec.Config property but this property can
-                    be used to open additional ports that can't be inferred by the operator,
-                    like for custom receivers.
+                  description: |-
+                    Ports allows a set of ports to be exposed by the underlying v1.Service. By default, the operator
+                    will attempt to infer the required ports by parsing the .Spec.Config property but this property can be
+                    used to open additional ports that can't be inferred by the operator, like for custom receivers.
                   items:
                     description: ServicePort contains information on service's port.
                     properties:
                       appProtocol:
-                        description: "The application protocol for this port. This is
-                        used as a hint for implementations to offer richer behavior
-                        for protocols that they understand. This field follows standard
-                        Kubernetes label syntax. Valid values are either: \n * Un-prefixed
-                        protocol names - reserved for IANA standard service names
-                        (as per RFC-6335 and https://www.iana.org/assignments/service-names).
-                        \n * Kubernetes-defined prefixed names: * 'kubernetes.io/h2c'
-                        - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
-                        * 'kubernetes.io/ws'  - WebSocket over cleartext as described
-                        in https://www.rfc-editor.org/rfc/rfc6455 * 'kubernetes.io/wss'
-                        - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
-                        \n * Other protocols should use implementation-defined prefixed
-                        names such as mycompany.com/my-custom-protocol."
+                        description: |-
+                          The application protocol for this port.
+                          This is used as a hint for implementations to offer richer behavior for protocols that they understand.
+                          This field follows standard Kubernetes label syntax.
+                          Valid values are either:
+                          
+                          
+                          * Un-prefixed protocol names - reserved for IANA standard service names (as per
+                          RFC-6335 and https://www.iana.org/assignments/service-names).
+                          
+                          
+                          * Kubernetes-defined prefixed names:
+                            * 'kubernetes.io/h2c' - HTTP/2 prior knowledge over cleartext as described in https://www.rfc-editor.org/rfc/rfc9113.html#name-starting-http-2-with-prior-
+                            * 'kubernetes.io/ws'  - WebSocket over cleartext as described in https://www.rfc-editor.org/rfc/rfc6455
+                            * 'kubernetes.io/wss' - WebSocket over TLS as described in https://www.rfc-editor.org/rfc/rfc6455
+                          
+                          
+                          * Other protocols should use implementation-defined prefixed names such as
+                          mycompany.com/my-custom-protocol.
                         type: string
                       name:
-                        description: The name of this port within the service. This
-                          must be a DNS_LABEL. All ports within a ServiceSpec must have
-                          unique names. When considering the endpoints for a Service,
-                          this must match the 'name' field in the EndpointPort. Optional
-                          if only one ServicePort is defined on this service.
+                        description: |-
+                          The name of this port within the service. This must be a DNS_LABEL.
+                          All ports within a ServiceSpec must have unique names. When considering
+                          the endpoints for a Service, this must match the 'name' field in the
+                          EndpointPort.
+                          Optional if only one ServicePort is defined on this service.
                         type: string
                       nodePort:
-                        description: 'The port on each node on which this service is
-                        exposed when type is NodePort or LoadBalancer.  Usually assigned
-                        by the system. If a value is specified, in-range, and not
-                        in use it will be used, otherwise the operation will fail.  If
-                        not specified, a port will be allocated if this Service requires
-                        one.  If this field is specified when creating a Service which
-                        does not need it, creation will fail. This field will be wiped
-                        when updating a Service to no longer need it (e.g. changing
-                        type from NodePort to ClusterIP). More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport'
+                        description: |-
+                          The port on each node on which this service is exposed when type is
+                          NodePort or LoadBalancer.  Usually assigned by the system. If a value is
+                          specified, in-range, and not in use it will be used, otherwise the
+                          operation will fail.  If not specified, a port will be allocated if this
+                          Service requires one.  If this field is specified when creating a
+                          Service which does not need it, creation will fail. This field will be
+                          wiped when updating a Service to no longer need it (e.g. changing type
+                          from NodePort to ClusterIP).
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
                         format: int32
                         type: integer
                       port:
@@ -4788,21 +4777,23 @@ spec:
                         type: integer
                       protocol:
                         default: TCP
-                        description: The IP protocol for this port. Supports "TCP",
-                          "UDP", and "SCTP". Default is TCP.
+                        description: |-
+                          The IP protocol for this port. Supports "TCP", "UDP", and "SCTP".
+                          Default is TCP.
                         type: string
                       targetPort:
                         anyOf:
                           - type: integer
                           - type: string
-                        description: 'Number or name of the port to access on the pods
-                        targeted by the service. Number must be in the range 1 to
-                        65535. Name must be an IANA_SVC_NAME. If this is a string,
-                        it will be looked up as a named port in the target Pod''s
-                        container ports. If this is not specified, the value of the
-                        ''port'' field is used (an identity map). This field is ignored
-                        for services with clusterIP=None, and should be omitted or
-                        set equal to the ''port'' field. More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service'
+                        description: |-
+                          Number or name of the port to access on the pods targeted by the service.
+                          Number must be in the range 1 to 65535. Name must be an IANA_SVC_NAME.
+                          If this is a string, it will be looked up as a named port in the
+                          target Pod's container ports. If this is not specified, the value
+                          of the 'port' field is used (an identity map).
+                          This field is ignored for services with clusterIP=None, and should be
+                          omitted or set equal to the 'port' field.
+                          More info: https://kubernetes.io/docs/concepts/services-networking/service/#defining-a-service
                         x-kubernetes-int-or-string: true
                     required:
                       - port
@@ -4810,9 +4801,36 @@ spec:
                   type: array
                   x-kubernetes-list-type: atomic
                 priorityClassName:
-                  description: If specified, indicates the pod's priority. If not specified,
-                    the pod priority will be default or zero if there is no default.
+                  description: |-
+                    If specified, indicates the pod's priority.
+                    If not specified, the pod priority will be default or zero if there is no
+                    default.
                   type: string
+                prometheus:
+                  description: Prometheus is the raw YAML to be used as the collector's
+                    prometheus configuration.
+                  properties:
+                    config:
+                      description: AnyConfig represent parts of the config.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    report_extra_scrape_metrics:
+                      type: boolean
+                      x-kubernetes-preserve-unknown-fields: true
+                    start_time_metric_regex:
+                      type: string
+                      x-kubernetes-preserve-unknown-fields: true
+                    target_allocator:
+                      description: AnyConfig represent parts of the config.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                    trim_metric_suffixes:
+                      type: boolean
+                      x-kubernetes-preserve-unknown-fields: true
+                    use_start_time_metric:
+                      type: boolean
+                      x-kubernetes-preserve-unknown-fields: true
+                  type: object
                 replicas:
                   description: Replicas is the number of pod instances for the underlying
                     OpenTelemetry Collector. Set this if your are not using autoscaling
@@ -4822,18 +4840,24 @@ spec:
                   description: Resources to set on the OpenTelemetry Collector pods.
                   properties:
                     claims:
-                      description: "Claims lists the names of resources, defined in
-                      spec.resourceClaims, that are used by this container. \n This
-                      is an alpha field and requires enabling the DynamicResourceAllocation
-                      feature gate. \n This field is immutable. It can only be set
-                      for containers."
+                      description: |-
+                        Claims lists the names of resources, defined in spec.resourceClaims,
+                        that are used by this container.
+                        
+                        
+                        This is an alpha field and requires enabling the
+                        DynamicResourceAllocation feature gate.
+                        
+                        
+                        This field is immutable. It can only be set for containers.
                       items:
                         description: ResourceClaim references one entry in PodSpec.ResourceClaims.
                         properties:
                           name:
-                            description: Name must match the name of one entry in pod.spec.resourceClaims
-                              of the Pod where this field is used. It makes that resource
-                              available inside a container.
+                            description: |-
+                              Name must match the name of one entry in pod.spec.resourceClaims of
+                              the Pod where this field is used. It makes that resource available
+                              inside a container.
                             type: string
                         required:
                           - name
@@ -4849,8 +4873,9 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute resources
-                      allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      description: |-
+                        Limits describes the maximum amount of compute resources allowed.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                       type: object
                     requests:
                       additionalProperties:
@@ -4859,33 +4884,42 @@ spec:
                           - type: string
                         pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                         x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                      resources required. If Requests is omitted for a container,
-                      it defaults to Limits if that is explicitly specified, otherwise
-                      to an implementation-defined value. Requests cannot exceed Limits.
-                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                      description: |-
+                        Requests describes the minimum amount of compute resources required.
+                        If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                        otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                        More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                       type: object
                   type: object
                 securityContext:
-                  description: "SecurityContext configures the container security context
-                  for the opentelemetry-collector container. \n In deployment, daemonset,
-                  or statefulset mode, this controls the security context settings
-                  for the primary application container. \n In sidecar mode, this
-                  controls the security context for the injected sidecar container."
+                  description: |-
+                    SecurityContext configures the container security context for
+                    the amazon-cloudwatch-agent container.
+                    
+                    
+                    In deployment, daemonset, or statefulset mode, this controls
+                    the security context settings for the primary application
+                    container.
+                    
+                    
+                    In sidecar mode, this controls the security context for the
+                    injected sidecar container.
                   properties:
                     allowPrivilegeEscalation:
-                      description: 'AllowPrivilegeEscalation controls whether a process
-                      can gain more privileges than its parent process. This bool
-                      directly controls if the no_new_privs flag will be set on the
-                      container process. AllowPrivilegeEscalation is true always when
-                      the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN
-                      Note that this field cannot be set when spec.os.name is windows.'
+                      description: |-
+                        AllowPrivilegeEscalation controls whether a process can gain more
+                        privileges than its parent process. This bool directly controls if
+                        the no_new_privs flag will be set on the container process.
+                        AllowPrivilegeEscalation is true always when the container is:
+                        1) run as Privileged
+                        2) has CAP_SYS_ADMIN
+                        Note that this field cannot be set when spec.os.name is windows.
                       type: boolean
                     capabilities:
-                      description: The capabilities to add/drop when running containers.
-                        Defaults to the default set of capabilities granted by the container
-                        runtime. Note that this field cannot be set when spec.os.name
-                        is windows.
+                      description: |-
+                        The capabilities to add/drop when running containers.
+                        Defaults to the default set of capabilities granted by the container runtime.
+                        Note that this field cannot be set when spec.os.name is windows.
                       properties:
                         add:
                           description: Added capabilities
@@ -4901,56 +4935,60 @@ spec:
                           type: array
                       type: object
                     privileged:
-                      description: Run container in privileged mode. Processes in privileged
-                        containers are essentially equivalent to root on the host. Defaults
-                        to false. Note that this field cannot be set when spec.os.name
-                        is windows.
+                      description: |-
+                        Run container in privileged mode.
+                        Processes in privileged containers are essentially equivalent to root on the host.
+                        Defaults to false.
+                        Note that this field cannot be set when spec.os.name is windows.
                       type: boolean
                     procMount:
-                      description: procMount denotes the type of proc mount to use for
-                        the containers. The default is DefaultProcMount which uses the
-                        container runtime defaults for readonly paths and masked paths.
+                      description: |-
+                        procMount denotes the type of proc mount to use for the containers.
+                        The default is DefaultProcMount which uses the container runtime defaults for
+                        readonly paths and masked paths.
                         This requires the ProcMountType feature flag to be enabled.
                         Note that this field cannot be set when spec.os.name is windows.
                       type: string
                     readOnlyRootFilesystem:
-                      description: Whether this container has a read-only root filesystem.
-                        Default is false. Note that this field cannot be set when spec.os.name
-                        is windows.
+                      description: |-
+                        Whether this container has a read-only root filesystem.
+                        Default is false.
+                        Note that this field cannot be set when spec.os.name is windows.
                       type: boolean
                     runAsGroup:
-                      description: The GID to run the entrypoint of the container process.
-                        Uses runtime default if unset. May also be set in PodSecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence. Note that this
-                        field cannot be set when spec.os.name is windows.
+                      description: |-
+                        The GID to run the entrypoint of the container process.
+                        Uses runtime default if unset.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is windows.
                       format: int64
                       type: integer
                     runAsNonRoot:
-                      description: Indicates that the container must run as a non-root
-                        user. If true, the Kubelet will validate the image at runtime
-                        to ensure that it does not run as UID 0 (root) and fail to start
-                        the container if it does. If unset or false, no such validation
-                        will be performed. May also be set in PodSecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence.
+                      description: |-
+                        Indicates that the container must run as a non-root user.
+                        If true, the Kubelet will validate the image at runtime to ensure that it
+                        does not run as UID 0 (root) and fail to start the container if it does.
+                        If unset or false, no such validation will be performed.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
                       type: boolean
                     runAsUser:
-                      description: The UID to run the entrypoint of the container process.
+                      description: |-
+                        The UID to run the entrypoint of the container process.
                         Defaults to user specified in image metadata if unspecified.
-                        May also be set in PodSecurityContext.  If set in both SecurityContext
-                        and PodSecurityContext, the value specified in SecurityContext
-                        takes precedence. Note that this field cannot be set when spec.os.name
-                        is windows.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is windows.
                       format: int64
                       type: integer
                     seLinuxOptions:
-                      description: The SELinux context to be applied to the container.
-                        If unspecified, the container runtime will allocate a random
-                        SELinux context for each container.  May also be set in PodSecurityContext.  If
-                        set in both SecurityContext and PodSecurityContext, the value
-                        specified in SecurityContext takes precedence. Note that this
-                        field cannot be set when spec.os.name is windows.
+                      description: |-
+                        The SELinux context to be applied to the container.
+                        If unspecified, the container runtime will allocate a random SELinux context for each
+                        container.  May also be set in PodSecurityContext.  If set in both SecurityContext and
+                        PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is windows.
                       properties:
                         level:
                           description: Level is SELinux level label that applies to
@@ -4970,118 +5008,1666 @@ spec:
                           type: string
                       type: object
                     seccompProfile:
-                      description: The seccomp options to use by this container. If
-                        seccomp options are provided at both the pod & container level,
-                        the container options override the pod options. Note that this
-                        field cannot be set when spec.os.name is windows.
+                      description: |-
+                        The seccomp options to use by this container. If seccomp options are
+                        provided at both the pod & container level, the container options
+                        override the pod options.
+                        Note that this field cannot be set when spec.os.name is windows.
                       properties:
                         localhostProfile:
-                          description: localhostProfile indicates a profile defined
-                            in a file on the node should be used. The profile must be
-                            preconfigured on the node to work. Must be a descending
-                            path, relative to the kubelet's configured seccomp profile
-                            location. Must be set if type is "Localhost". Must NOT be
-                            set for any other type.
+                          description: |-
+                            localhostProfile indicates a profile defined in a file on the node should be used.
+                            The profile must be preconfigured on the node to work.
+                            Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                            Must be set if type is "Localhost". Must NOT be set for any other type.
                           type: string
                         type:
-                          description: "type indicates which kind of seccomp profile
-                          will be applied. Valid options are: \n Localhost - a profile
-                          defined in a file on the node should be used. RuntimeDefault
-                          - the container runtime default profile should be used.
-                          Unconfined - no profile should be applied."
+                          description: |-
+                            type indicates which kind of seccomp profile will be applied.
+                            Valid options are:
+                            
+                            
+                            Localhost - a profile defined in a file on the node should be used.
+                            RuntimeDefault - the container runtime default profile should be used.
+                            Unconfined - no profile should be applied.
                           type: string
                       required:
                         - type
                       type: object
                     windowsOptions:
-                      description: The Windows specific settings applied to all containers.
-                        If unspecified, the options from the PodSecurityContext will
-                        be used. If set in both SecurityContext and PodSecurityContext,
-                        the value specified in SecurityContext takes precedence. Note
-                        that this field cannot be set when spec.os.name is linux.
+                      description: |-
+                        The Windows specific settings applied to all containers.
+                        If unspecified, the options from the PodSecurityContext will be used.
+                        If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                        Note that this field cannot be set when spec.os.name is linux.
                       properties:
                         gmsaCredentialSpec:
-                          description: GMSACredentialSpec is where the GMSA admission
-                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
-                            inlines the contents of the GMSA credential spec named by
-                            the GMSACredentialSpecName field.
+                          description: |-
+                            GMSACredentialSpec is where the GMSA admission webhook
+                            (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                            GMSA credential spec named by the GMSACredentialSpecName field.
                           type: string
                         gmsaCredentialSpecName:
                           description: GMSACredentialSpecName is the name of the GMSA
                             credential spec to use.
                           type: string
                         hostProcess:
-                          description: HostProcess determines if a container should
-                            be run as a 'Host Process' container. All of a Pod's containers
-                            must have the same effective HostProcess value (it is not
-                            allowed to have a mix of HostProcess containers and non-HostProcess
-                            containers). In addition, if HostProcess is true then HostNetwork
-                            must also be set to true.
+                          description: |-
+                            HostProcess determines if a container should be run as a 'Host Process' container.
+                            All of a Pod's containers must have the same effective HostProcess value
+                            (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                            In addition, if HostProcess is true then HostNetwork must also be set to true.
                           type: boolean
                         runAsUserName:
-                          description: The UserName in Windows to run the entrypoint
-                            of the container process. Defaults to the user specified
-                            in image metadata if unspecified. May also be set in PodSecurityContext.
-                            If set in both SecurityContext and PodSecurityContext, the
-                            value specified in SecurityContext takes precedence.
+                          description: |-
+                            The UserName in Windows to run the entrypoint of the container process.
+                            Defaults to the user specified in image metadata if unspecified.
+                            May also be set in PodSecurityContext. If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
                           type: string
                       type: object
                   type: object
                 serviceAccount:
-                  description: ServiceAccount indicates the name of an existing service
-                    account to use with this instance. When set, the operator will not
-                    automatically create a ServiceAccount for the collector.
+                  description: |-
+                    ServiceAccount indicates the name of an existing service account to use with this instance. When set,
+                    the operator will not automatically create a ServiceAccount for the collector.
                   type: string
+                targetAllocator:
+                  description: TargetAllocator indicates a value which determines whether
+                    to spawn a target allocation resource or not.
+                  properties:
+                    affinity:
+                      description: If specified, indicates the pod's scheduling constraints
+                      properties:
+                        nodeAffinity:
+                          description: Describes node affinity scheduling rules for
+                            the pod.
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node matches the corresponding matchExpressions; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: |-
+                                  An empty preferred scheduling term matches all objects with implicit weight 0
+                                  (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                properties:
+                                  preference:
+                                    description: A node selector term, associated with
+                                      the corresponding weight.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  weight:
+                                    description: Weight associated with matching the
+                                      corresponding nodeSelectorTerm, in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - preference
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to an update), the system
+                                may or may not try to eventually evict the pod from its node.
+                              properties:
+                                nodeSelectorTerms:
+                                  description: Required. A list of node selector terms.
+                                    The terms are ORed.
+                                  items:
+                                    description: |-
+                                      A null or empty node selector term matches no objects. The requirements of
+                                      them are ANDed.
+                                      The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                    properties:
+                                      matchExpressions:
+                                        description: A list of node selector requirements
+                                          by node's labels.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchFields:
+                                        description: A list of node selector requirements
+                                          by node's fields.
+                                        items:
+                                          description: |-
+                                            A node selector requirement is a selector that contains values, a key, and an operator
+                                            that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: The label key that the selector
+                                                applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                Represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                An array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. If the operator is Gt or Lt, the values
+                                                array must have a single element, which will be interpreted as an integer.
+                                                This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  type: array
+                              required:
+                                - nodeSelectorTerms
+                              type: object
+                              x-kubernetes-map-type: atomic
+                          type: object
+                        podAffinity:
+                          description: Describes pod affinity scheduling rules (e.g.
+                            co-locate this pod in the same node, zone, etc. as some
+                            other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          A label query over a set of resources, in this case pods.
+                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: |-
+                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                          Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                          This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: |-
+                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                          Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                          This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      namespaceSelector:
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    description: |-
+                                      weight associated with matching the corresponding podAffinityTerm,
+                                      in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod label update), the
+                                system may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding to each
+                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: |-
+                                  Defines a set of pods (namely those matching the labelSelector
+                                  relative to the given namespace(s)) that this pod should be
+                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                  where co-located is defined as running on a node whose value of
+                                  the label with key <topologyKey> matches that of any node on which
+                                  a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                      Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                      Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                        podAntiAffinity:
+                          description: Describes pod anti-affinity scheduling rules
+                            (e.g. avoid putting this pod in the same node, zone, etc.
+                            as some other pod(s)).
+                          properties:
+                            preferredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                The scheduler will prefer to schedule pods to nodes that satisfy
+                                the anti-affinity expressions specified by this field, but it may choose
+                                a node that violates one or more of the expressions. The node that is
+                                most preferred is the one with the greatest sum of weights, i.e.
+                                for each node that meets all of the scheduling requirements (resource
+                                request, requiredDuringScheduling anti-affinity expressions, etc.),
+                                compute a sum by iterating through the elements of this field and adding
+                                "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                                node(s) with the highest sum are the most preferred.
+                              items:
+                                description: The weights of all of the matched WeightedPodAffinityTerm
+                                  fields are added per-node to find the most preferred
+                                  node(s)
+                                properties:
+                                  podAffinityTerm:
+                                    description: Required. A pod affinity term, associated
+                                      with the corresponding weight.
+                                    properties:
+                                      labelSelector:
+                                        description: |-
+                                          A label query over a set of resources, in this case pods.
+                                          If it's null, this PodAffinityTerm matches with no Pods.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      matchLabelKeys:
+                                        description: |-
+                                          MatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                          Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                          This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      mismatchLabelKeys:
+                                        description: |-
+                                          MismatchLabelKeys is a set of pod label keys to select which pods will
+                                          be taken into consideration. The keys are used to lookup values from the
+                                          incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                          to select the group of existing pods which pods will be taken into consideration
+                                          for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                          pod labels will be ignored. The default value is empty.
+                                          The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                          Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                          This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                      namespaceSelector:
+                                        description: |-
+                                          A label query over the set of namespaces that the term applies to.
+                                          The term is applied to the union of the namespaces selected by this field
+                                          and the ones listed in the namespaces field.
+                                          null selector and null or empty namespaces list means "this pod's namespace".
+                                          An empty selector ({}) matches all namespaces.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list
+                                              of label selector requirements. The requirements
+                                              are ANDed.
+                                            items:
+                                              description: |-
+                                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                                relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key
+                                                    that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: |-
+                                                    operator represents a key's relationship to a set of values.
+                                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: |-
+                                                    values is an array of string values. If the operator is In or NotIn,
+                                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                    the values array must be empty. This array is replaced during a strategic
+                                                    merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: |-
+                                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                        x-kubernetes-map-type: atomic
+                                      namespaces:
+                                        description: |-
+                                          namespaces specifies a static list of namespace names that the term applies to.
+                                          The term is applied to the union of the namespaces listed in this field
+                                          and the ones selected by namespaceSelector.
+                                          null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                        items:
+                                          type: string
+                                        type: array
+                                      topologyKey:
+                                        description: |-
+                                          This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                          the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                          whose value of the label with key topologyKey matches that of any node on which any of the
+                                          selected pods is running.
+                                          Empty topologyKey is not allowed.
+                                        type: string
+                                    required:
+                                      - topologyKey
+                                    type: object
+                                  weight:
+                                    description: |-
+                                      weight associated with matching the corresponding podAffinityTerm,
+                                      in the range 1-100.
+                                    format: int32
+                                    type: integer
+                                required:
+                                  - podAffinityTerm
+                                  - weight
+                                type: object
+                              type: array
+                            requiredDuringSchedulingIgnoredDuringExecution:
+                              description: |-
+                                If the anti-affinity requirements specified by this field are not met at
+                                scheduling time, the pod will not be scheduled onto the node.
+                                If the anti-affinity requirements specified by this field cease to be met
+                                at some point during pod execution (e.g. due to a pod label update), the
+                                system may or may not try to eventually evict the pod from its node.
+                                When there are multiple elements, the lists of nodes corresponding to each
+                                podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                              items:
+                                description: |-
+                                  Defines a set of pods (namely those matching the labelSelector
+                                  relative to the given namespace(s)) that this pod should be
+                                  co-located (affinity) or not co-located (anti-affinity) with,
+                                  where co-located is defined as running on a node whose value of
+                                  the label with key <topologyKey> matches that of any node on which
+                                  a pod of the set of pods is running
+                                properties:
+                                  labelSelector:
+                                    description: |-
+                                      A label query over a set of resources, in this case pods.
+                                      If it's null, this PodAffinityTerm matches with no Pods.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  matchLabelKeys:
+                                    description: |-
+                                      MatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `LabelSelector` as `key in (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                                      Also, MatchLabelKeys cannot be set when LabelSelector isn't set.
+                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  mismatchLabelKeys:
+                                    description: |-
+                                      MismatchLabelKeys is a set of pod label keys to select which pods will
+                                      be taken into consideration. The keys are used to lookup values from the
+                                      incoming pod labels, those key-value labels are merged with `LabelSelector` as `key notin (value)`
+                                      to select the group of existing pods which pods will be taken into consideration
+                                      for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                      pod labels will be ignored. The default value is empty.
+                                      The same key is forbidden to exist in both MismatchLabelKeys and LabelSelector.
+                                      Also, MismatchLabelKeys cannot be set when LabelSelector isn't set.
+                                      This is an alpha field and requires enabling MatchLabelKeysInPodAffinity feature gate.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                  namespaceSelector:
+                                    description: |-
+                                      A label query over the set of namespaces that the term applies to.
+                                      The term is applied to the union of the namespaces selected by this field
+                                      and the ones listed in the namespaces field.
+                                      null selector and null or empty namespaces list means "this pod's namespace".
+                                      An empty selector ({}) matches all namespaces.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label
+                                          selector requirements. The requirements are
+                                          ANDed.
+                                        items:
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that
+                                                the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
+                                                merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  namespaces:
+                                    description: |-
+                                      namespaces specifies a static list of namespace names that the term applies to.
+                                      The term is applied to the union of the namespaces listed in this field
+                                      and the ones selected by namespaceSelector.
+                                      null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                    items:
+                                      type: string
+                                    type: array
+                                  topologyKey:
+                                    description: |-
+                                      This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                      the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                      whose value of the label with key topologyKey matches that of any node on which any of the
+                                      selected pods is running.
+                                      Empty topologyKey is not allowed.
+                                    type: string
+                                required:
+                                  - topologyKey
+                                type: object
+                              type: array
+                          type: object
+                      type: object
+                    allocationStrategy:
+                      description: |-
+                        AllocationStrategy determines which strategy the target allocator should use for allocation.
+                        The current option is consistent-hashing.
+                      enum:
+                        - consistent-hashing
+                      type: string
+                    enabled:
+                      description: Enabled indicates whether to use a target allocation
+                        mechanism for Prometheus targets or not.
+                      type: boolean
+                    env:
+                      description: |-
+                        ENV vars to set on the OpenTelemetry TargetAllocator's Pods. These can then in certain cases be
+                        consumed in the config file for the TargetAllocator.
+                      items:
+                        description: EnvVar represents an environment variable present
+                          in a Container.
+                        properties:
+                          name:
+                            description: Name of the environment variable. Must be a
+                              C_IDENTIFIER.
+                            type: string
+                          value:
+                            description: |-
+                              Variable references $(VAR_NAME) are expanded
+                              using the previously defined environment variables in the container and
+                              any service environment variables. If a variable cannot be resolved,
+                              the reference in the input string will be unchanged. Double $$ are reduced
+                              to a single $, which allows for escaping the $(VAR_NAME) syntax: i.e.
+                              "$$(VAR_NAME)" will produce the string literal "$(VAR_NAME)".
+                              Escaped references will never be expanded, regardless of whether the variable
+                              exists or not.
+                              Defaults to "".
+                            type: string
+                          valueFrom:
+                            description: Source for the environment variable's value.
+                              Cannot be used if value is not empty.
+                            properties:
+                              configMapKeyRef:
+                                description: Selects a key of a ConfigMap.
+                                properties:
+                                  key:
+                                    description: The key to select.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
+                                    type: string
+                                  optional:
+                                    description: Specify whether the ConfigMap or its
+                                      key must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              fieldRef:
+                                description: |-
+                                  Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels['<KEY>']`, `metadata.annotations['<KEY>']`,
+                                  spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.
+                                properties:
+                                  apiVersion:
+                                    description: Version of the schema the FieldPath
+                                      is written in terms of, defaults to "v1".
+                                    type: string
+                                  fieldPath:
+                                    description: Path of the field to select in the
+                                      specified API version.
+                                    type: string
+                                required:
+                                  - fieldPath
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              resourceFieldRef:
+                                description: |-
+                                  Selects a resource of the container: only resources limits and requests
+                                  (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.
+                                properties:
+                                  containerName:
+                                    description: 'Container name: required for volumes,
+                                    optional for env vars'
+                                    type: string
+                                  divisor:
+                                    anyOf:
+                                      - type: integer
+                                      - type: string
+                                    description: Specifies the output format of the
+                                      exposed resources, defaults to "1"
+                                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                    x-kubernetes-int-or-string: true
+                                  resource:
+                                    description: 'Required: resource to select'
+                                    type: string
+                                required:
+                                  - resource
+                                type: object
+                                x-kubernetes-map-type: atomic
+                              secretKeyRef:
+                                description: Selects a key of a secret in the pod's
+                                  namespace
+                                properties:
+                                  key:
+                                    description: The key of the secret to select from.  Must
+                                      be a valid secret key.
+                                    type: string
+                                  name:
+                                    description: |-
+                                      Name of the referent.
+                                      More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                      TODO: Add other useful fields. apiVersion, kind, uid?
+                                    type: string
+                                  optional:
+                                    description: Specify whether the Secret or its key
+                                      must be defined
+                                    type: boolean
+                                required:
+                                  - key
+                                type: object
+                                x-kubernetes-map-type: atomic
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
+                    filterStrategy:
+                      description: |-
+                        FilterStrategy determines how to filter targets before allocating them among the collectors.
+                        The only current option is relabel-config (drops targets based on prom relabel_config).
+                        Filtering is disabled by default.
+                      type: string
+                    image:
+                      description: Image indicates the container image to use for the
+                        OpenTelemetry TargetAllocator.
+                      type: string
+                    nodeSelector:
+                      additionalProperties:
+                        type: string
+                      description: NodeSelector to schedule OpenTelemetry TargetAllocator
+                        pods.
+                      type: object
+                    prometheusCR:
+                      description: |-
+                        PrometheusCR defines the configuration for the retrieval of PrometheusOperator CRDs ( servicemonitor.monitoring.coreos.com/v1 and podmonitor.monitoring.coreos.com/v1 )  retrieval.
+                        All CR instances which the ServiceAccount has access to will be retrieved. This includes other namespaces.
+                      properties:
+                        enabled:
+                          description: Enabled indicates whether to use a PrometheusOperator
+                            custom resources as targets or not.
+                          type: boolean
+                        podMonitorSelector:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            PodMonitors to be selected for target discovery.
+                            This is a map of {key,value} pairs. Each {key,value} in the map is going to exactly match a label in a
+                            PodMonitor's meta labels. The requirements are ANDed.
+                          type: object
+                        scrapeInterval:
+                          default: 30s
+                          description: |-
+                            Interval between consecutive scrapes. Equivalent to the same setting on the Prometheus CRD.
+                            
+                            
+                            Default: "30s"
+                          format: duration
+                          type: string
+                        serviceMonitorSelector:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            ServiceMonitors to be selected for target discovery.
+                            This is a map of {key,value} pairs. Each {key,value} in the map is going to exactly match a label in a
+                            ServiceMonitor's meta labels. The requirements are ANDed.
+                          type: object
+                      type: object
+                    replicas:
+                      description: |-
+                        Replicas is the number of pod instances for the underlying TargetAllocator. This should only be set to a value
+                        other than 1 if a strategy that allows for high availability is chosen. Currently, the only allocation strategy
+                        that can be run in a high availability mode is consistent-hashing.
+                      format: int32
+                      type: integer
+                    resources:
+                      description: Resources to set on the OpenTelemetryTargetAllocator
+                        containers.
+                      properties:
+                        claims:
+                          description: |-
+                            Claims lists the names of resources, defined in spec.resourceClaims,
+                            that are used by this container.
+                            
+                            
+                            This is an alpha field and requires enabling the
+                            DynamicResourceAllocation feature gate.
+                            
+                            
+                            This field is immutable. It can only be set for containers.
+                          items:
+                            description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                            properties:
+                              name:
+                                description: |-
+                                  Name must match the name of one entry in pod.spec.resourceClaims of
+                                  the Pod where this field is used. It makes that resource available
+                                  inside a container.
+                                type: string
+                            required:
+                              - name
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                        limits:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Limits describes the maximum amount of compute resources allowed.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                        requests:
+                          additionalProperties:
+                            anyOf:
+                              - type: integer
+                              - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: |-
+                            Requests describes the minimum amount of compute resources required.
+                            If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                            otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                            More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                          type: object
+                      type: object
+                    securityContext:
+                      description: |-
+                        SecurityContext configures the container security context for
+                        the target-allocator.
+                      properties:
+                        fsGroup:
+                          description: |-
+                            A special supplemental group that applies to all containers in a pod.
+                            Some volume types allow the Kubelet to change the ownership of that volume
+                            to be owned by the pod:
+                            
+                            
+                            1. The owning GID will be the FSGroup
+                            2. The setgid bit is set (new files created in the volume will be owned by FSGroup)
+                            3. The permission bits are OR'd with rw-rw----
+                            
+                            
+                            If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        fsGroupChangePolicy:
+                          description: |-
+                            fsGroupChangePolicy defines behavior of changing ownership and permission of the volume
+                            before being exposed inside Pod. This field will only apply to
+                            volume types which support fsGroup based ownership(and permissions).
+                            It will have no effect on ephemeral volume types such as: secret, configmaps
+                            and emptydir.
+                            Valid values are "OnRootMismatch" and "Always". If not specified, "Always" is used.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          type: string
+                        runAsGroup:
+                          description: |-
+                            The GID to run the entrypoint of the container process.
+                            Uses runtime default if unset.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                            for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        runAsNonRoot:
+                          description: |-
+                            Indicates that the container must run as a non-root user.
+                            If true, the Kubelet will validate the image at runtime to ensure that it
+                            does not run as UID 0 (root) and fail to start the container if it does.
+                            If unset or false, no such validation will be performed.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence.
+                          type: boolean
+                        runAsUser:
+                          description: |-
+                            The UID to run the entrypoint of the container process.
+                            Defaults to user specified in image metadata if unspecified.
+                            May also be set in SecurityContext.  If set in both SecurityContext and
+                            PodSecurityContext, the value specified in SecurityContext takes precedence
+                            for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          format: int64
+                          type: integer
+                        seLinuxOptions:
+                          description: |-
+                            The SELinux context to be applied to all containers.
+                            If unspecified, the container runtime will allocate a random SELinux context for each
+                            container.  May also be set in SecurityContext.  If set in
+                            both SecurityContext and PodSecurityContext, the value specified in SecurityContext
+                            takes precedence for that container.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            level:
+                              description: Level is SELinux level label that applies
+                                to the container.
+                              type: string
+                            role:
+                              description: Role is a SELinux role label that applies
+                                to the container.
+                              type: string
+                            type:
+                              description: Type is a SELinux type label that applies
+                                to the container.
+                              type: string
+                            user:
+                              description: User is a SELinux user label that applies
+                                to the container.
+                              type: string
+                          type: object
+                        seccompProfile:
+                          description: |-
+                            The seccomp options to use by the containers in this pod.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          properties:
+                            localhostProfile:
+                              description: |-
+                                localhostProfile indicates a profile defined in a file on the node should be used.
+                                The profile must be preconfigured on the node to work.
+                                Must be a descending path, relative to the kubelet's configured seccomp profile location.
+                                Must be set if type is "Localhost". Must NOT be set for any other type.
+                              type: string
+                            type:
+                              description: |-
+                                type indicates which kind of seccomp profile will be applied.
+                                Valid options are:
+                                
+                                
+                                Localhost - a profile defined in a file on the node should be used.
+                                RuntimeDefault - the container runtime default profile should be used.
+                                Unconfined - no profile should be applied.
+                              type: string
+                          required:
+                            - type
+                          type: object
+                        supplementalGroups:
+                          description: |-
+                            A list of groups applied to the first process run in each container, in addition
+                            to the container's primary GID, the fsGroup (if specified), and group memberships
+                            defined in the container image for the uid of the container process. If unspecified,
+                            no additional groups are added to any container. Note that group memberships
+                            defined in the container image for the uid of the container process are still effective,
+                            even if they are not included in this list.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          items:
+                            format: int64
+                            type: integer
+                          type: array
+                        sysctls:
+                          description: |-
+                            Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported
+                            sysctls (by the container runtime) might fail to launch.
+                            Note that this field cannot be set when spec.os.name is windows.
+                          items:
+                            description: Sysctl defines a kernel parameter to be set
+                            properties:
+                              name:
+                                description: Name of a property to set
+                                type: string
+                              value:
+                                description: Value of a property to set
+                                type: string
+                            required:
+                              - name
+                              - value
+                            type: object
+                          type: array
+                        windowsOptions:
+                          description: |-
+                            The Windows specific settings applied to all containers.
+                            If unspecified, the options within a container's SecurityContext will be used.
+                            If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.
+                            Note that this field cannot be set when spec.os.name is linux.
+                          properties:
+                            gmsaCredentialSpec:
+                              description: |-
+                                GMSACredentialSpec is where the GMSA admission webhook
+                                (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the
+                                GMSA credential spec named by the GMSACredentialSpecName field.
+                              type: string
+                            gmsaCredentialSpecName:
+                              description: GMSACredentialSpecName is the name of the
+                                GMSA credential spec to use.
+                              type: string
+                            hostProcess:
+                              description: |-
+                                HostProcess determines if a container should be run as a 'Host Process' container.
+                                All of a Pod's containers must have the same effective HostProcess value
+                                (it is not allowed to have a mix of HostProcess containers and non-HostProcess containers).
+                                In addition, if HostProcess is true then HostNetwork must also be set to true.
+                              type: boolean
+                            runAsUserName:
+                              description: |-
+                                The UserName in Windows to run the entrypoint of the container process.
+                                Defaults to the user specified in image metadata if unspecified.
+                                May also be set in PodSecurityContext. If set in both SecurityContext and
+                                PodSecurityContext, the value specified in SecurityContext takes precedence.
+                              type: string
+                          type: object
+                      type: object
+                    serviceAccount:
+                      description: |-
+                        ServiceAccount indicates the name of an existing service account to use with this instance. When set,
+                        the operator will not automatically create a ServiceAccount for the TargetAllocator.
+                      type: string
+                    tolerations:
+                      description: |-
+                        Toleration embedded kubernetes pod configuration option,
+                        controls how pods can be scheduled with matching taints
+                      items:
+                        description: |-
+                          The pod this Toleration is attached to tolerates any taint that matches
+                          the triple <key,value,effect> using the matching operator <operator>.
+                        properties:
+                          effect:
+                            description: |-
+                              Effect indicates the taint effect to match. Empty means match all taint effects.
+                              When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
+                            type: string
+                          key:
+                            description: |-
+                              Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                              If the key is empty, operator must be Exists; this combination means to match all values and all keys.
+                            type: string
+                          operator:
+                            description: |-
+                              Operator represents a key's relationship to the value.
+                              Valid operators are Exists and Equal. Defaults to Equal.
+                              Exists is equivalent to wildcard for value, so that a pod can
+                              tolerate all taints of a particular category.
+                            type: string
+                          tolerationSeconds:
+                            description: |-
+                              TolerationSeconds represents the period of time the toleration (which must be
+                              of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                              it is not set, which means tolerate the taint forever (do not evict). Zero and
+                              negative values will be treated as 0 (evict immediately) by the system.
+                            format: int64
+                            type: integer
+                          value:
+                            description: |-
+                              Value is the taint value the toleration matches to.
+                              If the operator is Exists, the value should be empty, otherwise just a regular string.
+                            type: string
+                        type: object
+                      type: array
+                    topologySpreadConstraints:
+                      description: |-
+                        TopologySpreadConstraints embedded kubernetes pod configuration option,
+                        controls how pods are spread across your cluster among failure-domains
+                        such as regions, zones, nodes, and other user-defined topology domains
+                        https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
+                      items:
+                        description: TopologySpreadConstraint specifies how to spread
+                          matching pods among the given topology.
+                        properties:
+                          labelSelector:
+                            description: |-
+                              LabelSelector is used to find matching pods.
+                              Pods that match this label selector are counted to determine the number of pods
+                              in their corresponding topology domain.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector
+                                  requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector
+                                        applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          matchLabelKeys:
+                            description: |-
+                              MatchLabelKeys is a set of pod label keys to select the pods over which
+                              spreading will be calculated. The keys are used to lookup values from the
+                              incoming pod labels, those key-value labels are ANDed with labelSelector
+                              to select the group of existing pods over which spreading will be calculated
+                              for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                              MatchLabelKeys cannot be set when LabelSelector isn't set.
+                              Keys that don't exist in the incoming pod labels will
+                              be ignored. A null or empty list means only match against labelSelector.
+                              
+                              
+                              This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
+                            items:
+                              type: string
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          maxSkew:
+                            description: |-
+                              MaxSkew describes the degree to which pods may be unevenly distributed.
+                              When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                              between the number of matching pods in the target topology and the global minimum.
+                              The global minimum is the minimum number of matching pods in an eligible domain
+                              or zero if the number of eligible domains is less than MinDomains.
+                              For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                              labelSelector spread as 2/2/1:
+                              In this case, the global minimum is 1.
+                              | zone1 | zone2 | zone3 |
+                              |  P P  |  P P  |   P   |
+                              - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                              scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                              violate MaxSkew(1).
+                              - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                              When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                              to topologies that satisfy it.
+                              It's a required field. Default value is 1 and 0 is not allowed.
+                            format: int32
+                            type: integer
+                          minDomains:
+                            description: |-
+                              MinDomains indicates a minimum number of eligible domains.
+                              When the number of eligible domains with matching topology keys is less than minDomains,
+                              Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                              And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                              this value has no effect on scheduling.
+                              As a result, when the number of eligible domains is less than minDomains,
+                              scheduler won't schedule more than maxSkew Pods to those domains.
+                              If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                              Valid values are integers greater than 0.
+                              When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+                              
+                              
+                              For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                              labelSelector spread as 2/2/2:
+                              | zone1 | zone2 | zone3 |
+                              |  P P  |  P P  |  P P  |
+                              The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                              In this situation, new pod with the same labelSelector cannot be scheduled,
+                              because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                              it will violate MaxSkew.
+                              
+                              
+                              This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
+                            format: int32
+                            type: integer
+                          nodeAffinityPolicy:
+                            description: |-
+                              NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                              when calculating pod topology spread skew. Options are:
+                              - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                              - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+                              
+                              
+                              If this value is nil, the behavior is equivalent to the Honor policy.
+                              This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                            type: string
+                          nodeTaintsPolicy:
+                            description: |-
+                              NodeTaintsPolicy indicates how we will treat node taints when calculating
+                              pod topology spread skew. Options are:
+                              - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                              has a toleration, are included.
+                              - Ignore: node taints are ignored. All nodes are included.
+                              
+                              
+                              If this value is nil, the behavior is equivalent to the Ignore policy.
+                              This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
+                            type: string
+                          topologyKey:
+                            description: |-
+                              TopologyKey is the key of node labels. Nodes that have a label with this key
+                              and identical values are considered to be in the same topology.
+                              We consider each <key, value> as a "bucket", and try to put balanced number
+                              of pods into each bucket.
+                              We define a domain as a particular instance of a topology.
+                              Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                              nodeAffinityPolicy and nodeTaintsPolicy.
+                              e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                              And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                              It's a required field.
+                            type: string
+                          whenUnsatisfiable:
+                            description: |-
+                              WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                              the spread constraint.
+                              - DoNotSchedule (default) tells the scheduler not to schedule it.
+                              - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                                but giving higher precedence to topologies that would help reduce the
+                                skew.
+                              A constraint is considered "Unsatisfiable" for an incoming pod
+                              if and only if every possible node assignment for that pod would violate
+                              "MaxSkew" on some topology.
+                              For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                              labelSelector spread as 3/1/1:
+                              | zone1 | zone2 | zone3 |
+                              | P P P |   P   |   P   |
+                              If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                              to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                              MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                              won't make it *more* imbalanced.
+                              It's a required field.
+                            type: string
+                        required:
+                          - maxSkew
+                          - topologyKey
+                          - whenUnsatisfiable
+                        type: object
+                      type: array
+                  type: object
                 terminationGracePeriodSeconds:
                   description: Duration in seconds the pod needs to terminate gracefully
                     upon probe failure.
                   format: int64
                   type: integer
                 tolerations:
-                  description: Toleration to schedule OpenTelemetry Collector pods.
-                    This is only relevant to daemonset, statefulset, and deployment
-                    mode
+                  description: |-
+                    Toleration to schedule OpenTelemetry Collector pods.
+                    This is only relevant to daemonset, statefulset, and deployment mode
                   items:
-                    description: The pod this Toleration is attached to tolerates any
-                      taint that matches the triple <key,value,effect> using the matching
-                      operator <operator>.
+                    description: |-
+                      The pod this Toleration is attached to tolerates any taint that matches
+                      the triple <key,value,effect> using the matching operator <operator>.
                     properties:
                       effect:
-                        description: Effect indicates the taint effect to match. Empty
-                          means match all taint effects. When specified, allowed values
-                          are NoSchedule, PreferNoSchedule and NoExecute.
+                        description: |-
+                          Effect indicates the taint effect to match. Empty means match all taint effects.
+                          When specified, allowed values are NoSchedule, PreferNoSchedule and NoExecute.
                         type: string
                       key:
-                        description: Key is the taint key that the toleration applies
-                          to. Empty means match all taint keys. If the key is empty,
-                          operator must be Exists; this combination means to match all
-                          values and all keys.
+                        description: |-
+                          Key is the taint key that the toleration applies to. Empty means match all taint keys.
+                          If the key is empty, operator must be Exists; this combination means to match all values and all keys.
                         type: string
                       operator:
-                        description: Operator represents a key's relationship to the
-                          value. Valid operators are Exists and Equal. Defaults to Equal.
-                          Exists is equivalent to wildcard for value, so that a pod
-                          can tolerate all taints of a particular category.
+                        description: |-
+                          Operator represents a key's relationship to the value.
+                          Valid operators are Exists and Equal. Defaults to Equal.
+                          Exists is equivalent to wildcard for value, so that a pod can
+                          tolerate all taints of a particular category.
                         type: string
                       tolerationSeconds:
-                        description: TolerationSeconds represents the period of time
-                          the toleration (which must be of effect NoExecute, otherwise
-                          this field is ignored) tolerates the taint. By default, it
-                          is not set, which means tolerate the taint forever (do not
-                          evict). Zero and negative values will be treated as 0 (evict
-                          immediately) by the system.
+                        description: |-
+                          TolerationSeconds represents the period of time the toleration (which must be
+                          of effect NoExecute, otherwise this field is ignored) tolerates the taint. By default,
+                          it is not set, which means tolerate the taint forever (do not evict). Zero and
+                          negative values will be treated as 0 (evict immediately) by the system.
                         format: int64
                         type: integer
                       value:
-                        description: Value is the taint value the toleration matches
-                          to. If the operator is Exists, the value should be empty,
-                          otherwise just a regular string.
+                        description: |-
+                          Value is the taint value the toleration matches to.
+                          If the operator is Exists, the value should be empty, otherwise just a regular string.
                         type: string
                     type: object
                   type: array
                 topologySpreadConstraints:
-                  description: TopologySpreadConstraints embedded kubernetes pod configuration
-                    option, controls how pods are spread across your cluster among failure-domains
+                  description: |-
+                    TopologySpreadConstraints embedded kubernetes pod configuration option,
+                    controls how pods are spread across your cluster among failure-domains
                     such as regions, zones, nodes, and other user-defined topology domains
                     https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
                     This is only relevant to statefulset, and deployment mode
@@ -5090,33 +6676,34 @@ spec:
                       pods among the given topology.
                     properties:
                       labelSelector:
-                        description: LabelSelector is used to find matching pods. Pods
-                          that match this label selector are counted to determine the
-                          number of pods in their corresponding topology domain.
+                        description: |-
+                          LabelSelector is used to find matching pods.
+                          Pods that match this label selector are counted to determine the number of pods
+                          in their corresponding topology domain.
                         properties:
                           matchExpressions:
                             description: matchExpressions is a list of label selector
                               requirements. The requirements are ANDed.
                             items:
-                              description: A label selector requirement is a selector
-                                that contains values, a key, and an operator that relates
-                                the key and values.
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
                               properties:
                                 key:
                                   description: key is the label key that the selector
                                     applies to.
                                   type: string
                                 operator:
-                                  description: operator represents a key's relationship
-                                    to a set of values. Valid operators are In, NotIn,
-                                    Exists and DoesNotExist.
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
                                   type: string
                                 values:
-                                  description: values is an array of string values.
-                                    If the operator is In or NotIn, the values array
-                                    must be non-empty. If the operator is Exists or
-                                    DoesNotExist, the values array must be empty. This
-                                    array is replaced during a strategic merge patch.
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
                                   items:
                                     type: string
                                   type: array
@@ -5128,126 +6715,134 @@ spec:
                           matchLabels:
                             additionalProperties:
                               type: string
-                            description: matchLabels is a map of {key,value} pairs.
-                              A single {key,value} in the matchLabels map is equivalent
-                              to an element of matchExpressions, whose key field is
-                              "key", the operator is "In", and the values array contains
-                              only "value". The requirements are ANDed.
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
                             type: object
                         type: object
                         x-kubernetes-map-type: atomic
                       matchLabelKeys:
-                        description: "MatchLabelKeys is a set of pod label keys to select
-                        the pods over which spreading will be calculated. The keys
-                        are used to lookup values from the incoming pod labels, those
-                        key-value labels are ANDed with labelSelector to select the
-                        group of existing pods over which spreading will be calculated
-                        for the incoming pod. The same key is forbidden to exist in
-                        both MatchLabelKeys and LabelSelector. MatchLabelKeys cannot
-                        be set when LabelSelector isn't set. Keys that don't exist
-                        in the incoming pod labels will be ignored. A null or empty
-                        list means only match against labelSelector. \n This is a
-                        beta field and requires the MatchLabelKeysInPodTopologySpread
-                        feature gate to be enabled (enabled by default)."
+                        description: |-
+                          MatchLabelKeys is a set of pod label keys to select the pods over which
+                          spreading will be calculated. The keys are used to lookup values from the
+                          incoming pod labels, those key-value labels are ANDed with labelSelector
+                          to select the group of existing pods over which spreading will be calculated
+                          for the incoming pod. The same key is forbidden to exist in both MatchLabelKeys and LabelSelector.
+                          MatchLabelKeys cannot be set when LabelSelector isn't set.
+                          Keys that don't exist in the incoming pod labels will
+                          be ignored. A null or empty list means only match against labelSelector.
+                          
+                          
+                          This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                         items:
                           type: string
                         type: array
                         x-kubernetes-list-type: atomic
                       maxSkew:
-                        description: 'MaxSkew describes the degree to which pods may
-                        be unevenly distributed. When `whenUnsatisfiable=DoNotSchedule`,
-                        it is the maximum permitted difference between the number
-                        of matching pods in the target topology and the global minimum.
-                        The global minimum is the minimum number of matching pods
-                        in an eligible domain or zero if the number of eligible domains
-                        is less than MinDomains. For example, in a 3-zone cluster,
-                        MaxSkew is set to 1, and pods with the same labelSelector
-                        spread as 2/2/1: In this case, the global minimum is 1. |
-                        zone1 | zone2 | zone3 | |  P P  |  P P  |   P   | - if MaxSkew
-                        is 1, incoming pod can only be scheduled to zone3 to become
-                        2/2/2; scheduling it onto zone1(zone2) would make the ActualSkew(3-1)
-                        on zone1(zone2) violate MaxSkew(1). - if MaxSkew is 2, incoming
-                        pod can be scheduled onto any zone. When `whenUnsatisfiable=ScheduleAnyway`,
-                        it is used to give higher precedence to topologies that satisfy
-                        it. It''s a required field. Default value is 1 and 0 is not
-                        allowed.'
+                        description: |-
+                          MaxSkew describes the degree to which pods may be unevenly distributed.
+                          When `whenUnsatisfiable=DoNotSchedule`, it is the maximum permitted difference
+                          between the number of matching pods in the target topology and the global minimum.
+                          The global minimum is the minimum number of matching pods in an eligible domain
+                          or zero if the number of eligible domains is less than MinDomains.
+                          For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                          labelSelector spread as 2/2/1:
+                          In this case, the global minimum is 1.
+                          | zone1 | zone2 | zone3 |
+                          |  P P  |  P P  |   P   |
+                          - if MaxSkew is 1, incoming pod can only be scheduled to zone3 to become 2/2/2;
+                          scheduling it onto zone1(zone2) would make the ActualSkew(3-1) on zone1(zone2)
+                          violate MaxSkew(1).
+                          - if MaxSkew is 2, incoming pod can be scheduled onto any zone.
+                          When `whenUnsatisfiable=ScheduleAnyway`, it is used to give higher precedence
+                          to topologies that satisfy it.
+                          It's a required field. Default value is 1 and 0 is not allowed.
                         format: int32
                         type: integer
                       minDomains:
-                        description: "MinDomains indicates a minimum number of eligible
-                        domains. When the number of eligible domains with matching
-                        topology keys is less than minDomains, Pod Topology Spread
-                        treats \"global minimum\" as 0, and then the calculation of
-                        Skew is performed. And when the number of eligible domains
-                        with matching topology keys equals or greater than minDomains,
-                        this value has no effect on scheduling. As a result, when
-                        the number of eligible domains is less than minDomains, scheduler
-                        won't schedule more than maxSkew Pods to those domains. If
-                        value is nil, the constraint behaves as if MinDomains is equal
-                        to 1. Valid values are integers greater than 0. When value
-                        is not nil, WhenUnsatisfiable must be DoNotSchedule. \n For
-                        example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains
-                        is set to 5 and pods with the same labelSelector spread as
-                        2/2/2: | zone1 | zone2 | zone3 | |  P P  |  P P  |  P P  |
-                        The number of domains is less than 5(MinDomains), so \"global
-                        minimum\" is treated as 0. In this situation, new pod with
-                        the same labelSelector cannot be scheduled, because computed
-                        skew will be 3(3 - 0) if new Pod is scheduled to any of the
-                        three zones, it will violate MaxSkew. \n This is a beta field
-                        and requires the MinDomainsInPodTopologySpread feature gate
-                        to be enabled (enabled by default)."
+                        description: |-
+                          MinDomains indicates a minimum number of eligible domains.
+                          When the number of eligible domains with matching topology keys is less than minDomains,
+                          Pod Topology Spread treats "global minimum" as 0, and then the calculation of Skew is performed.
+                          And when the number of eligible domains with matching topology keys equals or greater than minDomains,
+                          this value has no effect on scheduling.
+                          As a result, when the number of eligible domains is less than minDomains,
+                          scheduler won't schedule more than maxSkew Pods to those domains.
+                          If value is nil, the constraint behaves as if MinDomains is equal to 1.
+                          Valid values are integers greater than 0.
+                          When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
+                          
+                          
+                          For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
+                          labelSelector spread as 2/2/2:
+                          | zone1 | zone2 | zone3 |
+                          |  P P  |  P P  |  P P  |
+                          The number of domains is less than 5(MinDomains), so "global minimum" is treated as 0.
+                          In this situation, new pod with the same labelSelector cannot be scheduled,
+                          because computed skew will be 3(3 - 0) if new Pod is scheduled to any of the three zones,
+                          it will violate MaxSkew.
+                          
+                          
+                          This is a beta field and requires the MinDomainsInPodTopologySpread feature gate to be enabled (enabled by default).
                         format: int32
                         type: integer
                       nodeAffinityPolicy:
-                        description: "NodeAffinityPolicy indicates how we will treat
-                        Pod's nodeAffinity/nodeSelector when calculating pod topology
-                        spread skew. Options are: - Honor: only nodes matching nodeAffinity/nodeSelector
-                        are included in the calculations. - Ignore: nodeAffinity/nodeSelector
-                        are ignored. All nodes are included in the calculations. \n
-                        If this value is nil, the behavior is equivalent to the Honor
-                        policy. This is a beta-level feature default enabled by the
-                        NodeInclusionPolicyInPodTopologySpread feature flag."
+                        description: |-
+                          NodeAffinityPolicy indicates how we will treat Pod's nodeAffinity/nodeSelector
+                          when calculating pod topology spread skew. Options are:
+                          - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
+                          - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
+                          
+                          
+                          If this value is nil, the behavior is equivalent to the Honor policy.
+                          This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                         type: string
                       nodeTaintsPolicy:
-                        description: "NodeTaintsPolicy indicates how we will treat node
-                        taints when calculating pod topology spread skew. Options
-                        are: - Honor: nodes without taints, along with tainted nodes
-                        for which the incoming pod has a toleration, are included.
-                        - Ignore: node taints are ignored. All nodes are included.
-                        \n If this value is nil, the behavior is equivalent to the
-                        Ignore policy. This is a beta-level feature default enabled
-                        by the NodeInclusionPolicyInPodTopologySpread feature flag."
+                        description: |-
+                          NodeTaintsPolicy indicates how we will treat node taints when calculating
+                          pod topology spread skew. Options are:
+                          - Honor: nodes without taints, along with tainted nodes for which the incoming pod
+                          has a toleration, are included.
+                          - Ignore: node taints are ignored. All nodes are included.
+                          
+                          
+                          If this value is nil, the behavior is equivalent to the Ignore policy.
+                          This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                         type: string
                       topologyKey:
-                        description: TopologyKey is the key of node labels. Nodes that
-                          have a label with this key and identical values are considered
-                          to be in the same topology. We consider each <key, value>
-                          as a "bucket", and try to put balanced number of pods into
-                          each bucket. We define a domain as a particular instance of
-                          a topology. Also, we define an eligible domain as a domain
-                          whose nodes meet the requirements of nodeAffinityPolicy and
-                          nodeTaintsPolicy. e.g. If TopologyKey is "kubernetes.io/hostname",
-                          each Node is a domain of that topology. And, if TopologyKey
-                          is "topology.kubernetes.io/zone", each zone is a domain of
-                          that topology. It's a required field.
+                        description: |-
+                          TopologyKey is the key of node labels. Nodes that have a label with this key
+                          and identical values are considered to be in the same topology.
+                          We consider each <key, value> as a "bucket", and try to put balanced number
+                          of pods into each bucket.
+                          We define a domain as a particular instance of a topology.
+                          Also, we define an eligible domain as a domain whose nodes meet the requirements of
+                          nodeAffinityPolicy and nodeTaintsPolicy.
+                          e.g. If TopologyKey is "kubernetes.io/hostname", each Node is a domain of that topology.
+                          And, if TopologyKey is "topology.kubernetes.io/zone", each zone is a domain of that topology.
+                          It's a required field.
                         type: string
                       whenUnsatisfiable:
-                        description: 'WhenUnsatisfiable indicates how to deal with a
-                        pod if it doesn''t satisfy the spread constraint. - DoNotSchedule
-                        (default) tells the scheduler not to schedule it. - ScheduleAnyway
-                        tells the scheduler to schedule the pod in any location, but
-                        giving higher precedence to topologies that would help reduce
-                        the skew. A constraint is considered "Unsatisfiable" for an
-                        incoming pod if and only if every possible node assignment
-                        for that pod would violate "MaxSkew" on some topology. For
-                        example, in a 3-zone cluster, MaxSkew is set to 1, and pods
-                        with the same labelSelector spread as 3/1/1: | zone1 | zone2
-                        | zone3 | | P P P |   P   |   P   | If WhenUnsatisfiable is
-                        set to DoNotSchedule, incoming pod can only be scheduled to
-                        zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on
-                        zone2(zone3) satisfies MaxSkew(1). In other words, the cluster
-                        can still be imbalanced, but scheduler won''t make it *more*
-                        imbalanced. It''s a required field.'
+                        description: |-
+                          WhenUnsatisfiable indicates how to deal with a pod if it doesn't satisfy
+                          the spread constraint.
+                          - DoNotSchedule (default) tells the scheduler not to schedule it.
+                          - ScheduleAnyway tells the scheduler to schedule the pod in any location,
+                            but giving higher precedence to topologies that would help reduce the
+                            skew.
+                          A constraint is considered "Unsatisfiable" for an incoming pod
+                          if and only if every possible node assignment for that pod would violate
+                          "MaxSkew" on some topology.
+                          For example, in a 3-zone cluster, MaxSkew is set to 1, and pods with the same
+                          labelSelector spread as 3/1/1:
+                          | zone1 | zone2 | zone3 |
+                          | P P P |   P   |   P   |
+                          If WhenUnsatisfiable is set to DoNotSchedule, incoming pod can only be scheduled
+                          to zone2(zone3) to become 3/2/1(3/1/2) as ActualSkew(2-1) on zone2(zone3) satisfies
+                          MaxSkew(1). In other words, the cluster can still be imbalanced, but scheduler
+                          won't make it *more* imbalanced.
+                          It's a required field.
                         type: string
                     required:
                       - maxSkew
@@ -5256,61 +6851,62 @@ spec:
                     type: object
                   type: array
                 updateStrategy:
-                  description: UpdateStrategy represents the strategy the operator will
-                    take replacing existing DaemonSet pods with new pods https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec
+                  description: |-
+                    UpdateStrategy represents the strategy the operator will take replacing existing DaemonSet pods with new pods
+                    https://kubernetes.io/docs/reference/kubernetes-api/workload-resources/daemon-set-v1/#DaemonSetSpec
                     This is only applicable to Daemonset mode.
                   properties:
                     rollingUpdate:
-                      description: 'Rolling update config params. Present only if type
-                      = "RollingUpdate". --- TODO: Update this to follow our convention
-                      for oneOf, whatever we decide it to be. Same as Deployment `strategy.rollingUpdate`.
-                      See https://github.com/kubernetes/kubernetes/issues/35345'
+                      description: |-
+                        Rolling update config params. Present only if type = "RollingUpdate".
+                        ---
+                        TODO: Update this to follow our convention for oneOf, whatever we decide it
+                        to be. Same as Deployment `strategy.rollingUpdate`.
+                        See https://github.com/kubernetes/kubernetes/issues/35345
                       properties:
                         maxSurge:
                           anyOf:
                             - type: integer
                             - type: string
-                          description: 'The maximum number of nodes with an existing
-                          available DaemonSet pod that can have an updated DaemonSet
-                          pod during during an update. Value can be an absolute number
-                          (ex: 5) or a percentage of desired pods (ex: 10%). This
-                          can not be 0 if MaxUnavailable is 0. Absolute number is
-                          calculated from percentage by rounding up to a minimum of
-                          1. Default value is 0. Example: when this is set to 30%,
-                          at most 30% of the total number of nodes that should be
-                          running the daemon pod (i.e. status.desiredNumberScheduled)
-                          can have their a new pod created before the old pod is marked
-                          as deleted. The update starts by launching new pods on 30%
-                          of nodes. Once an updated pod is available (Ready for at
-                          least minReadySeconds) the old DaemonSet pod on that node
-                          is marked deleted. If the old pod becomes unavailable for
-                          any reason (Ready transitions to false, is evicted, or is
-                          drained) an updated pod is immediatedly created on that
-                          node without considering surge limits. Allowing surge implies
-                          the possibility that the resources consumed by the daemonset
-                          on any given node can double if the readiness check fails,
-                          and so resource intensive daemonsets should take into account
-                          that they may cause evictions during disruption.'
+                          description: |-
+                            The maximum number of nodes with an existing available DaemonSet pod that
+                            can have an updated DaemonSet pod during during an update.
+                            Value can be an absolute number (ex: 5) or a percentage of desired pods (ex: 10%).
+                            This can not be 0 if MaxUnavailable is 0.
+                            Absolute number is calculated from percentage by rounding up to a minimum of 1.
+                            Default value is 0.
+                            Example: when this is set to 30%, at most 30% of the total number of nodes
+                            that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                            can have their a new pod created before the old pod is marked as deleted.
+                            The update starts by launching new pods on 30% of nodes. Once an updated
+                            pod is available (Ready for at least minReadySeconds) the old DaemonSet pod
+                            on that node is marked deleted. If the old pod becomes unavailable for any
+                            reason (Ready transitions to false, is evicted, or is drained) an updated
+                            pod is immediatedly created on that node without considering surge limits.
+                            Allowing surge implies the possibility that the resources consumed by the
+                            daemonset on any given node can double if the readiness check fails, and
+                            so resource intensive daemonsets should take into account that they may
+                            cause evictions during disruption.
                           x-kubernetes-int-or-string: true
                         maxUnavailable:
                           anyOf:
                             - type: integer
                             - type: string
-                          description: 'The maximum number of DaemonSet pods that can
-                          be unavailable during the update. Value can be an absolute
-                          number (ex: 5) or a percentage of total number of DaemonSet
-                          pods at the start of the update (ex: 10%). Absolute number
-                          is calculated from percentage by rounding up. This cannot
-                          be 0 if MaxSurge is 0 Default value is 1. Example: when
-                          this is set to 30%, at most 30% of the total number of nodes
-                          that should be running the daemon pod (i.e. status.desiredNumberScheduled)
-                          can have their pods stopped for an update at any given time.
-                          The update starts by stopping at most 30% of those DaemonSet
-                          pods and then brings up new DaemonSet pods in their place.
-                          Once the new pods are available, it then proceeds onto other
-                          DaemonSet pods, thus ensuring that at least 70% of original
-                          number of DaemonSet pods are available at all times during
-                          the update.'
+                          description: |-
+                            The maximum number of DaemonSet pods that can be unavailable during the
+                            update. Value can be an absolute number (ex: 5) or a percentage of total
+                            number of DaemonSet pods at the start of the update (ex: 10%). Absolute
+                            number is calculated from percentage by rounding up.
+                            This cannot be 0 if MaxSurge is 0
+                            Default value is 1.
+                            Example: when this is set to 30%, at most 30% of the total number of nodes
+                            that should be running the daemon pod (i.e. status.desiredNumberScheduled)
+                            can have their pods stopped for an update at any given time. The update
+                            starts by stopping at most 30% of those DaemonSet pods and then brings
+                            up new DaemonSet pods in their place. Once the new pods are available,
+                            it then proceeds onto other DaemonSet pods, thus ensuring that at least
+                            70% of original number of DaemonSet pods are available at all times during
+                            the update.
                           x-kubernetes-int-or-string: true
                       type: object
                     type:
@@ -5333,19 +6929,24 @@ spec:
                       to a persistent volume
                     properties:
                       apiVersion:
-                        description: 'APIVersion defines the versioned schema of this
-                        representation of an object. Servers should convert recognized
-                        schemas to the latest internal value, and may reject unrecognized
-                        values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+                        description: |-
+                          APIVersion defines the versioned schema of this representation of an object.
+                          Servers should convert recognized schemas to the latest internal value, and
+                          may reject unrecognized values.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
                         type: string
                       kind:
-                        description: 'Kind is a string value representing the REST resource
-                        this object represents. Servers may infer this from the endpoint
-                        the client submits requests to. Cannot be updated. In CamelCase.
-                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                        description: |-
+                          Kind is a string value representing the REST resource this object represents.
+                          Servers may infer this from the endpoint the client submits requests to.
+                          Cannot be updated.
+                          In CamelCase.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
                         type: string
                       metadata:
-                        description: 'Standard object''s metadata. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata'
+                        description: |-
+                          Standard object's metadata.
+                          More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                         properties:
                           annotations:
                             additionalProperties:
@@ -5365,33 +6966,33 @@ spec:
                             type: string
                         type: object
                       spec:
-                        description: 'spec defines the desired characteristics of a
-                        volume requested by a pod author. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        description: |-
+                          spec defines the desired characteristics of a volume requested by a pod author.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                         properties:
                           accessModes:
-                            description: 'accessModes contains the desired access modes
-                            the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                            description: |-
+                              accessModes contains the desired access modes the volume should have.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                             items:
                               type: string
                             type: array
                           dataSource:
-                            description: 'dataSource field can be used to specify either:
-                            * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                            * An existing PVC (PersistentVolumeClaim) If the provisioner
-                            or an external controller can support the specified data
-                            source, it will create a new volume based on the contents
-                            of the specified data source. When the AnyVolumeDataSource
-                            feature gate is enabled, dataSource contents will be copied
-                            to dataSourceRef, and dataSourceRef contents will be copied
-                            to dataSource when dataSourceRef.namespace is not specified.
-                            If the namespace is specified, then dataSourceRef will
-                            not be copied to dataSource.'
+                            description: |-
+                              dataSource field can be used to specify either:
+                              * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                              * An existing PVC (PersistentVolumeClaim)
+                              If the provisioner or an external controller can support the specified data source,
+                              it will create a new volume based on the contents of the specified data source.
+                              When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                              and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                              If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                             properties:
                               apiGroup:
-                                description: APIGroup is the group for the resource
-                                  being referenced. If APIGroup is not specified, the
-                                  specified Kind must be in the core API group. For
-                                  any other third-party types, APIGroup is required.
+                                description: |-
+                                  APIGroup is the group for the resource being referenced.
+                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
                                 type: string
                               kind:
                                 description: Kind is the type of resource being referenced
@@ -5405,39 +7006,36 @@ spec:
                             type: object
                             x-kubernetes-map-type: atomic
                           dataSourceRef:
-                            description: 'dataSourceRef specifies the object from which
-                            to populate the volume with data, if a non-empty volume
-                            is desired. This may be any object from a non-empty API
-                            group (non core object) or a PersistentVolumeClaim object.
-                            When this field is specified, volume binding will only
-                            succeed if the type of the specified object matches some
-                            installed volume populator or dynamic provisioner. This
-                            field will replace the functionality of the dataSource
-                            field and as such if both fields are non-empty, they must
-                            have the same value. For backwards compatibility, when
-                            namespace isn''t specified in dataSourceRef, both fields
-                            (dataSource and dataSourceRef) will be set to the same
-                            value automatically if one of them is empty and the other
-                            is non-empty. When namespace is specified in dataSourceRef,
-                            dataSource isn''t set to the same value and must be empty.
-                            There are three important differences between dataSource
-                            and dataSourceRef: * While dataSource only allows two
-                            specific types of objects, dataSourceRef allows any non-core
-                            object, as well as PersistentVolumeClaim objects. * While
-                            dataSource ignores disallowed values (dropping them),
-                            dataSourceRef preserves all values, and generates an error
-                            if a disallowed value is specified. * While dataSource
-                            only allows local objects, dataSourceRef allows objects
-                            in any namespaces. (Beta) Using this field requires the
-                            AnyVolumeDataSource feature gate to be enabled. (Alpha)
-                            Using the namespace field of dataSourceRef requires the
-                            CrossNamespaceVolumeDataSource feature gate to be enabled.'
+                            description: |-
+                              dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                              volume is desired. This may be any object from a non-empty API group (non
+                              core object) or a PersistentVolumeClaim object.
+                              When this field is specified, volume binding will only succeed if the type of
+                              the specified object matches some installed volume populator or dynamic
+                              provisioner.
+                              This field will replace the functionality of the dataSource field and as such
+                              if both fields are non-empty, they must have the same value. For backwards
+                              compatibility, when namespace isn't specified in dataSourceRef,
+                              both fields (dataSource and dataSourceRef) will be set to the same
+                              value automatically if one of them is empty and the other is non-empty.
+                              When namespace is specified in dataSourceRef,
+                              dataSource isn't set to the same value and must be empty.
+                              There are three important differences between dataSource and dataSourceRef:
+                              * While dataSource only allows two specific types of objects, dataSourceRef
+                                allows any non-core object, as well as PersistentVolumeClaim objects.
+                              * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                preserves all values, and generates an error if a disallowed value is
+                                specified.
+                              * While dataSource only allows local objects, dataSourceRef allows objects
+                                in any namespaces.
+                              (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                              (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                             properties:
                               apiGroup:
-                                description: APIGroup is the group for the resource
-                                  being referenced. If APIGroup is not specified, the
-                                  specified Kind must be in the core API group. For
-                                  any other third-party types, APIGroup is required.
+                                description: |-
+                                  APIGroup is the group for the resource being referenced.
+                                  If APIGroup is not specified, the specified Kind must be in the core API group.
+                                  For any other third-party types, APIGroup is required.
                                 type: string
                               kind:
                                 description: Kind is the type of resource being referenced
@@ -5446,26 +7044,22 @@ spec:
                                 description: Name is the name of resource being referenced
                                 type: string
                               namespace:
-                                description: Namespace is the namespace of resource
-                                  being referenced Note that when a namespace is specified,
-                                  a gateway.networking.k8s.io/ReferenceGrant object
-                                  is required in the referent namespace to allow that
-                                  namespace's owner to accept the reference. See the
-                                  ReferenceGrant documentation for details. (Alpha)
-                                  This field requires the CrossNamespaceVolumeDataSource
-                                  feature gate to be enabled.
+                                description: |-
+                                  Namespace is the namespace of resource being referenced
+                                  Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                  (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                 type: string
                             required:
                               - kind
                               - name
                             type: object
                           resources:
-                            description: 'resources represents the minimum resources
-                            the volume should have. If RecoverVolumeExpansionFailure
-                            feature is enabled users are allowed to specify resource
-                            requirements that are lower than previous value but must
-                            still be higher than capacity recorded in the status field
-                            of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                            description: |-
+                              resources represents the minimum resources the volume should have.
+                              If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                              that are lower than previous value but must still be higher than capacity recorded in the
+                              status field of the claim.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                             properties:
                               limits:
                                 additionalProperties:
@@ -5474,8 +7068,9 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Limits describes the maximum amount of
-                                compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: |-
+                                  Limits describes the maximum amount of compute resources allowed.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                               requests:
                                 additionalProperties:
@@ -5484,11 +7079,11 @@ spec:
                                     - type: string
                                   pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                   x-kubernetes-int-or-string: true
-                                description: 'Requests describes the minimum amount
-                                of compute resources required. If Requests is omitted
-                                for a container, it defaults to Limits if that is
-                                explicitly specified, otherwise to an implementation-defined
-                                value. Requests cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                description: |-
+                                  Requests describes the minimum amount of compute resources required.
+                                  If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                  otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                  More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                 type: object
                             type: object
                           selector:
@@ -5499,8 +7094,8 @@ spec:
                                 description: matchExpressions is a list of label selector
                                   requirements. The requirements are ANDed.
                                 items:
-                                  description: A label selector requirement is a selector
-                                    that contains values, a key, and an operator that
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
                                     relates the key and values.
                                   properties:
                                     key:
@@ -5508,17 +7103,16 @@ spec:
                                         applies to.
                                       type: string
                                     operator:
-                                      description: operator represents a key's relationship
-                                        to a set of values. Valid operators are In,
-                                        NotIn, Exists and DoesNotExist.
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
                                       type: string
                                     values:
-                                      description: values is an array of string values.
-                                        If the operator is In or NotIn, the values array
-                                        must be non-empty. If the operator is Exists
-                                        or DoesNotExist, the values array must be empty.
-                                        This array is replaced during a strategic merge
-                                        patch.
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
                                       items:
                                         type: string
                                       type: array
@@ -5530,41 +7124,37 @@ spec:
                               matchLabels:
                                 additionalProperties:
                                   type: string
-                                description: matchLabels is a map of {key,value} pairs.
-                                  A single {key,value} in the matchLabels map is equivalent
-                                  to an element of matchExpressions, whose key field
-                                  is "key", the operator is "In", and the values array
-                                  contains only "value". The requirements are ANDed.
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
                                 type: object
                             type: object
                             x-kubernetes-map-type: atomic
                           storageClassName:
-                            description: 'storageClassName is the name of the StorageClass
-                            required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                            description: |-
+                              storageClassName is the name of the StorageClass required by the claim.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                             type: string
                           volumeAttributesClassName:
-                            description: 'volumeAttributesClassName may be used to set
-                            the VolumeAttributesClass used by this claim. If specified,
-                            the CSI driver will create or update the volume with the
-                            attributes defined in the corresponding VolumeAttributesClass.
-                            This has a different purpose than storageClassName, it
-                            can be changed after the claim is created. An empty string
-                            value means that no VolumeAttributesClass will be applied
-                            to the claim but it''s not allowed to reset this field
-                            to empty string once it is set. If unspecified and the
-                            PersistentVolumeClaim is unbound, the default VolumeAttributesClass
-                            will be set by the persistentvolume controller if it exists.
-                            If the resource referred to by volumeAttributesClass does
-                            not exist, this PersistentVolumeClaim will be set to a
-                            Pending state, as reflected by the modifyVolumeStatus
-                            field, until such as a resource exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                            (Alpha) Using this field requires the VolumeAttributesClass
-                            feature gate to be enabled.'
+                            description: |-
+                              volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                              If specified, the CSI driver will create or update the volume with the attributes defined
+                              in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                              it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                              will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                              If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                              will be set by the persistentvolume controller if it exists.
+                              If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                              set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                              exists.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                              (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                             type: string
                           volumeMode:
-                            description: volumeMode defines what type of volume is required
-                              by the claim. Value of Filesystem is implied when not
-                              included in claim spec.
+                            description: |-
+                              volumeMode defines what type of volume is required by the claim.
+                              Value of Filesystem is implied when not included in claim spec.
                             type: string
                           volumeName:
                             description: volumeName is the binding reference to the
@@ -5572,56 +7162,59 @@ spec:
                             type: string
                         type: object
                       status:
-                        description: 'status represents the current information/status
-                        of a persistent volume claim. Read-only. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        description: |-
+                          status represents the current information/status of a persistent volume claim.
+                          Read-only.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                         properties:
                           accessModes:
-                            description: 'accessModes contains the actual access modes
-                            the volume backing the PVC has. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                            description: |-
+                              accessModes contains the actual access modes the volume backing the PVC has.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                             items:
                               type: string
                             type: array
                           allocatedResourceStatuses:
                             additionalProperties:
-                              description: When a controller receives persistentvolume
-                                claim update with ClaimResourceStatus for a resource
-                                that it does not recognizes, then it should ignore that
-                                update and let other controllers handle it.
+                              description: |-
+                                When a controller receives persistentvolume claim update with ClaimResourceStatus for a resource
+                                that it does not recognizes, then it should ignore that update and let other controllers
+                                handle it.
                               type: string
                             description: "allocatedResourceStatuses stores status of
-                            resource being resized for the given PVC. Key names follow
-                            standard Kubernetes label syntax. Valid values are either:
-                            * Un-prefixed keys: - storage - the capacity of the volume.
-                            * Custom resources must use implementation-defined prefixed
-                            names such as \"example.com/my-custom-resource\" Apart
+                            resource being resized for the given PVC.\nKey names follow
+                            standard Kubernetes label syntax. Valid values are either:\n\t*
+                            Un-prefixed keys:\n\t\t- storage - the capacity of the
+                            volume.\n\t* Custom resources must use implementation-defined
+                            prefixed names such as \"example.com/my-custom-resource\"\nApart
                             from above values - keys that are unprefixed or have kubernetes.io
-                            prefix are considered reserved and hence may not be used.
-                            \n ClaimResourceStatus can be in any of following states:
-                            - ControllerResizeInProgress: State set when resize controller
-                            starts resizing the volume in control-plane. - ControllerResizeFailed:
-                            State set when resize has failed in resize controller
-                            with a terminal error. - NodeResizePending: State set
+                            prefix are considered\nreserved and hence may not be used.\n\n\nClaimResourceStatus
+                            can be in any of following states:\n\t- ControllerResizeInProgress:\n\t\tState
+                            set when resize controller starts resizing the volume
+                            in control-plane.\n\t- ControllerResizeFailed:\n\t\tState
+                            set when resize has failed in resize controller with a
+                            terminal error.\n\t- NodeResizePending:\n\t\tState set
                             when resize controller has finished resizing the volume
-                            but further resizing of volume is needed on the node.
-                            - NodeResizeInProgress: State set when kubelet starts
-                            resizing the volume. - NodeResizeFailed: State set when
-                            resizing has failed in kubelet with a terminal error.
-                            Transient errors don't set NodeResizeFailed. For example:
-                            if expanding a PVC for more capacity - this field can
-                            be one of the following states: - pvc.status.allocatedResourceStatus['storage']
-                            = \"ControllerResizeInProgress\" - pvc.status.allocatedResourceStatus['storage']
-                            = \"ControllerResizeFailed\" - pvc.status.allocatedResourceStatus['storage']
-                            = \"NodeResizePending\" - pvc.status.allocatedResourceStatus['storage']
-                            = \"NodeResizeInProgress\" - pvc.status.allocatedResourceStatus['storage']
-                            = \"NodeResizeFailed\" When this field is not set, it
+                            but further resizing of\n\t\tvolume is needed on the node.\n\t-
+                            NodeResizeInProgress:\n\t\tState set when kubelet starts
+                            resizing the volume.\n\t- NodeResizeFailed:\n\t\tState
+                            set when resizing has failed in kubelet with a terminal
+                            error. Transient errors don't set\n\t\tNodeResizeFailed.\nFor
+                            example: if expanding a PVC for more capacity - this field
+                            can be one of the following states:\n\t- pvc.status.allocatedResourceStatus['storage']
+                            = \"ControllerResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage']
+                            = \"ControllerResizeFailed\"\n     - pvc.status.allocatedResourceStatus['storage']
+                            = \"NodeResizePending\"\n     - pvc.status.allocatedResourceStatus['storage']
+                            = \"NodeResizeInProgress\"\n     - pvc.status.allocatedResourceStatus['storage']
+                            = \"NodeResizeFailed\"\nWhen this field is not set, it
                             means that no resize operation is in progress for the
-                            given PVC. \n A controller that receives PVC update with
-                            previously unknown resourceName or ClaimResourceStatus
-                            should ignore the update for the purpose it was designed.
-                            For example - a controller that only is responsible for
-                            resizing capacity of the volume, should ignore PVC updates
-                            that change other valid resources associated with PVC.
-                            \n This is an alpha field and requires enabling RecoverVolumeExpansionFailure
+                            given PVC.\n\n\nA controller that receives PVC update
+                            with previously unknown resourceName or ClaimResourceStatus\nshould
+                            ignore the update for the purpose it was designed. For
+                            example - a controller that\nonly is responsible for resizing
+                            capacity of the volume, should ignore PVC updates that
+                            change other valid\nresources associated with PVC.\n\n\nThis
+                            is an alpha field and requires enabling RecoverVolumeExpansionFailure
                             feature."
                             type: object
                             x-kubernetes-map-type: granular
@@ -5633,29 +7226,29 @@ spec:
                               pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                               x-kubernetes-int-or-string: true
                             description: "allocatedResources tracks the resources allocated
-                            to a PVC including its capacity. Key names follow standard
-                            Kubernetes label syntax. Valid values are either: * Un-prefixed
-                            keys: - storage - the capacity of the volume. * Custom
-                            resources must use implementation-defined prefixed names
-                            such as \"example.com/my-custom-resource\" Apart from
-                            above values - keys that are unprefixed or have kubernetes.io
-                            prefix are considered reserved and hence may not be used.
-                            \n Capacity reported here may be larger than the actual
-                            capacity when a volume expansion operation is requested.
-                            For storage quota, the larger value from allocatedResources
-                            and PVC.spec.resources is used. If allocatedResources
-                            is not set, PVC.spec.resources alone is used for quota
-                            calculation. If a volume expansion capacity request is
-                            lowered, allocatedResources is only lowered if there are
-                            no expansion operations in progress and if the actual
-                            volume capacity is equal or lower than the requested capacity.
-                            \n A controller that receives PVC update with previously
-                            unknown resourceName should ignore the update for the
-                            purpose it was designed. For example - a controller that
-                            only is responsible for resizing capacity of the volume,
-                            should ignore PVC updates that change other valid resources
-                            associated with PVC. \n This is an alpha field and requires
-                            enabling RecoverVolumeExpansionFailure feature."
+                            to a PVC including its capacity.\nKey names follow standard
+                            Kubernetes label syntax. Valid values are either:\n\t*
+                            Un-prefixed keys:\n\t\t- storage - the capacity of the
+                            volume.\n\t* Custom resources must use implementation-defined
+                            prefixed names such as \"example.com/my-custom-resource\"\nApart
+                            from above values - keys that are unprefixed or have kubernetes.io
+                            prefix are considered\nreserved and hence may not be used.\n\n\nCapacity
+                            reported here may be larger than the actual capacity when
+                            a volume expansion operation\nis requested.\nFor storage
+                            quota, the larger value from allocatedResources and PVC.spec.resources
+                            is used.\nIf allocatedResources is not set, PVC.spec.resources
+                            alone is used for quota calculation.\nIf a volume expansion
+                            capacity request is lowered, allocatedResources is only\nlowered
+                            if there are no expansion operations in progress and if
+                            the actual volume capacity\nis equal or lower than the
+                            requested capacity.\n\n\nA controller that receives PVC
+                            update with previously unknown resourceName\nshould ignore
+                            the update for the purpose it was designed. For example
+                            - a controller that\nonly is responsible for resizing
+                            capacity of the volume, should ignore PVC updates that
+                            change other valid\nresources associated with PVC.\n\n\nThis
+                            is an alpha field and requires enabling RecoverVolumeExpansionFailure
+                            feature."
                             type: object
                           capacity:
                             additionalProperties:
@@ -5668,8 +7261,8 @@ spec:
                               the underlying volume.
                             type: object
                           conditions:
-                            description: conditions is the current Condition of persistent
-                              volume claim. If underlying persistent volume is being
+                            description: |-
+                              conditions is the current Condition of persistent volume claim. If underlying persistent volume is being
                               resized then the Condition will be set to 'ResizeStarted'.
                             items:
                               description: PersistentVolumeClaimCondition contains details
@@ -5690,10 +7283,9 @@ spec:
                                     indicating details about last transition.
                                   type: string
                                 reason:
-                                  description: reason is a unique, this should be a
-                                    short, machine understandable string that gives
-                                    the reason for condition's last transition. If it
-                                    reports "ResizeStarted" that means the underlying
+                                  description: |-
+                                    reason is a unique, this should be a short, machine understandable string that gives the reason
+                                    for condition's last transition. If it reports "ResizeStarted" that means the underlying
                                     persistent volume is being resized.
                                   type: string
                                 status:
@@ -5708,32 +7300,30 @@ spec:
                               type: object
                             type: array
                           currentVolumeAttributesClassName:
-                            description: currentVolumeAttributesClassName is the current
-                              name of the VolumeAttributesClass the PVC is using. When
-                              unset, there is no VolumeAttributeClass applied to this
-                              PersistentVolumeClaim This is an alpha field and requires
-                              enabling VolumeAttributesClass feature.
+                            description: |-
+                              currentVolumeAttributesClassName is the current name of the VolumeAttributesClass the PVC is using.
+                              When unset, there is no VolumeAttributeClass applied to this PersistentVolumeClaim
+                              This is an alpha field and requires enabling VolumeAttributesClass feature.
                             type: string
                           modifyVolumeStatus:
-                            description: ModifyVolumeStatus represents the status object
-                              of ControllerModifyVolume operation. When this is unset,
-                              there is no ModifyVolume operation being attempted. This
-                              is an alpha field and requires enabling VolumeAttributesClass
-                              feature.
+                            description: |-
+                              ModifyVolumeStatus represents the status object of ControllerModifyVolume operation.
+                              When this is unset, there is no ModifyVolume operation being attempted.
+                              This is an alpha field and requires enabling VolumeAttributesClass feature.
                             properties:
                               status:
-                                description: 'status is the status of the ControllerModifyVolume
-                                operation. It can be in any of following states: -
-                                Pending Pending indicates that the PersistentVolumeClaim
+                                description: "status is the status of the ControllerModifyVolume
+                                operation. It can be in any of following states:\n
+                                - Pending\n   Pending indicates that the PersistentVolumeClaim
                                 cannot be modified due to unmet requirements, such
-                                as the specified VolumeAttributesClass not existing.
-                                - InProgress InProgress indicates that the volume
-                                is being modified. - Infeasible Infeasible indicates
+                                as\n   the specified VolumeAttributesClass not existing.\n
+                                - InProgress\n   InProgress indicates that the volume
+                                is being modified.\n - Infeasible\n  Infeasible indicates
                                 that the request has been rejected as invalid by the
-                                CSI driver. To resolve the error, a valid VolumeAttributesClass
-                                needs to be specified. Note: New statuses can be added
-                                in the future. Consumers should check for unknown
-                                statuses and fail appropriately.'
+                                CSI driver. To\n\t  resolve the error, a valid VolumeAttributesClass
+                                needs to be specified.\nNote: New statuses can be
+                                added in the future. Consumers should check for unknown
+                                statuses and fail appropriately."
                                 type: string
                               targetVolumeAttributesClassName:
                                 description: targetVolumeAttributesClassName is the
@@ -5758,32 +7348,36 @@ spec:
                       a container.
                     properties:
                       mountPath:
-                        description: Path within the container at which the volume should
-                          be mounted.  Must not contain ':'.
+                        description: |-
+                          Path within the container at which the volume should be mounted.  Must
+                          not contain ':'.
                         type: string
                       mountPropagation:
-                        description: mountPropagation determines how mounts are propagated
-                          from the host to container and the other way around. When
-                          not set, MountPropagationNone is used. This field is beta
-                          in 1.10.
+                        description: |-
+                          mountPropagation determines how mounts are propagated from the host
+                          to container and the other way around.
+                          When not set, MountPropagationNone is used.
+                          This field is beta in 1.10.
                         type: string
                       name:
                         description: This must match the Name of a Volume.
                         type: string
                       readOnly:
-                        description: Mounted read-only if true, read-write otherwise
-                          (false or unspecified). Defaults to false.
+                        description: |-
+                          Mounted read-only if true, read-write otherwise (false or unspecified).
+                          Defaults to false.
                         type: boolean
                       subPath:
-                        description: Path within the volume from which the container's
-                          volume should be mounted. Defaults to "" (volume's root).
+                        description: |-
+                          Path within the volume from which the container's volume should be mounted.
+                          Defaults to "" (volume's root).
                         type: string
                       subPathExpr:
-                        description: Expanded path within the volume from which the
-                          container's volume should be mounted. Behaves similarly to
-                          SubPath but environment variable references $(VAR_NAME) are
-                          expanded using the container's environment. Defaults to ""
-                          (volume's root). SubPathExpr and SubPath are mutually exclusive.
+                        description: |-
+                          Expanded path within the volume from which the container's volume should be mounted.
+                          Behaves similarly to SubPath but environment variable references $(VAR_NAME) are expanded using the container's environment.
+                          Defaults to "" (volume's root).
+                          SubPathExpr and SubPath are mutually exclusive.
                         type: string
                     required:
                       - mountPath
@@ -5799,34 +7393,36 @@ spec:
                       be accessed by any container in the pod.
                     properties:
                       awsElasticBlockStore:
-                        description: 'awsElasticBlockStore represents an AWS Disk resource
-                        that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        description: |-
+                          awsElasticBlockStore represents an AWS Disk resource that is attached to a
+                          kubelet's host machine and then exposed to the pod.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                         properties:
                           fsType:
-                            description: 'fsType is the filesystem type of the volume
-                            that you want to mount. Tip: Ensure that the filesystem
-                            type is supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
+                            description: |-
+                              fsType is the filesystem type of the volume that you want to mount.
+                              Tip: Ensure that the filesystem type is supported by the host operating system.
+                              Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
+                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           partition:
-                            description: 'partition is the partition in the volume that
-                            you want to mount. If omitted, the default is to mount
-                            by volume name. Examples: For volume /dev/sda1, you specify
-                            the partition as "1". Similarly, the volume partition
-                            for /dev/sda is "0" (or you can leave the property empty).'
+                            description: |-
+                              partition is the partition in the volume that you want to mount.
+                              If omitted, the default is to mount by volume name.
+                              Examples: For volume /dev/sda1, you specify the partition as "1".
+                              Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
                             format: int32
                             type: integer
                           readOnly:
-                            description: 'readOnly value true will force the readOnly
-                            setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            description: |-
+                              readOnly value true will force the readOnly setting in VolumeMounts.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                             type: boolean
                           volumeID:
-                            description: 'volumeID is unique ID of the persistent disk
-                            resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            description: |-
+                              volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume).
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore
                             type: string
                         required:
                           - volumeID
@@ -5848,10 +7444,10 @@ spec:
                               storage
                             type: string
                           fsType:
-                            description: fsType is Filesystem type to mount. Must be
-                              a filesystem type supported by the host operating system.
-                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                              if unspecified.
+                            description: |-
+                              fsType is Filesystem type to mount.
+                              Must be a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                             type: string
                           kind:
                             description: 'kind expected values are Shared: multiple
@@ -5860,8 +7456,9 @@ spec:
                             disk (only in managed availability set). defaults to shared'
                             type: string
                           readOnly:
-                            description: readOnly Defaults to false (read/write). ReadOnly
-                              here will force the ReadOnly setting in VolumeMounts.
+                            description: |-
+                              readOnly Defaults to false (read/write). ReadOnly here will force
+                              the ReadOnly setting in VolumeMounts.
                             type: boolean
                         required:
                           - diskName
@@ -5872,8 +7469,9 @@ spec:
                           on the host and bind mount to the pod.
                         properties:
                           readOnly:
-                            description: readOnly defaults to false (read/write). ReadOnly
-                              here will force the ReadOnly setting in VolumeMounts.
+                            description: |-
+                              readOnly defaults to false (read/write). ReadOnly here will force
+                              the ReadOnly setting in VolumeMounts.
                             type: boolean
                           secretName:
                             description: secretName is the  name of secret that contains
@@ -5891,8 +7489,9 @@ spec:
                           shares a pod's lifetime
                         properties:
                           monitors:
-                            description: 'monitors is Required: Monitors is a collection
-                            of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            description: |-
+                              monitors is Required: Monitors is a collection of Ceph monitors
+                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                             items:
                               type: string
                             type: array
@@ -5901,61 +7500,72 @@ spec:
                             rather than the full Ceph tree, default is /'
                             type: string
                           readOnly:
-                            description: 'readOnly is Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            description: |-
+                              readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                              the ReadOnly setting in VolumeMounts.
+                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                             type: boolean
                           secretFile:
-                            description: 'secretFile is Optional: SecretFile is the
-                            path to key ring for User, default is /etc/ceph/user.secret
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            description: |-
+                              secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret
+                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                             type: string
                           secretRef:
-                            description: 'secretRef is Optional: SecretRef is reference
-                            to the authentication secret for User, default is empty.
-                            More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            description: |-
+                              secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty.
+                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           user:
-                            description: 'user is optional: User is the rados user name,
-                            default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            description: |-
+                              user is optional: User is the rados user name, default is admin
+                              More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it
                             type: string
                         required:
                           - monitors
                         type: object
                       cinder:
-                        description: 'cinder represents a cinder volume attached and
-                        mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        description: |-
+                          cinder represents a cinder volume attached and mounted on kubelets host machine.
+                          More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                         properties:
                           fsType:
-                            description: 'fsType is the filesystem type to mount. Must
-                            be a filesystem type supported by the host operating system.
-                            Examples: "ext4", "xfs", "ntfs". Implicitly inferred to
-                            be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            description: |-
+                              fsType is the filesystem type to mount.
+                              Must be a filesystem type supported by the host operating system.
+                              Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                             type: string
                           readOnly:
-                            description: 'readOnly defaults to false (read/write). ReadOnly
-                            here will force the ReadOnly setting in VolumeMounts.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            description: |-
+                              readOnly defaults to false (read/write). ReadOnly here will force
+                              the ReadOnly setting in VolumeMounts.
+                              More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                             type: boolean
                           secretRef:
-                            description: 'secretRef is optional: points to a secret
-                            object containing parameters used to connect to OpenStack.'
+                            description: |-
+                              secretRef is optional: points to a secret object containing parameters used to connect
+                              to OpenStack.
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           volumeID:
-                            description: 'volumeID used to identify the volume in cinder.
-                            More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            description: |-
+                              volumeID used to identify the volume in cinder.
+                              More info: https://examples.k8s.io/mysql-cinder-pd/README.md
                             type: string
                         required:
                           - volumeID
@@ -5965,27 +7575,25 @@ spec:
                           this volume
                         properties:
                           defaultMode:
-                            description: 'defaultMode is optional: mode bits used to
-                            set permissions on created files by default. Must be an
-                            octal value between 0000 and 0777 or a decimal value between
-                            0 and 511. YAML accepts both octal and decimal values,
-                            JSON requires decimal values for mode bits. Defaults to
-                            0644. Directories within the path are not affected by
-                            this setting. This might be in conflict with other options
-                            that affect the file mode, like fsGroup, and the result
-                            can be other mode bits set.'
+                            description: |-
+                              defaultMode is optional: mode bits used to set permissions on created files by default.
+                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                              Defaults to 0644.
+                              Directories within the path are not affected by this setting.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
                           items:
-                            description: items if unspecified, each key-value pair in
-                              the Data field of the referenced ConfigMap will be projected
-                              into the volume as a file whose name is the key and content
-                              is the value. If specified, the listed keys will be projected
-                              into the specified paths, and unlisted keys will not be
-                              present. If a key is specified which is not present in
-                              the ConfigMap, the volume setup will error unless it is
-                              marked optional. Paths must be relative and may not contain
-                              the '..' path or start with '..'.
+                            description: |-
+                              items if unspecified, each key-value pair in the Data field of the referenced
+                              ConfigMap will be projected into the volume as a file whose name is the
+                              key and content is the value. If specified, the listed keys will be
+                              projected into the specified paths, and unlisted keys will not be
+                              present. If a key is specified which is not present in the ConfigMap,
+                              the volume setup will error unless it is marked optional. Paths must be
+                              relative and may not contain the '..' path or start with '..'.
                             items:
                               description: Maps a string key to a path within a volume.
                               properties:
@@ -5993,22 +7601,21 @@ spec:
                                   description: key is the key to project.
                                   type: string
                                 mode:
-                                  description: 'mode is Optional: mode bits used to
-                                  set permissions on this file. Must be an octal value
-                                  between 0000 and 0777 or a decimal value between
-                                  0 and 511. YAML accepts both octal and decimal values,
-                                  JSON requires decimal values for mode bits. If not
-                                  specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that
-                                  affect the file mode, like fsGroup, and the result
-                                  can be other mode bits set.'
+                                  description: |-
+                                    mode is Optional: mode bits used to set permissions on this file.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    If not specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 path:
-                                  description: path is the relative path of the file
-                                    to map the key to. May not be an absolute path.
-                                    May not contain the path element '..'. May not start
-                                    with the string '..'.
+                                  description: |-
+                                    path is the relative path of the file to map the key to.
+                                    May not be an absolute path.
+                                    May not contain the path element '..'.
+                                    May not start with the string '..'.
                                   type: string
                               required:
                                 - key
@@ -6016,8 +7623,10 @@ spec:
                               type: object
                             type: array
                           name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                            description: |-
+                              Name of the referent.
+                              More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                              TODO: Add other useful fields. apiVersion, kind, uid?
                             type: string
                           optional:
                             description: optional specify whether the ConfigMap or its
@@ -6031,41 +7640,43 @@ spec:
                           feature).
                         properties:
                           driver:
-                            description: driver is the name of the CSI driver that handles
-                              this volume. Consult with your admin for the correct name
-                              as registered in the cluster.
+                            description: |-
+                              driver is the name of the CSI driver that handles this volume.
+                              Consult with your admin for the correct name as registered in the cluster.
                             type: string
                           fsType:
-                            description: fsType to mount. Ex. "ext4", "xfs", "ntfs".
-                              If not provided, the empty value is passed to the associated
-                              CSI driver which will determine the default filesystem
-                              to apply.
+                            description: |-
+                              fsType to mount. Ex. "ext4", "xfs", "ntfs".
+                              If not provided, the empty value is passed to the associated CSI driver
+                              which will determine the default filesystem to apply.
                             type: string
                           nodePublishSecretRef:
-                            description: nodePublishSecretRef is a reference to the
-                              secret object containing sensitive information to pass
-                              to the CSI driver to complete the CSI NodePublishVolume
-                              and NodeUnpublishVolume calls. This field is optional,
-                              and  may be empty if no secret is required. If the secret
-                              object contains more than one secret, all secret references
-                              are passed.
+                            description: |-
+                              nodePublishSecretRef is a reference to the secret object containing
+                              sensitive information to pass to the CSI driver to complete the CSI
+                              NodePublishVolume and NodeUnpublishVolume calls.
+                              This field is optional, and  may be empty if no secret is required. If the
+                              secret object contains more than one secret, all secret references are passed.
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           readOnly:
-                            description: readOnly specifies a read-only configuration
-                              for the volume. Defaults to false (read/write).
+                            description: |-
+                              readOnly specifies a read-only configuration for the volume.
+                              Defaults to false (read/write).
                             type: boolean
                           volumeAttributes:
                             additionalProperties:
                               type: string
-                            description: volumeAttributes stores driver-specific properties
-                              that are passed to the CSI driver. Consult your driver's
-                              documentation for supported values.
+                            description: |-
+                              volumeAttributes stores driver-specific properties that are passed to the CSI
+                              driver. Consult your driver's documentation for supported values.
                             type: object
                         required:
                           - driver
@@ -6075,16 +7686,15 @@ spec:
                           that should populate this volume
                         properties:
                           defaultMode:
-                            description: 'Optional: mode bits to use on created files
-                            by default. Must be a Optional: mode bits used to set
-                            permissions on created files by default. Must be an octal
-                            value between 0000 and 0777 or a decimal value between
-                            0 and 511. YAML accepts both octal and decimal values,
-                            JSON requires decimal values for mode bits. Defaults to
-                            0644. Directories within the path are not affected by
-                            this setting. This might be in conflict with other options
-                            that affect the file mode, like fsGroup, and the result
-                            can be other mode bits set.'
+                            description: |-
+                              Optional: mode bits to use on created files by default. Must be a
+                              Optional: mode bits used to set permissions on created files by default.
+                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                              Defaults to 0644.
+                              Directories within the path are not affected by this setting.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
                           items:
@@ -6111,15 +7721,13 @@ spec:
                                   type: object
                                   x-kubernetes-map-type: atomic
                                 mode:
-                                  description: 'Optional: mode bits used to set permissions
-                                  on this file, must be an octal value between 0000
-                                  and 0777 or a decimal value between 0 and 511. YAML
-                                  accepts both octal and decimal values, JSON requires
-                                  decimal values for mode bits. If not specified,
-                                  the volume defaultMode will be used. This might
-                                  be in conflict with other options that affect the
-                                  file mode, like fsGroup, and the result can be other
-                                  mode bits set.'
+                                  description: |-
+                                    Optional: mode bits used to set permissions on this file, must be an octal value
+                                    between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    If not specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 path:
@@ -6130,10 +7738,9 @@ spec:
                                   with ''..'''
                                   type: string
                                 resourceFieldRef:
-                                  description: 'Selects a resource of the container:
-                                  only resources limits and requests (limits.cpu,
-                                  limits.memory, requests.cpu and requests.memory)
-                                  are currently supported.'
+                                  description: |-
+                                    Selects a resource of the container: only resources limits and requests
+                                    (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                   properties:
                                     containerName:
                                       description: 'Container name: required for volumes,
@@ -6160,73 +7767,94 @@ spec:
                             type: array
                         type: object
                       emptyDir:
-                        description: 'emptyDir represents a temporary directory that
-                        shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        description: |-
+                          emptyDir represents a temporary directory that shares a pod's lifetime.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                         properties:
                           medium:
-                            description: 'medium represents what type of storage medium
-                            should back this directory. The default is "" which means
-                            to use the node''s default medium. Must be an empty string
-                            (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            description: |-
+                              medium represents what type of storage medium should back this directory.
+                              The default is "" which means to use the node's default medium.
+                              Must be an empty string (default) or Memory.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                             type: string
                           sizeLimit:
                             anyOf:
                               - type: integer
                               - type: string
-                            description: 'sizeLimit is the total amount of local storage
-                            required for this EmptyDir volume. The size limit is also
-                            applicable for memory medium. The maximum usage on memory
-                            medium EmptyDir would be the minimum value between the
-                            SizeLimit specified here and the sum of memory limits
-                            of all containers in a pod. The default is nil which means
-                            that the limit is undefined. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            description: |-
+                              sizeLimit is the total amount of local storage required for this EmptyDir volume.
+                              The size limit is also applicable for memory medium.
+                              The maximum usage on memory medium EmptyDir would be the minimum value between
+                              the SizeLimit specified here and the sum of memory limits of all containers in a pod.
+                              The default is nil which means that the limit is undefined.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir
                             pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                             x-kubernetes-int-or-string: true
                         type: object
                       ephemeral:
-                        description: "ephemeral represents a volume that is handled
-                        by a cluster storage driver. The volume's lifecycle is tied
-                        to the pod that defines it - it will be created before the
-                        pod starts, and deleted when the pod is removed. \n Use this
-                        if: a) the volume is only needed while the pod runs, b) features
-                        of normal volumes like restoring from snapshot or capacity
-                        tracking are needed, c) the storage driver is specified through
-                        a storage class, and d) the storage driver supports dynamic
-                        volume provisioning through a PersistentVolumeClaim (see EphemeralVolumeSource
-                        for more information on the connection between this volume
-                        type and PersistentVolumeClaim). \n Use PersistentVolumeClaim
-                        or one of the vendor-specific APIs for volumes that persist
-                        for longer than the lifecycle of an individual pod. \n Use
-                        CSI for light-weight local ephemeral volumes if the CSI driver
-                        is meant to be used that way - see the documentation of the
-                        driver for more information. \n A pod can use both types of
-                        ephemeral volumes and persistent volumes at the same time."
+                        description: |-
+                          ephemeral represents a volume that is handled by a cluster storage driver.
+                          The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts,
+                          and deleted when the pod is removed.
+                          
+                          
+                          Use this if:
+                          a) the volume is only needed while the pod runs,
+                          b) features of normal volumes like restoring from snapshot or capacity
+                             tracking are needed,
+                          c) the storage driver is specified through a storage class, and
+                          d) the storage driver supports dynamic volume provisioning through
+                             a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                             information on the connection between this volume type
+                             and PersistentVolumeClaim).
+                          
+                          
+                          Use PersistentVolumeClaim or one of the vendor-specific
+                          APIs for volumes that persist for longer than the lifecycle
+                          of an individual pod.
+                          
+                          
+                          Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to
+                          be used that way - see the documentation of the driver for
+                          more information.
+                          
+                          
+                          A pod can use both types of ephemeral volumes and
+                          persistent volumes at the same time.
                         properties:
                           volumeClaimTemplate:
-                            description: "Will be used to create a stand-alone PVC to
-                            provision the volume. The pod in which this EphemeralVolumeSource
-                            is embedded will be the owner of the PVC, i.e. the PVC
-                            will be deleted together with the pod.  The name of the
-                            PVC will be `<pod name>-<volume name>` where `<volume
-                            name>` is the name from the `PodSpec.Volumes` array entry.
-                            Pod validation will reject the pod if the concatenated
-                            name is not valid for a PVC (for example, too long). \n
-                            An existing PVC with that name that is not owned by the
-                            pod will *not* be used for the pod to avoid using an unrelated
-                            volume by mistake. Starting the pod is then blocked until
-                            the unrelated PVC is removed. If such a pre-created PVC
-                            is meant to be used by the pod, the PVC has to updated
-                            with an owner reference to the pod once the pod exists.
-                            Normally this should not be necessary, but it may be useful
-                            when manually reconstructing a broken cluster. \n This
-                            field is read-only and no changes will be made by Kubernetes
-                            to the PVC after it has been created. \n Required, must
-                            not be nil."
+                            description: |-
+                              Will be used to create a stand-alone PVC to provision the volume.
+                              The pod in which this EphemeralVolumeSource is embedded will be the
+                              owner of the PVC, i.e. the PVC will be deleted together with the
+                              pod.  The name of the PVC will be `<pod name>-<volume name>` where
+                              `<volume name>` is the name from the `PodSpec.Volumes` array
+                              entry. Pod validation will reject the pod if the concatenated name
+                              is not valid for a PVC (for example, too long).
+                              
+                              
+                              An existing PVC with that name that is not owned by the pod
+                              will *not* be used for the pod to avoid using an unrelated
+                              volume by mistake. Starting the pod is then blocked until
+                              the unrelated PVC is removed. If such a pre-created PVC is
+                              meant to be used by the pod, the PVC has to updated with an
+                              owner reference to the pod once the pod exists. Normally
+                              this should not be necessary, but it may be useful when
+                              manually reconstructing a broken cluster.
+                              
+                              
+                              This field is read-only and no changes will be made by Kubernetes
+                              to the PVC after it has been created.
+                              
+                              
+                              Required, must not be nil.
                             properties:
                               metadata:
-                                description: May contain labels and annotations that
-                                  will be copied into the PVC when creating it. No other
-                                  fields are allowed and will be rejected during validation.
+                                description: |-
+                                  May contain labels and annotations that will be copied into the PVC
+                                  when creating it. No other fields are allowed and will be rejected during
+                                  validation.
                                 properties:
                                   annotations:
                                     additionalProperties:
@@ -6246,37 +7874,35 @@ spec:
                                     type: string
                                 type: object
                               spec:
-                                description: The specification for the PersistentVolumeClaim.
-                                  The entire content is copied unchanged into the PVC
-                                  that gets created from this template. The same fields
-                                  as in a PersistentVolumeClaim are also valid here.
+                                description: |-
+                                  The specification for the PersistentVolumeClaim. The entire content is
+                                  copied unchanged into the PVC that gets created from this
+                                  template. The same fields as in a PersistentVolumeClaim
+                                  are also valid here.
                                 properties:
                                   accessModes:
-                                    description: 'accessModes contains the desired access
-                                    modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                    description: |-
+                                      accessModes contains the desired access modes the volume should have.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1
                                     items:
                                       type: string
                                     type: array
                                   dataSource:
-                                    description: 'dataSource field can be used to specify
-                                    either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
-                                    * An existing PVC (PersistentVolumeClaim) If the
-                                    provisioner or an external controller can support
-                                    the specified data source, it will create a new
-                                    volume based on the contents of the specified
-                                    data source. When the AnyVolumeDataSource feature
-                                    gate is enabled, dataSource contents will be copied
-                                    to dataSourceRef, and dataSourceRef contents will
-                                    be copied to dataSource when dataSourceRef.namespace
-                                    is not specified. If the namespace is specified,
-                                    then dataSourceRef will not be copied to dataSource.'
+                                    description: |-
+                                      dataSource field can be used to specify either:
+                                      * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot)
+                                      * An existing PVC (PersistentVolumeClaim)
+                                      If the provisioner or an external controller can support the specified data source,
+                                      it will create a new volume based on the contents of the specified data source.
+                                      When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef,
+                                      and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified.
+                                      If the namespace is specified, then dataSourceRef will not be copied to dataSource.
                                     properties:
                                       apiGroup:
-                                        description: APIGroup is the group for the resource
-                                          being referenced. If APIGroup is not specified,
-                                          the specified Kind must be in the core API
-                                          group. For any other third-party types, APIGroup
-                                          is required.
+                                        description: |-
+                                          APIGroup is the group for the resource being referenced.
+                                          If APIGroup is not specified, the specified Kind must be in the core API group.
+                                          For any other third-party types, APIGroup is required.
                                         type: string
                                       kind:
                                         description: Kind is the type of resource being
@@ -6292,45 +7918,36 @@ spec:
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   dataSourceRef:
-                                    description: 'dataSourceRef specifies the object
-                                    from which to populate the volume with data, if
-                                    a non-empty volume is desired. This may be any
-                                    object from a non-empty API group (non core object)
-                                    or a PersistentVolumeClaim object. When this field
-                                    is specified, volume binding will only succeed
-                                    if the type of the specified object matches some
-                                    installed volume populator or dynamic provisioner.
-                                    This field will replace the functionality of the
-                                    dataSource field and as such if both fields are
-                                    non-empty, they must have the same value. For
-                                    backwards compatibility, when namespace isn''t
-                                    specified in dataSourceRef, both fields (dataSource
-                                    and dataSourceRef) will be set to the same value
-                                    automatically if one of them is empty and the
-                                    other is non-empty. When namespace is specified
-                                    in dataSourceRef, dataSource isn''t set to the
-                                    same value and must be empty. There are three
-                                    important differences between dataSource and dataSourceRef:
-                                    * While dataSource only allows two specific types
-                                    of objects, dataSourceRef allows any non-core
-                                    object, as well as PersistentVolumeClaim objects.
-                                    * While dataSource ignores disallowed values (dropping
-                                    them), dataSourceRef preserves all values, and
-                                    generates an error if a disallowed value is specified.
-                                    * While dataSource only allows local objects,
-                                    dataSourceRef allows objects in any namespaces.
-                                    (Beta) Using this field requires the AnyVolumeDataSource
-                                    feature gate to be enabled. (Alpha) Using the
-                                    namespace field of dataSourceRef requires the
-                                    CrossNamespaceVolumeDataSource feature gate to
-                                    be enabled.'
+                                    description: |-
+                                      dataSourceRef specifies the object from which to populate the volume with data, if a non-empty
+                                      volume is desired. This may be any object from a non-empty API group (non
+                                      core object) or a PersistentVolumeClaim object.
+                                      When this field is specified, volume binding will only succeed if the type of
+                                      the specified object matches some installed volume populator or dynamic
+                                      provisioner.
+                                      This field will replace the functionality of the dataSource field and as such
+                                      if both fields are non-empty, they must have the same value. For backwards
+                                      compatibility, when namespace isn't specified in dataSourceRef,
+                                      both fields (dataSource and dataSourceRef) will be set to the same
+                                      value automatically if one of them is empty and the other is non-empty.
+                                      When namespace is specified in dataSourceRef,
+                                      dataSource isn't set to the same value and must be empty.
+                                      There are three important differences between dataSource and dataSourceRef:
+                                      * While dataSource only allows two specific types of objects, dataSourceRef
+                                        allows any non-core object, as well as PersistentVolumeClaim objects.
+                                      * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                        preserves all values, and generates an error if a disallowed value is
+                                        specified.
+                                      * While dataSource only allows local objects, dataSourceRef allows objects
+                                        in any namespaces.
+                                      (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled.
+                                      (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                     properties:
                                       apiGroup:
-                                        description: APIGroup is the group for the resource
-                                          being referenced. If APIGroup is not specified,
-                                          the specified Kind must be in the core API
-                                          group. For any other third-party types, APIGroup
-                                          is required.
+                                        description: |-
+                                          APIGroup is the group for the resource being referenced.
+                                          If APIGroup is not specified, the specified Kind must be in the core API group.
+                                          For any other third-party types, APIGroup is required.
                                         type: string
                                       kind:
                                         description: Kind is the type of resource being
@@ -6341,27 +7958,22 @@ spec:
                                           referenced
                                         type: string
                                       namespace:
-                                        description: Namespace is the namespace of resource
-                                          being referenced Note that when a namespace
-                                          is specified, a gateway.networking.k8s.io/ReferenceGrant
-                                          object is required in the referent namespace
-                                          to allow that namespace's owner to accept
-                                          the reference. See the ReferenceGrant documentation
-                                          for details. (Alpha) This field requires the
-                                          CrossNamespaceVolumeDataSource feature gate
-                                          to be enabled.
+                                        description: |-
+                                          Namespace is the namespace of resource being referenced
+                                          Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details.
+                                          (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
                                         type: string
                                     required:
                                       - kind
                                       - name
                                     type: object
                                   resources:
-                                    description: 'resources represents the minimum resources
-                                    the volume should have. If RecoverVolumeExpansionFailure
-                                    feature is enabled users are allowed to specify
-                                    resource requirements that are lower than previous
-                                    value but must still be higher than capacity recorded
-                                    in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                    description: |-
+                                      resources represents the minimum resources the volume should have.
+                                      If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements
+                                      that are lower than previous value but must still be higher than capacity recorded in the
+                                      status field of the claim.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources
                                     properties:
                                       limits:
                                         additionalProperties:
@@ -6370,8 +7982,9 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Limits describes the maximum amount
-                                        of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Limits describes the maximum amount of compute resources allowed.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                       requests:
                                         additionalProperties:
@@ -6380,12 +7993,11 @@ spec:
                                             - type: string
                                           pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
                                           x-kubernetes-int-or-string: true
-                                        description: 'Requests describes the minimum
-                                        amount of compute resources required. If Requests
-                                        is omitted for a container, it defaults to
-                                        Limits if that is explicitly specified, otherwise
-                                        to an implementation-defined value. Requests
-                                        cannot exceed Limits. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        description: |-
+                                          Requests describes the minimum amount of compute resources required.
+                                          If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                                          otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                                          More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                                         type: object
                                     type: object
                                   selector:
@@ -6397,28 +8009,24 @@ spec:
                                           selector requirements. The requirements are
                                           ANDed.
                                         items:
-                                          description: A label selector requirement
-                                            is a selector that contains values, a key,
-                                            and an operator that relates the key and
-                                            values.
+                                          description: |-
+                                            A label selector requirement is a selector that contains values, a key, and an operator that
+                                            relates the key and values.
                                           properties:
                                             key:
                                               description: key is the label key that
                                                 the selector applies to.
                                               type: string
                                             operator:
-                                              description: operator represents a key's
-                                                relationship to a set of values. Valid
-                                                operators are In, NotIn, Exists and
-                                                DoesNotExist.
+                                              description: |-
+                                                operator represents a key's relationship to a set of values.
+                                                Valid operators are In, NotIn, Exists and DoesNotExist.
                                               type: string
                                             values:
-                                              description: values is an array of string
-                                                values. If the operator is In or NotIn,
-                                                the values array must be non-empty.
-                                                If the operator is Exists or DoesNotExist,
-                                                the values array must be empty. This
-                                                array is replaced during a strategic
+                                              description: |-
+                                                values is an array of string values. If the operator is In or NotIn,
+                                                the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                the values array must be empty. This array is replaced during a strategic
                                                 merge patch.
                                               items:
                                                 type: string
@@ -6431,46 +8039,37 @@ spec:
                                       matchLabels:
                                         additionalProperties:
                                           type: string
-                                        description: matchLabels is a map of {key,value}
-                                          pairs. A single {key,value} in the matchLabels
-                                          map is equivalent to an element of matchExpressions,
-                                          whose key field is "key", the operator is
-                                          "In", and the values array contains only "value".
-                                          The requirements are ANDed.
+                                        description: |-
+                                          matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                          map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                          operator is "In", and the values array contains only "value". The requirements are ANDed.
                                         type: object
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   storageClassName:
-                                    description: 'storageClassName is the name of the
-                                    StorageClass required by the claim. More info:
-                                    https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                    description: |-
+                                      storageClassName is the name of the StorageClass required by the claim.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1
                                     type: string
                                   volumeAttributesClassName:
-                                    description: 'volumeAttributesClassName may be used
-                                    to set the VolumeAttributesClass used by this
-                                    claim. If specified, the CSI driver will create
-                                    or update the volume with the attributes defined
-                                    in the corresponding VolumeAttributesClass. This
-                                    has a different purpose than storageClassName,
-                                    it can be changed after the claim is created.
-                                    An empty string value means that no VolumeAttributesClass
-                                    will be applied to the claim but it''s not allowed
-                                    to reset this field to empty string once it is
-                                    set. If unspecified and the PersistentVolumeClaim
-                                    is unbound, the default VolumeAttributesClass
-                                    will be set by the persistentvolume controller
-                                    if it exists. If the resource referred to by volumeAttributesClass
-                                    does not exist, this PersistentVolumeClaim will
-                                    be set to a Pending state, as reflected by the
-                                    modifyVolumeStatus field, until such as a resource
-                                    exists. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
-                                    (Alpha) Using this field requires the VolumeAttributesClass
-                                    feature gate to be enabled.'
+                                    description: |-
+                                      volumeAttributesClassName may be used to set the VolumeAttributesClass used by this claim.
+                                      If specified, the CSI driver will create or update the volume with the attributes defined
+                                      in the corresponding VolumeAttributesClass. This has a different purpose than storageClassName,
+                                      it can be changed after the claim is created. An empty string value means that no VolumeAttributesClass
+                                      will be applied to the claim but it's not allowed to reset this field to empty string once it is set.
+                                      If unspecified and the PersistentVolumeClaim is unbound, the default VolumeAttributesClass
+                                      will be set by the persistentvolume controller if it exists.
+                                      If the resource referred to by volumeAttributesClass does not exist, this PersistentVolumeClaim will be
+                                      set to a Pending state, as reflected by the modifyVolumeStatus field, until such as a resource
+                                      exists.
+                                      More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#volumeattributesclass
+                                      (Alpha) Using this field requires the VolumeAttributesClass feature gate to be enabled.
                                     type: string
                                   volumeMode:
-                                    description: volumeMode defines what type of volume
-                                      is required by the claim. Value of Filesystem
-                                      is implied when not included in claim spec.
+                                    description: |-
+                                      volumeMode defines what type of volume is required by the claim.
+                                      Value of Filesystem is implied when not included in claim spec.
                                     type: string
                                   volumeName:
                                     description: volumeName is the binding reference
@@ -6487,19 +8086,20 @@ spec:
                           pod.
                         properties:
                           fsType:
-                            description: 'fsType is the filesystem type to mount. Must
-                            be a filesystem type supported by the host operating system.
-                            Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. TODO: how do we prevent errors in the
-                            filesystem from compromising the machine'
+                            description: |-
+                              fsType is the filesystem type to mount.
+                              Must be a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           lun:
                             description: 'lun is Optional: FC target lun number'
                             format: int32
                             type: integer
                           readOnly:
-                            description: 'readOnly is Optional: Defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                            description: |-
+                              readOnly is Optional: Defaults to false (read/write). ReadOnly here will force
+                              the ReadOnly setting in VolumeMounts.
                             type: boolean
                           targetWWNs:
                             description: 'targetWWNs is Optional: FC target worldwide
@@ -6508,26 +8108,27 @@ spec:
                               type: string
                             type: array
                           wwids:
-                            description: 'wwids Optional: FC volume world wide identifiers
-                            (wwids) Either wwids or combination of targetWWNs and
-                            lun must be set, but not both simultaneously.'
+                            description: |-
+                              wwids Optional: FC volume world wide identifiers (wwids)
+                              Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.
                             items:
                               type: string
                             type: array
                         type: object
                       flexVolume:
-                        description: flexVolume represents a generic volume resource
-                          that is provisioned/attached using an exec based plugin.
+                        description: |-
+                          flexVolume represents a generic volume resource that is
+                          provisioned/attached using an exec based plugin.
                         properties:
                           driver:
                             description: driver is the name of the driver to use for
                               this volume.
                             type: string
                           fsType:
-                            description: fsType is the filesystem type to mount. Must
-                              be a filesystem type supported by the host operating system.
-                              Ex. "ext4", "xfs", "ntfs". The default filesystem depends
-                              on FlexVolume script.
+                            description: |-
+                              fsType is the filesystem type to mount.
+                              Must be a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
                             type: string
                           options:
                             additionalProperties:
@@ -6536,20 +8137,23 @@ spec:
                             command options if any.'
                             type: object
                           readOnly:
-                            description: 'readOnly is Optional: defaults to false (read/write).
-                            ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                            description: |-
+                              readOnly is Optional: defaults to false (read/write). ReadOnly here will force
+                              the ReadOnly setting in VolumeMounts.
                             type: boolean
                           secretRef:
-                            description: 'secretRef is Optional: secretRef is reference
-                            to the secret object containing sensitive information
-                            to pass to the plugin scripts. This may be empty if no
-                            secret object is specified. If the secret object contains
-                            more than one secret, all secrets are passed to the plugin
-                            scripts.'
+                            description: |-
+                              secretRef is Optional: secretRef is reference to the secret object containing
+                              sensitive information to pass to the plugin scripts. This may be
+                              empty if no secret object is specified. If the secret object
+                              contains more than one secret, all secrets are passed to the plugin
+                              scripts.
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -6562,9 +8166,9 @@ spec:
                           service being running
                         properties:
                           datasetName:
-                            description: datasetName is Name of the dataset stored as
-                              metadata -> name on the dataset for Flocker should be
-                              considered as deprecated
+                            description: |-
+                              datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker
+                              should be considered as deprecated
                             type: string
                           datasetUUID:
                             description: datasetUUID is the UUID of the dataset. This
@@ -6572,52 +8176,55 @@ spec:
                             type: string
                         type: object
                       gcePersistentDisk:
-                        description: 'gcePersistentDisk represents a GCE Disk resource
-                        that is attached to a kubelet''s host machine and then exposed
-                        to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        description: |-
+                          gcePersistentDisk represents a GCE Disk resource that is attached to a
+                          kubelet's host machine and then exposed to the pod.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                         properties:
                           fsType:
-                            description: 'fsType is filesystem type of the volume that
-                            you want to mount. Tip: Ensure that the filesystem type
-                            is supported by the host operating system. Examples: "ext4",
-                            "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
+                            description: |-
+                              fsType is filesystem type of the volume that you want to mount.
+                              Tip: Ensure that the filesystem type is supported by the host operating system.
+                              Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
+                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           partition:
-                            description: 'partition is the partition in the volume that
-                            you want to mount. If omitted, the default is to mount
-                            by volume name. Examples: For volume /dev/sda1, you specify
-                            the partition as "1". Similarly, the volume partition
-                            for /dev/sda is "0" (or you can leave the property empty).
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            description: |-
+                              partition is the partition in the volume that you want to mount.
+                              If omitted, the default is to mount by volume name.
+                              Examples: For volume /dev/sda1, you specify the partition as "1".
+                              Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                             format: int32
                             type: integer
                           pdName:
-                            description: 'pdName is unique name of the PD resource in
-                            GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            description: |-
+                              pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                             type: string
                           readOnly:
-                            description: 'readOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            description: |-
+                              readOnly here will force the ReadOnly setting in VolumeMounts.
+                              Defaults to false.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk
                             type: boolean
                         required:
                           - pdName
                         type: object
                       gitRepo:
-                        description: 'gitRepo represents a git repository at a particular
-                        revision. DEPRECATED: GitRepo is deprecated. To provision
-                        a container with a git repo, mount an EmptyDir into an InitContainer
-                        that clones the repo using git, then mount the EmptyDir into
-                        the Pod''s container.'
+                        description: |-
+                          gitRepo represents a git repository at a particular revision.
+                          DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an
+                          EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir
+                          into the Pod's container.
                         properties:
                           directory:
-                            description: directory is the target directory name. Must
-                              not contain or start with '..'.  If '.' is supplied, the
-                              volume directory will be the git repository.  Otherwise,
-                              if specified, the volume will contain the git repository
-                              in the subdirectory with the given name.
+                            description: |-
+                              directory is the target directory name.
+                              Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the
+                              git repository.  Otherwise, if specified, the volume will contain the git repository in
+                              the subdirectory with the given name.
                             type: string
                           repository:
                             description: repository is the URL
@@ -6630,51 +8237,61 @@ spec:
                           - repository
                         type: object
                       glusterfs:
-                        description: 'glusterfs represents a Glusterfs mount on the
-                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                        description: |-
+                          glusterfs represents a Glusterfs mount on the host that shares a pod's lifetime.
+                          More info: https://examples.k8s.io/volumes/glusterfs/README.md
                         properties:
                           endpoints:
-                            description: 'endpoints is the endpoint name that details
-                            Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                            description: |-
+                              endpoints is the endpoint name that details Glusterfs topology.
+                              More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                             type: string
                           path:
-                            description: 'path is the Glusterfs volume path. More info:
-                            https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                            description: |-
+                              path is the Glusterfs volume path.
+                              More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                             type: string
                           readOnly:
-                            description: 'readOnly here will force the Glusterfs volume
-                            to be mounted with read-only permissions. Defaults to
-                            false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                            description: |-
+                              readOnly here will force the Glusterfs volume to be mounted with read-only permissions.
+                              Defaults to false.
+                              More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod
                             type: boolean
                         required:
                           - endpoints
                           - path
                         type: object
                       hostPath:
-                        description: 'hostPath represents a pre-existing file or directory
-                        on the host machine that is directly exposed to the container.
-                        This is generally used for system agents or other privileged
-                        things that are allowed to see the host machine. Most containers
-                        will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
-                        --- TODO(jonesdl) We need to restrict who can use host directory
-                        mounts and who can/can not mount host directories as read/write.'
+                        description: |-
+                          hostPath represents a pre-existing file or directory on the host
+                          machine that is directly exposed to the container. This is generally
+                          used for system agents or other privileged things that are allowed
+                          to see the host machine. Most containers will NOT need this.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
+                          ---
+                          TODO(jonesdl) We need to restrict who can use host directory mounts and who can/can not
+                          mount host directories as read/write.
                         properties:
                           path:
-                            description: 'path of the directory on the host. If the
-                            path is a symlink, it will follow the link to the real
-                            path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            description: |-
+                              path of the directory on the host.
+                              If the path is a symlink, it will follow the link to the real path.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                             type: string
                           type:
-                            description: 'type for HostPath Volume Defaults to "" More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            description: |-
+                              type for HostPath Volume
+                              Defaults to ""
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath
                             type: string
                         required:
                           - path
                         type: object
                       iscsi:
-                        description: 'iscsi represents an ISCSI Disk resource that is
-                        attached to a kubelet''s host machine and then exposed to
-                        the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                        description: |-
+                          iscsi represents an ISCSI Disk resource that is attached to a
+                          kubelet's host machine and then exposed to the pod.
+                          More info: https://examples.k8s.io/volumes/iscsi/README.md
                         properties:
                           chapAuthDiscovery:
                             description: chapAuthDiscovery defines whether support iSCSI
@@ -6685,56 +8302,59 @@ spec:
                               Session CHAP authentication
                             type: boolean
                           fsType:
-                            description: 'fsType is the filesystem type of the volume
-                            that you want to mount. Tip: Ensure that the filesystem
-                            type is supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
+                            description: |-
+                              fsType is the filesystem type of the volume that you want to mount.
+                              Tip: Ensure that the filesystem type is supported by the host operating system.
+                              Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi
+                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           initiatorName:
-                            description: initiatorName is the custom iSCSI Initiator
-                              Name. If initiatorName is specified with iscsiInterface
-                              simultaneously, new iSCSI interface <target portal>:<volume
-                              name> will be created for the connection.
+                            description: |-
+                              initiatorName is the custom iSCSI Initiator Name.
+                              If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface
+                              <target portal>:<volume name> will be created for the connection.
                             type: string
                           iqn:
                             description: iqn is the target iSCSI Qualified Name.
                             type: string
                           iscsiInterface:
-                            description: iscsiInterface is the interface Name that uses
-                              an iSCSI transport. Defaults to 'default' (tcp).
+                            description: |-
+                              iscsiInterface is the interface Name that uses an iSCSI transport.
+                              Defaults to 'default' (tcp).
                             type: string
                           lun:
                             description: lun represents iSCSI Target Lun number.
                             format: int32
                             type: integer
                           portals:
-                            description: portals is the iSCSI Target Portal List. The
-                              portal is either an IP or ip_addr:port if the port is
-                              other than default (typically TCP ports 860 and 3260).
+                            description: |-
+                              portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port
+                              is other than default (typically TCP ports 860 and 3260).
                             items:
                               type: string
                             type: array
                           readOnly:
-                            description: readOnly here will force the ReadOnly setting
-                              in VolumeMounts. Defaults to false.
+                            description: |-
+                              readOnly here will force the ReadOnly setting in VolumeMounts.
+                              Defaults to false.
                             type: boolean
                           secretRef:
                             description: secretRef is the CHAP Secret for iSCSI target
                               and initiator authentication
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           targetPortal:
-                            description: targetPortal is iSCSI Target Portal. The Portal
-                              is either an IP or ip_addr:port if the port is other than
-                              default (typically TCP ports 860 and 3260).
+                            description: |-
+                              targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port
+                              is other than default (typically TCP ports 860 and 3260).
                             type: string
                         required:
                           - iqn
@@ -6742,43 +8362,51 @@ spec:
                           - targetPortal
                         type: object
                       name:
-                        description: 'name of the volume. Must be a DNS_LABEL and unique
-                        within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        description: |-
+                          name of the volume.
+                          Must be a DNS_LABEL and unique within the pod.
+                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
                         type: string
                       nfs:
-                        description: 'nfs represents an NFS mount on the host that shares
-                        a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        description: |-
+                          nfs represents an NFS mount on the host that shares a pod's lifetime
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                         properties:
                           path:
-                            description: 'path that is exported by the NFS server. More
-                            info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            description: |-
+                              path that is exported by the NFS server.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                             type: string
                           readOnly:
-                            description: 'readOnly here will force the NFS export to
-                            be mounted with read-only permissions. Defaults to false.
-                            More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            description: |-
+                              readOnly here will force the NFS export to be mounted with read-only permissions.
+                              Defaults to false.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                             type: boolean
                           server:
-                            description: 'server is the hostname or IP address of the
-                            NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            description: |-
+                              server is the hostname or IP address of the NFS server.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs
                             type: string
                         required:
                           - path
                           - server
                         type: object
                       persistentVolumeClaim:
-                        description: 'persistentVolumeClaimVolumeSource represents a
-                        reference to a PersistentVolumeClaim in the same namespace.
-                        More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        description: |-
+                          persistentVolumeClaimVolumeSource represents a reference to a
+                          PersistentVolumeClaim in the same namespace.
+                          More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                         properties:
                           claimName:
-                            description: 'claimName is the name of a PersistentVolumeClaim
-                            in the same namespace as the pod using this volume. More
-                            info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            description: |-
+                              claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume.
+                              More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims
                             type: string
                           readOnly:
-                            description: readOnly Will force the ReadOnly setting in
-                              VolumeMounts. Default false.
+                            description: |-
+                              readOnly Will force the ReadOnly setting in VolumeMounts.
+                              Default false.
                             type: boolean
                         required:
                           - claimName
@@ -6788,10 +8416,10 @@ spec:
                           persistent disk attached and mounted on kubelets host machine
                         properties:
                           fsType:
-                            description: fsType is the filesystem type to mount. Must
-                              be a filesystem type supported by the host operating system.
-                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                              if unspecified.
+                            description: |-
+                              fsType is the filesystem type to mount.
+                              Must be a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                             type: string
                           pdID:
                             description: pdID is the ID that identifies Photon Controller
@@ -6805,14 +8433,15 @@ spec:
                           and mounted on kubelets host machine
                         properties:
                           fsType:
-                            description: fSType represents the filesystem type to mount
-                              Must be a filesystem type supported by the host operating
-                              system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4"
-                              if unspecified.
+                            description: |-
+                              fSType represents the filesystem type to mount
+                              Must be a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
                             type: string
                           readOnly:
-                            description: readOnly defaults to false (read/write). ReadOnly
-                              here will force the ReadOnly setting in VolumeMounts.
+                            description: |-
+                              readOnly defaults to false (read/write). ReadOnly here will force
+                              the ReadOnly setting in VolumeMounts.
                             type: boolean
                           volumeID:
                             description: volumeID uniquely identifies a Portworx volume
@@ -6825,14 +8454,13 @@ spec:
                           configmaps, and downward API
                         properties:
                           defaultMode:
-                            description: defaultMode are the mode bits used to set permissions
-                              on created files by default. Must be an octal value between
-                              0000 and 0777 or a decimal value between 0 and 511. YAML
-                              accepts both octal and decimal values, JSON requires decimal
-                              values for mode bits. Directories within the path are
-                              not affected by this setting. This might be in conflict
-                              with other options that affect the file mode, like fsGroup,
-                              and the result can be other mode bits set.
+                            description: |-
+                              defaultMode are the mode bits used to set permissions on created files by default.
+                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                              Directories within the path are not affected by this setting.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
                           sources:
@@ -6842,54 +8470,54 @@ spec:
                                 other supported volume types
                               properties:
                                 clusterTrustBundle:
-                                  description: "ClusterTrustBundle allows a pod to access
-                                  the `.spec.trustBundle` field of ClusterTrustBundle
-                                  objects in an auto-updating file. \n Alpha, gated
-                                  by the ClusterTrustBundleProjection feature gate.
-                                  \n ClusterTrustBundle objects can either be selected
-                                  by name, or by the combination of signer name and
-                                  a label selector. \n Kubelet performs aggressive
-                                  normalization of the PEM contents written into the
-                                  pod filesystem.  Esoteric PEM features such as inter-block
-                                  comments and block headers are stripped.  Certificates
-                                  are deduplicated. The ordering of certificates within
-                                  the file is arbitrary, and Kubelet may change the
-                                  order over time."
+                                  description: |-
+                                    ClusterTrustBundle allows a pod to access the `.spec.trustBundle` field
+                                    of ClusterTrustBundle objects in an auto-updating file.
+                                    
+                                    
+                                    Alpha, gated by the ClusterTrustBundleProjection feature gate.
+                                    
+                                    
+                                    ClusterTrustBundle objects can either be selected by name, or by the
+                                    combination of signer name and a label selector.
+                                    
+                                    
+                                    Kubelet performs aggressive normalization of the PEM contents written
+                                    into the pod filesystem.  Esoteric PEM features such as inter-block
+                                    comments and block headers are stripped.  Certificates are deduplicated.
+                                    The ordering of certificates within the file is arbitrary, and Kubelet
+                                    may change the order over time.
                                   properties:
                                     labelSelector:
-                                      description: Select all ClusterTrustBundles that
-                                        match this label selector.  Only has effect
-                                        if signerName is set.  Mutually-exclusive with
-                                        name.  If unset, interpreted as "match nothing".  If
-                                        set but empty, interpreted as "match everything".
+                                      description: |-
+                                        Select all ClusterTrustBundles that match this label selector.  Only has
+                                        effect if signerName is set.  Mutually-exclusive with name.  If unset,
+                                        interpreted as "match nothing".  If set but empty, interpreted as "match
+                                        everything".
                                       properties:
                                         matchExpressions:
                                           description: matchExpressions is a list of
                                             label selector requirements. The requirements
                                             are ANDed.
                                           items:
-                                            description: A label selector requirement
-                                              is a selector that contains values, a
-                                              key, and an operator that relates the
-                                              key and values.
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
                                             properties:
                                               key:
                                                 description: key is the label key that
                                                   the selector applies to.
                                                 type: string
                                               operator:
-                                                description: operator represents a key's
-                                                  relationship to a set of values. Valid
-                                                  operators are In, NotIn, Exists and
-                                                  DoesNotExist.
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
                                                 type: string
                                               values:
-                                                description: values is an array of string
-                                                  values. If the operator is In or NotIn,
-                                                  the values array must be non-empty.
-                                                  If the operator is Exists or DoesNotExist,
-                                                  the values array must be empty. This
-                                                  array is replaced during a strategic
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
                                                   merge patch.
                                                 items:
                                                   type: string
@@ -6902,37 +8530,35 @@ spec:
                                         matchLabels:
                                           additionalProperties:
                                             type: string
-                                          description: matchLabels is a map of {key,value}
-                                            pairs. A single {key,value} in the matchLabels
-                                            map is equivalent to an element of matchExpressions,
-                                            whose key field is "key", the operator is
-                                            "In", and the values array contains only
-                                            "value". The requirements are ANDed.
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
                                           type: object
                                       type: object
                                       x-kubernetes-map-type: atomic
                                     name:
-                                      description: Select a single ClusterTrustBundle
-                                        by object name.  Mutually-exclusive with signerName
-                                        and labelSelector.
+                                      description: |-
+                                        Select a single ClusterTrustBundle by object name.  Mutually-exclusive
+                                        with signerName and labelSelector.
                                       type: string
                                     optional:
-                                      description: If true, don't block pod startup
-                                        if the referenced ClusterTrustBundle(s) aren't
-                                        available.  If using name, then the named ClusterTrustBundle
-                                        is allowed not to exist.  If using signerName,
-                                        then the combination of signerName and labelSelector
-                                        is allowed to match zero ClusterTrustBundles.
+                                      description: |-
+                                        If true, don't block pod startup if the referenced ClusterTrustBundle(s)
+                                        aren't available.  If using name, then the named ClusterTrustBundle is
+                                        allowed not to exist.  If using signerName, then the combination of
+                                        signerName and labelSelector is allowed to match zero
+                                        ClusterTrustBundles.
                                       type: boolean
                                     path:
                                       description: Relative path from the volume root
                                         to write the bundle.
                                       type: string
                                     signerName:
-                                      description: Select all ClusterTrustBundles that
-                                        match this signer name. Mutually-exclusive with
-                                        name.  The contents of all selected ClusterTrustBundles
-                                        will be unified and deduplicated.
+                                      description: |-
+                                        Select all ClusterTrustBundles that match this signer name.
+                                        Mutually-exclusive with name.  The contents of all selected
+                                        ClusterTrustBundles will be unified and deduplicated.
                                       type: string
                                   required:
                                     - path
@@ -6942,17 +8568,14 @@ spec:
                                     data to project
                                   properties:
                                     items:
-                                      description: items if unspecified, each key-value
-                                        pair in the Data field of the referenced ConfigMap
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified which
-                                        is not present in the ConfigMap, the volume
-                                        setup will error unless it is marked optional.
-                                        Paths must be relative and may not contain the
-                                        '..' path or start with '..'.
+                                      description: |-
+                                        items if unspecified, each key-value pair in the Data field of the referenced
+                                        ConfigMap will be projected into the volume as a file whose name is the
+                                        key and content is the value. If specified, the listed keys will be
+                                        projected into the specified paths, and unlisted keys will not be
+                                        present. If a key is specified which is not present in the ConfigMap,
+                                        the volume setup will error unless it is marked optional. Paths must be
+                                        relative and may not contain the '..' path or start with '..'.
                                       items:
                                         description: Maps a string key to a path within
                                           a volume.
@@ -6961,25 +8584,21 @@ spec:
                                             description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                            used to set permissions on this file.
-                                            Must be an octal value between 0000 and
-                                            0777 or a decimal value between 0 and
-                                            511. YAML accepts both octal and decimal
-                                            values, JSON requires decimal values for
-                                            mode bits. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
+                                            description: |-
+                                              mode is Optional: mode bits used to set permissions on this file.
+                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path of
-                                              the file to map the key to. May not be
-                                              an absolute path. May not contain the
-                                              path element '..'. May not start with
-                                              the string '..'.
+                                            description: |-
+                                              path is the relative path of the file to map the key to.
+                                              May not be an absolute path.
+                                              May not contain the path element '..'.
+                                              May not start with the string '..'.
                                             type: string
                                         required:
                                           - key
@@ -6987,10 +8606,10 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: optional specify whether the ConfigMap
@@ -7029,17 +8648,13 @@ spec:
                                             type: object
                                             x-kubernetes-map-type: atomic
                                           mode:
-                                            description: 'Optional: mode bits used to
-                                            set permissions on this file, must be
-                                            an octal value between 0000 and 0777 or
-                                            a decimal value between 0 and 511. YAML
-                                            accepts both octal and decimal values,
-                                            JSON requires decimal values for mode
-                                            bits. If not specified, the volume defaultMode
-                                            will be used. This might be in conflict
-                                            with other options that affect the file
-                                            mode, like fsGroup, and the result can
-                                            be other mode bits set.'
+                                            description: |-
+                                              Optional: mode bits used to set permissions on this file, must be an octal value
+                                              between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
                                             format: int32
                                             type: integer
                                           path:
@@ -7051,10 +8666,9 @@ spec:
                                             with ''..'''
                                             type: string
                                           resourceFieldRef:
-                                            description: 'Selects a resource of the
-                                            container: only resources limits and requests
-                                            (limits.cpu, limits.memory, requests.cpu
-                                            and requests.memory) are currently supported.'
+                                            description: |-
+                                              Selects a resource of the container: only resources limits and requests
+                                              (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.
                                             properties:
                                               containerName:
                                                 description: 'Container name: required
@@ -7087,17 +8701,14 @@ spec:
                                     to project
                                   properties:
                                     items:
-                                      description: items if unspecified, each key-value
-                                        pair in the Data field of the referenced Secret
-                                        will be projected into the volume as a file
-                                        whose name is the key and content is the value.
-                                        If specified, the listed keys will be projected
-                                        into the specified paths, and unlisted keys
-                                        will not be present. If a key is specified which
-                                        is not present in the Secret, the volume setup
-                                        will error unless it is marked optional. Paths
-                                        must be relative and may not contain the '..'
-                                        path or start with '..'.
+                                      description: |-
+                                        items if unspecified, each key-value pair in the Data field of the referenced
+                                        Secret will be projected into the volume as a file whose name is the
+                                        key and content is the value. If specified, the listed keys will be
+                                        projected into the specified paths, and unlisted keys will not be
+                                        present. If a key is specified which is not present in the Secret,
+                                        the volume setup will error unless it is marked optional. Paths must be
+                                        relative and may not contain the '..' path or start with '..'.
                                       items:
                                         description: Maps a string key to a path within
                                           a volume.
@@ -7106,25 +8717,21 @@ spec:
                                             description: key is the key to project.
                                             type: string
                                           mode:
-                                            description: 'mode is Optional: mode bits
-                                            used to set permissions on this file.
-                                            Must be an octal value between 0000 and
-                                            0777 or a decimal value between 0 and
-                                            511. YAML accepts both octal and decimal
-                                            values, JSON requires decimal values for
-                                            mode bits. If not specified, the volume
-                                            defaultMode will be used. This might be
-                                            in conflict with other options that affect
-                                            the file mode, like fsGroup, and the result
-                                            can be other mode bits set.'
+                                            description: |-
+                                              mode is Optional: mode bits used to set permissions on this file.
+                                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                              YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                              If not specified, the volume defaultMode will be used.
+                                              This might be in conflict with other options that affect the file
+                                              mode, like fsGroup, and the result can be other mode bits set.
                                             format: int32
                                             type: integer
                                           path:
-                                            description: path is the relative path of
-                                              the file to map the key to. May not be
-                                              an absolute path. May not contain the
-                                              path element '..'. May not start with
-                                              the string '..'.
+                                            description: |-
+                                              path is the relative path of the file to map the key to.
+                                              May not be an absolute path.
+                                              May not contain the path element '..'.
+                                              May not start with the string '..'.
                                             type: string
                                         required:
                                           - key
@@ -7132,10 +8739,10 @@ spec:
                                         type: object
                                       type: array
                                     name:
-                                      description: 'Name of the referent. More info:
-                                      https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                      TODO: Add other useful fields. apiVersion, kind,
-                                      uid?'
+                                      description: |-
+                                        Name of the referent.
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        TODO: Add other useful fields. apiVersion, kind, uid?
                                       type: string
                                     optional:
                                       description: optional field specify whether the
@@ -7148,29 +8755,26 @@ spec:
                                     the serviceAccountToken data to project
                                   properties:
                                     audience:
-                                      description: audience is the intended audience
-                                        of the token. A recipient of a token must identify
-                                        itself with an identifier specified in the audience
-                                        of the token, and otherwise should reject the
-                                        token. The audience defaults to the identifier
-                                        of the apiserver.
+                                      description: |-
+                                        audience is the intended audience of the token. A recipient of a token
+                                        must identify itself with an identifier specified in the audience of the
+                                        token, and otherwise should reject the token. The audience defaults to the
+                                        identifier of the apiserver.
                                       type: string
                                     expirationSeconds:
-                                      description: expirationSeconds is the requested
-                                        duration of validity of the service account
-                                        token. As the token approaches expiration, the
-                                        kubelet volume plugin will proactively rotate
-                                        the service account token. The kubelet will
-                                        start trying to rotate the token if the token
-                                        is older than 80 percent of its time to live
-                                        or if the token is older than 24 hours.Defaults
-                                        to 1 hour and must be at least 10 minutes.
+                                      description: |-
+                                        expirationSeconds is the requested duration of validity of the service
+                                        account token. As the token approaches expiration, the kubelet volume
+                                        plugin will proactively rotate the service account token. The kubelet will
+                                        start trying to rotate the token if the token is older than 80 percent of
+                                        its time to live or if the token is older than 24 hours.Defaults to 1 hour
+                                        and must be at least 10 minutes.
                                       format: int64
                                       type: integer
                                     path:
-                                      description: path is the path relative to the
-                                        mount point of the file to project the token
-                                        into.
+                                      description: |-
+                                        path is the path relative to the mount point of the file to project the
+                                        token into.
                                       type: string
                                   required:
                                     - path
@@ -7183,28 +8787,30 @@ spec:
                           that shares a pod's lifetime
                         properties:
                           group:
-                            description: group to map volume access to Default is no
-                              group
+                            description: |-
+                              group to map volume access to
+                              Default is no group
                             type: string
                           readOnly:
-                            description: readOnly here will force the Quobyte volume
-                              to be mounted with read-only permissions. Defaults to
-                              false.
+                            description: |-
+                              readOnly here will force the Quobyte volume to be mounted with read-only permissions.
+                              Defaults to false.
                             type: boolean
                           registry:
-                            description: registry represents a single or multiple Quobyte
-                              Registry services specified as a string as host:port pair
-                              (multiple entries are separated with commas) which acts
-                              as the central registry for volumes
+                            description: |-
+                              registry represents a single or multiple Quobyte Registry services
+                              specified as a string as host:port pair (multiple entries are separated with commas)
+                              which acts as the central registry for volumes
                             type: string
                           tenant:
-                            description: tenant owning the given Quobyte volume in the
-                              Backend Used with dynamically provisioned Quobyte volumes,
-                              value is set by the plugin
+                            description: |-
+                              tenant owning the given Quobyte volume in the Backend
+                              Used with dynamically provisioned Quobyte volumes, value is set by the plugin
                             type: string
                           user:
-                            description: user to map volume access to Defaults to serivceaccount
-                              user
+                            description: |-
+                              user to map volume access to
+                              Defaults to serivceaccount user
                             type: string
                           volume:
                             description: volume is a string that references an already
@@ -7215,54 +8821,68 @@ spec:
                           - volume
                         type: object
                       rbd:
-                        description: 'rbd represents a Rados Block Device mount on the
-                        host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                        description: |-
+                          rbd represents a Rados Block Device mount on the host that shares a pod's lifetime.
+                          More info: https://examples.k8s.io/volumes/rbd/README.md
                         properties:
                           fsType:
-                            description: 'fsType is the filesystem type of the volume
-                            that you want to mount. Tip: Ensure that the filesystem
-                            type is supported by the host operating system. Examples:
-                            "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                            if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
-                            TODO: how do we prevent errors in the filesystem from
-                            compromising the machine'
+                            description: |-
+                              fsType is the filesystem type of the volume that you want to mount.
+                              Tip: Ensure that the filesystem type is supported by the host operating system.
+                              Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd
+                              TODO: how do we prevent errors in the filesystem from compromising the machine
                             type: string
                           image:
-                            description: 'image is the rados image name. More info:
-                            https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            description: |-
+                              image is the rados image name.
+                              More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             type: string
                           keyring:
-                            description: 'keyring is the path to key ring for RBDUser.
-                            Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            description: |-
+                              keyring is the path to key ring for RBDUser.
+                              Default is /etc/ceph/keyring.
+                              More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             type: string
                           monitors:
-                            description: 'monitors is a collection of Ceph monitors.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            description: |-
+                              monitors is a collection of Ceph monitors.
+                              More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             items:
                               type: string
                             type: array
                           pool:
-                            description: 'pool is the rados pool name. Default is rbd.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            description: |-
+                              pool is the rados pool name.
+                              Default is rbd.
+                              More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             type: string
                           readOnly:
-                            description: 'readOnly here will force the ReadOnly setting
-                            in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            description: |-
+                              readOnly here will force the ReadOnly setting in VolumeMounts.
+                              Defaults to false.
+                              More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             type: boolean
                           secretRef:
-                            description: 'secretRef is name of the authentication secret
-                            for RBDUser. If provided overrides keyring. Default is
-                            nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            description: |-
+                              secretRef is name of the authentication secret for RBDUser. If provided
+                              overrides keyring.
+                              Default is nil.
+                              More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           user:
-                            description: 'user is the rados user name. Default is admin.
-                            More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            description: |-
+                              user is the rados user name.
+                              Default is admin.
+                              More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it
                             type: string
                         required:
                           - image
@@ -7273,9 +8893,11 @@ spec:
                           attached and mounted on Kubernetes nodes.
                         properties:
                           fsType:
-                            description: fsType is the filesystem type to mount. Must
-                              be a filesystem type supported by the host operating system.
-                              Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                            description: |-
+                              fsType is the filesystem type to mount.
+                              Must be a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs".
+                              Default is "xfs".
                             type: string
                           gateway:
                             description: gateway is the host address of the ScaleIO
@@ -7286,17 +8908,20 @@ spec:
                               Protection Domain for the configured storage.
                             type: string
                           readOnly:
-                            description: readOnly Defaults to false (read/write). ReadOnly
-                              here will force the ReadOnly setting in VolumeMounts.
+                            description: |-
+                              readOnly Defaults to false (read/write). ReadOnly here will force
+                              the ReadOnly setting in VolumeMounts.
                             type: boolean
                           secretRef:
-                            description: secretRef references to the secret for ScaleIO
-                              user and other sensitive information. If this is not provided,
-                              Login operation will fail.
+                            description: |-
+                              secretRef references to the secret for ScaleIO user and other
+                              sensitive information. If this is not provided, Login operation will fail.
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
@@ -7305,8 +8930,8 @@ spec:
                               with Gateway, default false
                             type: boolean
                           storageMode:
-                            description: storageMode indicates whether the storage for
-                              a volume should be ThickProvisioned or ThinProvisioned.
+                            description: |-
+                              storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned.
                               Default is ThinProvisioned.
                             type: string
                           storagePool:
@@ -7318,9 +8943,9 @@ spec:
                               configured in ScaleIO.
                             type: string
                           volumeName:
-                            description: volumeName is the name of a volume already
-                              created in the ScaleIO system that is associated with
-                              this volume source.
+                            description: |-
+                              volumeName is the name of a volume already created in the ScaleIO system
+                              that is associated with this volume source.
                             type: string
                         required:
                           - gateway
@@ -7328,31 +8953,30 @@ spec:
                           - system
                         type: object
                       secret:
-                        description: 'secret represents a secret that should populate
-                        this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        description: |-
+                          secret represents a secret that should populate this volume.
+                          More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                         properties:
                           defaultMode:
-                            description: 'defaultMode is Optional: mode bits used to
-                            set permissions on created files by default. Must be an
-                            octal value between 0000 and 0777 or a decimal value between
-                            0 and 511. YAML accepts both octal and decimal values,
-                            JSON requires decimal values for mode bits. Defaults to
-                            0644. Directories within the path are not affected by
-                            this setting. This might be in conflict with other options
-                            that affect the file mode, like fsGroup, and the result
-                            can be other mode bits set.'
+                            description: |-
+                              defaultMode is Optional: mode bits used to set permissions on created files by default.
+                              Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                              YAML accepts both octal and decimal values, JSON requires decimal values
+                              for mode bits. Defaults to 0644.
+                              Directories within the path are not affected by this setting.
+                              This might be in conflict with other options that affect the file
+                              mode, like fsGroup, and the result can be other mode bits set.
                             format: int32
                             type: integer
                           items:
-                            description: items If unspecified, each key-value pair in
-                              the Data field of the referenced Secret will be projected
-                              into the volume as a file whose name is the key and content
-                              is the value. If specified, the listed keys will be projected
-                              into the specified paths, and unlisted keys will not be
-                              present. If a key is specified which is not present in
-                              the Secret, the volume setup will error unless it is marked
-                              optional. Paths must be relative and may not contain the
-                              '..' path or start with '..'.
+                            description: |-
+                              items If unspecified, each key-value pair in the Data field of the referenced
+                              Secret will be projected into the volume as a file whose name is the
+                              key and content is the value. If specified, the listed keys will be
+                              projected into the specified paths, and unlisted keys will not be
+                              present. If a key is specified which is not present in the Secret,
+                              the volume setup will error unless it is marked optional. Paths must be
+                              relative and may not contain the '..' path or start with '..'.
                             items:
                               description: Maps a string key to a path within a volume.
                               properties:
@@ -7360,22 +8984,21 @@ spec:
                                   description: key is the key to project.
                                   type: string
                                 mode:
-                                  description: 'mode is Optional: mode bits used to
-                                  set permissions on this file. Must be an octal value
-                                  between 0000 and 0777 or a decimal value between
-                                  0 and 511. YAML accepts both octal and decimal values,
-                                  JSON requires decimal values for mode bits. If not
-                                  specified, the volume defaultMode will be used.
-                                  This might be in conflict with other options that
-                                  affect the file mode, like fsGroup, and the result
-                                  can be other mode bits set.'
+                                  description: |-
+                                    mode is Optional: mode bits used to set permissions on this file.
+                                    Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511.
+                                    YAML accepts both octal and decimal values, JSON requires decimal values for mode bits.
+                                    If not specified, the volume defaultMode will be used.
+                                    This might be in conflict with other options that affect the file
+                                    mode, like fsGroup, and the result can be other mode bits set.
                                   format: int32
                                   type: integer
                                 path:
-                                  description: path is the relative path of the file
-                                    to map the key to. May not be an absolute path.
-                                    May not contain the path element '..'. May not start
-                                    with the string '..'.
+                                  description: |-
+                                    path is the relative path of the file to map the key to.
+                                    May not be an absolute path.
+                                    May not contain the path element '..'.
+                                    May not start with the string '..'.
                                   type: string
                               required:
                                 - key
@@ -7387,8 +9010,9 @@ spec:
                               its keys must be defined
                             type: boolean
                           secretName:
-                            description: 'secretName is the name of the secret in the
-                            pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                            description: |-
+                              secretName is the name of the secret in the pod's namespace to use.
+                              More info: https://kubernetes.io/docs/concepts/storage/volumes#secret
                             type: string
                         type: object
                       storageos:
@@ -7396,40 +9020,42 @@ spec:
                           and mounted on Kubernetes nodes.
                         properties:
                           fsType:
-                            description: fsType is the filesystem type to mount. Must
-                              be a filesystem type supported by the host operating system.
-                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                              if unspecified.
+                            description: |-
+                              fsType is the filesystem type to mount.
+                              Must be a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                             type: string
                           readOnly:
-                            description: readOnly defaults to false (read/write). ReadOnly
-                              here will force the ReadOnly setting in VolumeMounts.
+                            description: |-
+                              readOnly defaults to false (read/write). ReadOnly here will force
+                              the ReadOnly setting in VolumeMounts.
                             type: boolean
                           secretRef:
-                            description: secretRef specifies the secret to use for obtaining
-                              the StorageOS API credentials.  If not specified, default
-                              values will be attempted.
+                            description: |-
+                              secretRef specifies the secret to use for obtaining the StorageOS API
+                              credentials.  If not specified, default values will be attempted.
                             properties:
                               name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
-                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                                description: |-
+                                  Name of the referent.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  TODO: Add other useful fields. apiVersion, kind, uid?
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
                           volumeName:
-                            description: volumeName is the human-readable name of the
-                              StorageOS volume.  Volume names are only unique within
-                              a namespace.
+                            description: |-
+                              volumeName is the human-readable name of the StorageOS volume.  Volume
+                              names are only unique within a namespace.
                             type: string
                           volumeNamespace:
-                            description: volumeNamespace specifies the scope of the
-                              volume within StorageOS.  If no namespace is specified
-                              then the Pod's namespace will be used.  This allows the
-                              Kubernetes name scoping to be mirrored within StorageOS
-                              for tighter integration. Set VolumeName to any name to
-                              override the default behaviour. Set to "default" if you
-                              are not using namespaces within StorageOS. Namespaces
-                              that do not pre-exist within StorageOS will be created.
+                            description: |-
+                              volumeNamespace specifies the scope of the volume within StorageOS.  If no
+                              namespace is specified then the Pod's namespace will be used.  This allows the
+                              Kubernetes name scoping to be mirrored within StorageOS for tighter integration.
+                              Set VolumeName to any name to override the default behaviour.
+                              Set to "default" if you are not using namespaces within StorageOS.
+                              Namespaces that do not pre-exist within StorageOS will be created.
                             type: string
                         type: object
                       vsphereVolume:
@@ -7437,10 +9063,10 @@ spec:
                           and mounted on kubelets host machine
                         properties:
                           fsType:
-                            description: fsType is filesystem type to mount. Must be
-                              a filesystem type supported by the host operating system.
-                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4"
-                              if unspecified.
+                            description: |-
+                              fsType is filesystem type to mount.
+                              Must be a filesystem type supported by the host operating system.
+                              Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
                             type: string
                           storagePolicyID:
                             description: storagePolicyID is the storage Policy Based
@@ -7462,6 +9088,12 @@ spec:
                     type: object
                   type: array
                   x-kubernetes-list-type: atomic
+                workingDir:
+                  description: |-
+                    WorkingDir represents Container's working directory. If not specified,
+                    the container runtime's default will be used, which might
+                    be configured in the container image. Cannot be updated.
+                  type: string
               type: object
             status:
               description: AmazonCloudWatchAgentStatus defines the observed state of
@@ -7472,16 +9104,17 @@ spec:
                     Collector.
                   type: string
                 messages:
-                  description: 'Messages about actions performed by the operator on
-                  this resource. Deprecated: use Kubernetes events instead.'
+                  description: |-
+                    Messages about actions performed by the operator on this resource.
+                    Deprecated: use Kubernetes events instead.
                   items:
                     type: string
                   type: array
                   x-kubernetes-list-type: atomic
                 replicas:
-                  description: 'Replicas is currently not being set and might be removed
-                  in the next version. Deprecated: use "AmazonCloudWatchAgent.Status.Scale.Replicas"
-                  instead.'
+                  description: |-
+                    Replicas is currently not being set and might be removed in the next version.
+                    Deprecated: use "AmazonCloudWatchAgent.Status.Scale.Replicas" instead.
                   format: int32
                   type: integer
                 scale:
@@ -7489,19 +9122,21 @@ spec:
                     status.
                   properties:
                     replicas:
-                      description: The total number non-terminated pods targeted by
-                        this AmazonCloudWatchAgent's deployment or statefulSet.
+                      description: |-
+                        The total number non-terminated pods targeted by this
+                        AmazonCloudWatchAgent's deployment or statefulSet.
                       format: int32
                       type: integer
                     selector:
-                      description: The selector used to match the AmazonCloudWatchAgent's
+                      description: |-
+                        The selector used to match the AmazonCloudWatchAgent's
                         deployment or statefulSet pods.
                       type: string
                     statusReplicas:
-                      description: StatusReplicas is the number of pods targeted by
-                        this AmazonCloudWatchAgent's with a Ready Condition / Total
-                        number of non-terminated pods targeted by this AmazonCloudWatchAgent's
-                        (their labels match the selector). Deployment, Daemonset, StatefulSet.
+                      description: |-
+                        StatusReplicas is the number of pods targeted by this AmazonCloudWatchAgent's with a Ready Condition /
+                        Total number of non-terminated pods targeted by this AmazonCloudWatchAgent's (their labels match the selector).
+                        Deployment, Daemonset, StatefulSet.
                       type: string
                   type: object
                 version:
@@ -7517,9 +9152,7 @@ spec:
           specReplicasPath: .spec.replicas
           statusReplicasPath: .status.scale.replicas
         status: {}
-
 ---
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -8815,6 +10448,48 @@ spec:
                 description: TlsConfig is the raw YAML to be used as the exporter
                   TLS configuration.
                 type: string
+              tolerations:
+                description: Toleration to schedule DCGM Exporter pods.
+                  This is only relevant to daemonset, statefulset, and deployment
+                  mode
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
               volumeMounts:
                 description: VolumeMounts represents the mount points to use in the
                   underlying collector deployment(s)
@@ -10580,9 +12255,7 @@ spec:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.scale.replicas
       status: {}
-
 ---
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -12348,9 +14021,7 @@ spec:
       storage: true
       subresources:
         status: {}
-
 ---
-
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -13527,6 +15198,48 @@ spec:
               monitorConfig:
                 description: MonitorConfig is the raw Json to be used as monitor configuration.
                 type: string
+              tolerations:
+                description: Toleration to schedule Neuron Monitor Exporter pods.
+                  This is only relevant to daemonset, statefulset, and deployment
+                  mode
+                items:
+                  description: The pod this Toleration is attached to tolerates any
+                    taint that matches the triple <key,value,effect> using the matching
+                    operator <operator>.
+                  properties:
+                    effect:
+                      description: Effect indicates the taint effect to match. Empty
+                        means match all taint effects. When specified, allowed values
+                        are NoSchedule, PreferNoSchedule and NoExecute.
+                      type: string
+                    key:
+                      description: Key is the taint key that the toleration applies
+                        to. Empty means match all taint keys. If the key is empty,
+                        operator must be Exists; this combination means to match all
+                        values and all keys.
+                      type: string
+                    operator:
+                      description: Operator represents a key's relationship to the
+                        value. Valid operators are Exists and Equal. Defaults to Equal.
+                        Exists is equivalent to wildcard for value, so that a pod
+                        can tolerate all taints of a particular category.
+                      type: string
+                    tolerationSeconds:
+                      description: TolerationSeconds represents the period of time
+                        the toleration (which must be of effect NoExecute, otherwise
+                        this field is ignored) tolerates the taint. By default, it
+                        is not set, which means tolerate the taint forever (do not
+                        evict). Zero and negative values will be treated as 0 (evict
+                        immediately) by the system.
+                      format: int64
+                      type: integer
+                    value:
+                      description: Value is the taint value the toleration matches
+                        to. If the operator is Exists, the value should be empty,
+                        otherwise just a regular string.
+                      type: string
+                  type: object
+                type: array
               nodeSelector:
                 additionalProperties:
                   type: string

--- a/k8s-quickstart/cwagent-operator-rendered.yaml
+++ b/k8s-quickstart/cwagent-operator-rendered.yaml
@@ -1,5 +1,3 @@
----
-# create amazon-cloudwatch namespace
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -8,971 +6,32 @@ metadata:
     name: amazon-cloudwatch
 
 ---
-
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: cloudwatch-agent
-  namespace: amazon-cloudwatch
----
-
-apiVersion: v1
-kind: ServiceAccount
+apiVersion: cert-manager.io/v1
+kind: Issuer
 metadata:
   labels:
     app.kubernetes.io/name: amazon-cloudwatch-observability
     app.kubernetes.io/instance: amazon-cloudwatch-observability
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
-  name: amazon-cloudwatch-observability-controller-manager
-  namespace: amazon-cloudwatch
----
-
-apiVersion: v1
-kind: Secret
-metadata:
-  labels:
-    app.kubernetes.io/name: amazon-cloudwatch-observability
-    app.kubernetes.io/instance: amazon-cloudwatch-observability
-    app.kubernetes.io/version: "1.0.0"
-    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
-  name: "amazon-cloudwatch-observability-agent-cert"
-  namespace: amazon-cloudwatch
----
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: fluent-bit-config
-  namespace: amazon-cloudwatch
-  labels:
-    k8s-app: fluent-bit
-data:
-  fluent-bit.conf: |
-    [SERVICE]
-        Flush                     5
-        Grace                     30
-        Log_Level                 error
-        Daemon                    off
-        Parsers_File              parsers.conf
-        storage.path              /var/fluent-bit/state/flb-storage/
-        storage.sync              normal
-        storage.checksum          off
-        storage.backlog.mem_limit 5M
-    @INCLUDE application-log.conf
-    @INCLUDE dataplane-log.conf
-    @INCLUDE host-log.conf
-
-  application-log.conf: |
-    [INPUT]
-        Name                tail
-        Tag                 application.*
-        Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*, /var/log/containers/fluentd*
-        Path                /var/log/containers/*.log
-        multiline.parser    docker, cri
-        DB                  /var/fluent-bit/state/flb_container.db
-        Mem_Buf_Limit       50MB
-        Skip_Long_Lines     On
-        Refresh_Interval    10
-        Rotate_Wait         30
-        storage.type        filesystem
-        Read_from_Head      ${READ_FROM_HEAD}
-
-    [INPUT]
-        Name                tail
-        Tag                 application.*
-        Path                /var/log/containers/fluent-bit*
-        multiline.parser    docker, cri
-        DB                  /var/fluent-bit/state/flb_log.db
-        Mem_Buf_Limit       5MB
-        Skip_Long_Lines     On
-        Refresh_Interval    10
-        Read_from_Head      ${READ_FROM_HEAD}
-
-    [INPUT]
-        Name                tail
-        Tag                 application.*
-        Path                /var/log/containers/cloudwatch-agent*
-        multiline.parser    docker, cri
-        DB                  /var/fluent-bit/state/flb_cwagent.db
-        Mem_Buf_Limit       5MB
-        Skip_Long_Lines     On
-        Refresh_Interval    10
-        Read_from_Head      ${READ_FROM_HEAD}
-
-    [FILTER]
-        Name                kubernetes
-        Match               application.*
-        Kube_URL            https://kubernetes.default.svc:443
-        Kube_Tag_Prefix     application.var.log.containers.
-        Merge_Log           On
-        Merge_Log_Key       log_processed
-        K8S-Logging.Parser  On
-        K8S-Logging.Exclude Off
-        Labels              Off
-        Annotations         Off
-        Use_Kubelet         On
-        Kubelet_Port        10250
-        Buffer_Size         0
-
-    [OUTPUT]
-        Name                cloudwatch_logs
-        Match               application.*
-        region              ${AWS_REGION}
-        log_group_name      /aws/containerinsights/${CLUSTER_NAME}/application
-        log_stream_prefix   ${HOST_NAME}-
-        auto_create_group   true
-        extra_user_agent    container-insights
-
-  dataplane-log.conf: |
-    [INPUT]
-        Name                systemd
-        Tag                 dataplane.systemd.*
-        Systemd_Filter      _SYSTEMD_UNIT=docker.service
-        Systemd_Filter      _SYSTEMD_UNIT=containerd.service
-        Systemd_Filter      _SYSTEMD_UNIT=kubelet.service
-        DB                  /var/fluent-bit/state/systemd.db
-        Path                /var/log/journal
-        Read_From_Tail      ${READ_FROM_TAIL}
-
-    [INPUT]
-        Name                tail
-        Tag                 dataplane.tail.*
-        Path                /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
-        multiline.parser    docker, cri
-        DB                  /var/fluent-bit/state/flb_dataplane_tail.db
-        Mem_Buf_Limit       50MB
-        Skip_Long_Lines     On
-        Refresh_Interval    10
-        Rotate_Wait         30
-        storage.type        filesystem
-        Read_from_Head      ${READ_FROM_HEAD}
-
-    [FILTER]
-        Name                modify
-        Match               dataplane.systemd.*
-        Rename              _HOSTNAME                   hostname
-        Rename              _SYSTEMD_UNIT               systemd_unit
-        Rename              MESSAGE                     message
-        Remove_regex        ^((?!hostname|systemd_unit|message).)*$
-
-    [FILTER]
-        Name                aws
-        Match               dataplane.*
-        imds_version        v2
-
-    [OUTPUT]
-        Name                cloudwatch_logs
-        Match               dataplane.*
-        region              ${AWS_REGION}
-        log_group_name      /aws/containerinsights/${CLUSTER_NAME}/dataplane
-        log_stream_prefix   ${HOST_NAME}-
-        auto_create_group   true
-        extra_user_agent    container-insights
-
-  host-log.conf: |
-    [INPUT]
-        Name                tail
-        Tag                 host.dmesg
-        Path                /var/log/dmesg
-        Key                 message
-        DB                  /var/fluent-bit/state/flb_dmesg.db
-        Mem_Buf_Limit       5MB
-        Skip_Long_Lines     On
-        Refresh_Interval    10
-        Read_from_Head      ${READ_FROM_HEAD}
-
-    [INPUT]
-        Name                tail
-        Tag                 host.messages
-        Path                /var/log/messages
-        Parser              syslog
-        DB                  /var/fluent-bit/state/flb_messages.db
-        Mem_Buf_Limit       5MB
-        Skip_Long_Lines     On
-        Refresh_Interval    10
-        Read_from_Head      ${READ_FROM_HEAD}
-
-    [INPUT]
-        Name                tail
-        Tag                 host.secure
-        Path                /var/log/secure
-        Parser              syslog
-        DB                  /var/fluent-bit/state/flb_secure.db
-        Mem_Buf_Limit       5MB
-        Skip_Long_Lines     On
-        Refresh_Interval    10
-        Read_from_Head      ${READ_FROM_HEAD}
-
-    [FILTER]
-        Name                aws
-        Match               host.*
-        imds_version        v2
-
-    [OUTPUT]
-        Name                cloudwatch_logs
-        Match               host.*
-        region              ${AWS_REGION}
-        log_group_name      /aws/containerinsights/${CLUSTER_NAME}/host
-        log_stream_prefix   ${HOST_NAME}.
-        auto_create_group   true
-        extra_user_agent    container-insights
-
-  parsers.conf: |
-    [PARSER]
-        Name                syslog
-        Format              regex
-        Regex               ^(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
-        Time_Key            time
-        Time_Format         %b %d %H:%M:%S
-
-    [PARSER]
-        Name                container_firstline
-        Format              regex
-        Regex               (?<log>(?<="log":")\S(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
-        Time_Key            time
-        Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
-
-    [PARSER]
-        Name                cwagent_firstline
-        Format              regex
-        Regex               (?<log>(?<="log":")\d{4}[\/-]\d{1,2}[\/-]\d{1,2}[ T]\d{2}:\d{2}:\d{2}(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
-        Time_Key            time
-        Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
----
-
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: fluent-bit-windows-config
-  namespace: amazon-cloudwatch
-  labels:
-    k8s-app: fluent-bit
-data:
-  fluent-bit.conf: |
-    [SERVICE]
-        Flush                       5
-        Log_Level                   error
-        Daemon                      off
-        net.dns.resolver            LEGACY
-        Parsers_File                parsers.conf
-    @INCLUDE application-log.conf
-    @INCLUDE dataplane-log.conf
-    @INCLUDE host-log.conf
-
-  application-log.conf: |
-    [INPUT]
-        Name                tail
-        Tag                 application.*
-        Exclude_Path        C:\\var\\log\\containers\\fluent-bit*, C:\\var\\log\\containers\\cloudwatch-agent*
-        Path                C:\\var\\log\\containers\\*.log
-        Parser              docker
-        DB                  C:\\var\\fluent-bit\\state\\flb_container.db
-        Mem_Buf_Limit       50MB
-        Skip_Long_Lines     On
-        Rotate_Wait         30
-        Refresh_Interval    10
-        Read_from_Head      ${READ_FROM_HEAD}
-
-    [INPUT]
-        Name                tail
-        Tag                 application.*
-        Path                C:\\var\\log\\containers\\fluent-bit*
-        Parser              docker
-        DB                  C:\\var\\fluent-bit\\state\\flb_log.db
-        Mem_Buf_Limit       5MB
-        Skip_Long_Lines     On
-        Rotate_Wait         30
-        Refresh_Interval    10
-        Read_from_Head      ${READ_FROM_HEAD}
-
-    [INPUT]
-        Name                tail
-        Tag                 application.*
-        Path                C:\\var\\log\\containers\\cloudwatch-agent*
-        Parser              docker
-        DB                  C:\\var\\fluent-bit\\state\\flb_cwagent.db
-        Mem_Buf_Limit       5MB
-        Skip_Long_Lines     On
-        Rotate_Wait         30
-        Refresh_Interval    10
-        Read_from_Head      ${READ_FROM_HEAD}
-
-    [OUTPUT]
-        Name                cloudwatch_logs
-        Match               application.*
-        region              ${AWS_REGION}
-        log_group_name      /aws/containerinsights/${CLUSTER_NAME}/application
-        log_stream_prefix   ${HOST_NAME}-
-        auto_create_group   true
-        extra_user_agent    container-insights
-
-  dataplane-log.conf: |
-    [INPUT]
-        Name                tail
-        Tag                 dataplane.tail.*
-        Path                C:\\ProgramData\\containerd\\root\\*.log, C:\\ProgramData\\Amazon\\EKS\\logs\\*.log
-        Parser              dataplane_firstline
-        DB                  C:\\var\\fluent-bit\\state\\flb_dataplane_tail.db
-        Mem_Buf_Limit       5MB
-        Skip_Long_Lines     On
-        Rotate_Wait         30
-        Refresh_Interval    10
-        Read_from_Head      ${READ_FROM_HEAD}
-
-    [INPUT]
-        Name                tail
-        Tag                 dataplane.tail.C.ProgramData.Amazon.EKS.logs.vpc-bridge
-        Path                C:\\ProgramData\\Amazon\\EKS\\logs\\*.log.*
-        Path_Key            file_name
-        Parser              dataplane_firstline
-        DB                  C:\\var\\fluent-bit\\state\\flb_dataplane_cni_tail.db
-        Mem_Buf_Limit       5MB
-        Skip_Long_Lines     On
-        Rotate_Wait         30
-        Refresh_Interval    10
-        Read_from_Head      ${READ_FROM_HEAD}
-
-    [FILTER]
-        Name                aws
-        Match               dataplane.*
-        imds_version        v2
-
-    [OUTPUT]
-        Name                cloudwatch_logs
-        Match               dataplane.*
-        region              ${AWS_REGION}
-        log_group_name      /aws/containerinsights/${CLUSTER_NAME}/dataplane
-        log_stream_prefix   ${HOST_NAME}-
-        auto_create_group   true
-        extra_user_agent    container-insights
-
-  host-log.conf: |
-    [INPUT]
-        Name                winlog
-        Channels            EKS, System
-        DB                  C:\\var\\fluent-bit\\state\\flb_system_winlog.db
-        Interval_Sec        60
-
-    [FILTER]
-        Name                aws
-        Match               winlog.*
-        imds_version        v2
-
-    [OUTPUT]
-        Name                cloudwatch_logs
-        Match               winlog.*
-        region              ${AWS_REGION}
-        log_group_name      /aws/containerinsights/${CLUSTER_NAME}/host
-        log_stream_prefix   ${HOST_NAME}.
-        auto_create_group   true
-        extra_user_agent    container-insights
-
-  parsers.conf: |
-    [PARSER]
-        Name                docker
-        Format              json
-        Time_Key            time
-        Time_Format         %b %d %H:%M:%S
-
-    [PARSER]
-        Name                container_firstline
-        Format              regex
-        Regex               (?<log>(?<="log":")\S(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
-        Time_Key            time
-        Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
-
-    [PARSER]
-        Name                dataplane_firstline
-        Format              regex
-        Regex               (?<log>(?<="log":")\S(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
-        Time_Key            time
-        Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app.kubernetes.io/name: amazon-cloudwatch-observability
-    app.kubernetes.io/instance: amazon-cloudwatch-observability
-    app.kubernetes.io/version: "1.0.0"
-    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
-  name: cloudwatch-agent-role
-rules:
-- apiGroups: [ "" ]
-  resources: [ "pods", "pods/logs", "nodes", "nodes/proxy", "namespaces", "endpoints" ]
-  verbs: [ "list", "watch", "get" ]
-- apiGroups: [ "" ]
-  resources: [ "services" ]
-  verbs: [ "list", "watch" ]
-- apiGroups: [ "apps" ]
-  resources: [ "replicasets", "daemonsets", "deployments", "statefulsets" ]
-  verbs: [ "list", "watch", "get" ]
-- apiGroups: [ "batch" ]
-  resources: [ "jobs" ]
-  verbs: [ "list", "watch" ]
-- apiGroups: [ "" ]
-  resources: [ "nodes/stats", "configmaps", "events" ]
-  verbs: [ "create", "get" ]
-- apiGroups: [ "" ]
-  resources: [ "configmaps" ]
-  verbs: [ "update" ]
-- nonResourceURLs: [ "/metrics" ]
-  verbs: [ "get", "list", "watch" ]
-- apiGroups: ["discovery.k8s.io"]
-  resources: ["endpointslices"]
-  verbs: ["list", "watch", "get"]
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: amazon-cloudwatch-observability-manager-role
-rules:
-- apiGroups: [ "" ]
-  resources: [ "configmaps" ]
-  verbs: [ "create", "delete", "get", "list", "patch", "update", "watch" ]
-- apiGroups: [ "" ]
-  resources: [ "events" ]
-  verbs: [ "create", "patch" ]
-- apiGroups: [ "" ]
-  resources: [ "namespaces" ]
-  verbs: [ "get","list","patch","update","watch" ]
-- apiGroups: [ "" ]
-  resources: [ "serviceaccounts" ]
-  verbs: [ "create","delete","get","list","patch","update","watch" ]
-- apiGroups: [ "" ]
-  resources: [ "services" ]
-  verbs: [ "create","delete","get","list","patch","update","watch" ]
-- apiGroups: [ "apps" ]
-  resources: [ "daemonsets" ]
-  verbs: [ "create","delete","get","list","patch","update","watch" ]
-- apiGroups: [ "apps" ]
-  resources: [ "deployments" ]
-  verbs: [ "create","delete","get","list","patch","update","watch" ]
-- apiGroups: [ "apps" ]
-  resources: [ "statefulsets" ]
-  verbs: [ "create","delete","get","list","patch","update","watch" ]
-- apiGroups: [ "apps" ]
-  resources: [ "replicasets" ]
-  verbs: [ "get","list","watch" ]
-- apiGroups: [ "cloudwatch.aws.amazon.com" ]
-  resources: [ "amazoncloudwatchagents", "dcgmexporters", "neuronmonitors" ]
-  verbs: [ "get","list","patch","update","watch" ]
-- apiGroups: [ "cloudwatch.aws.amazon.com" ]
-  resources: [ "amazoncloudwatchagents/finalizers", "dcgmexporters/finalizers", "neuronmonitors/finalizers" ]
-  verbs: [ "get","patch","update" ]
-- apiGroups: [ "cloudwatch.aws.amazon.com" ]
-  resources: [ "amazoncloudwatchagents/status", "dcgmexporters/status", "neuronmonitors/status" ]
-  verbs: [ "get","patch","update" ]
-- apiGroups: [ "cloudwatch.aws.amazon.com" ]
-  resources: [ "instrumentations" ]
-  verbs: [ "get","list","patch","update","watch" ]
-- apiGroups: [ "coordination.k8s.io" ]
-  resources: [ "leases" ]
-  verbs: [ "create","get","list","update" ]
-- apiGroups: [ "networking.k8s.io" ]
-  resources: [ "ingresses" ]
-  verbs: [ "create","delete","get","list","patch","update","watch" ]
-- apiGroups: [ "route.openshift.io" ]
-  resources: [ "routes", "routes/custom-host" ]
-  verbs: [ "create","delete","get","list","patch","update","watch" ]
----
-
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: cloudwatch-agent-role-binding
-roleRef:
-  kind: ClusterRole
-  name: cloudwatch-agent-role
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-- kind: ServiceAccount
-  name: cloudwatch-agent
-  namespace: amazon-cloudwatch
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/name: amazon-cloudwatch-observability
-    app.kubernetes.io/instance: amazon-cloudwatch-observability
-    app.kubernetes.io/version: "1.0.0"
-    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
-  name: amazon-cloudwatch-observability-manager-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: amazon-cloudwatch-observability-manager-role
-subjects:
-- kind: ServiceAccount
-  name: amazon-cloudwatch-observability-controller-manager
-  namespace: amazon-cloudwatch
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: "dcgm-exporter-role"
-  namespace: amazon-cloudwatch
-  labels:
-    app.kubernetes.io/name: amazon-cloudwatch-observability
-    app.kubernetes.io/instance: amazon-cloudwatch-observability
-    app.kubernetes.io/version: "1.0.0"
-    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
-rules:
-- apiGroups: [""]
-  resources: ["configmaps"]
-  resourceNames: ["dcgm-exporter-config-map"]
-  verbs: ["get"]
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
-metadata:
-  name: "neuron-monitor-role"
-  namespace: amazon-cloudwatch
-  labels:
-    app.kubernetes.io/name: amazon-cloudwatch-observability
-    app.kubernetes.io/instance: amazon-cloudwatch-observability
-    app.kubernetes.io/version: "1.0.0"
-    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
-rules:
-- apiGroups: [""]
-  resources: ["configmaps"]
-  resourceNames: ["neuron-monitor-config-map"]
-  verbs: ["get"]
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  namespace: amazon-cloudwatch
-  name: dcgm-exporter-role-binding
-  labels:
-    app.kubernetes.io/name: amazon-cloudwatch-observability
-    app.kubernetes.io/instance: amazon-cloudwatch-observability
-    app.kubernetes.io/version: "1.0.0"
-    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
-roleRef:
-  kind: Role
-  name: "dcgm-exporter-role"
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-- kind: ServiceAccount
-  name: dcgm-exporter-service-acct
-  namespace: amazon-cloudwatch
----
-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  namespace: amazon-cloudwatch
-  name: neuron-monitor-role-binding
-  labels:
-    app.kubernetes.io/name: amazon-cloudwatch-observability
-    app.kubernetes.io/instance: amazon-cloudwatch-observability
-    app.kubernetes.io/version: "1.0.0"
-    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
-roleRef:
-  kind: Role
-  name: "neuron-monitor-role"
-  apiGroup: rbac.authorization.k8s.io
-subjects:
-- kind: ServiceAccount
-  name: neuron-monitor-service-acct
-  namespace: amazon-cloudwatch
----
-
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app.kubernetes.io/name: amazon-cloudwatch-observability
-    app.kubernetes.io/instance: amazon-cloudwatch-observability
-    app.kubernetes.io/version: "1.0.0"
-    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
-  name: amazon-cloudwatch-observability-webhook-service
+  name: amazon-cloudwatch-observability-selfsigned-issuer
   namespace: amazon-cloudwatch
 spec:
-  ports:
-  - port: 443
-    protocol: TCP
-    targetPort: 9443
-  selector:
-    app.kubernetes.io/name: amazon-cloudwatch-observability
-    control-plane: controller-manager
+  selfSigned: {}
 ---
-
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: fluent-bit
-  namespace: amazon-cloudwatch
-  labels:
-    k8s-app: fluent-bit
-    version: v1
-    kubernetes.io/cluster-service: "true"
-spec:
-  selector:
-    matchLabels:
-      k8s-app: fluent-bit
-  template:
-    metadata:
-      annotations:
-        checksum/config: 1356b1d704d353a90c127f6dad453991f51d88ae994a7583c1064e0c883d898e
-      labels:
-        k8s-app: fluent-bit
-        version: v1
-        kubernetes.io/cluster-service: "true"
-    spec:
-      containers:
-      - name: fluent-bit
-        image: public.ecr.aws/aws-observability/aws-for-fluent-bit:2.32.0.20240304
-        imagePullPolicy: Always
-        env:
-        - name: AWS_REGION
-          value: {{region_name}}
-        - name: CLUSTER_NAME
-          value: "{{cluster_name}}"
-        - name: READ_FROM_HEAD
-          value: "Off"
-        - name: READ_FROM_TAIL
-          value: "On"
-        - name: HOST_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: HOSTNAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: CI_VERSION
-          value: "k8s/1.3.34"
-        resources:
-          limits:
-            cpu: 500m
-            memory: 250Mi
-          
-          requests:
-            cpu: 50m
-            memory: 25Mi
-        volumeMounts:
-        # Please don't change below read-only permissions
-        - name: fluentbitstate
-          mountPath: /var/fluent-bit/state
-        - name: varlog
-          mountPath: /var/log
-          readOnly: true
-        - name: varlibdockercontainers
-          mountPath: /var/lib/docker/containers
-          readOnly: true
-        - name: fluent-bit-config
-          mountPath: /fluent-bit/etc/
-        - name: runlogjournal
-          mountPath: /run/log/journal
-          readOnly: true
-        - name: dmesg
-          mountPath: /var/log/dmesg
-          readOnly: true
-      terminationGracePeriodSeconds: 10
-      hostNetwork: true
-      dnsPolicy: ClusterFirstWithHostNet
-      volumes:
-      - name: fluentbitstate
-        hostPath:
-          path: /var/fluent-bit/state
-      - name: varlog
-        hostPath:
-          path: /var/log
-      - name: varlibdockercontainers
-        hostPath:
-          path: /var/lib/docker/containers
-      - name: fluent-bit-config
-        configMap:
-          name: fluent-bit-config
-      - name: runlogjournal
-        hostPath:
-          path: /run/log/journal
-      - name: dmesg
-        hostPath:
-          path: /var/log/dmesg
-      serviceAccountName: cloudwatch-agent
-      nodeSelector:
-        kubernetes.io/os: linux
----
-
-apiVersion: apps/v1
-kind: DaemonSet
-metadata:
-  name: fluent-bit-windows
-  namespace: amazon-cloudwatch
-  labels:
-    k8s-app: fluent-bit
-    version: v1
-    kubernetes.io/cluster-service: "true"
-spec:
-  selector:
-    matchLabels:
-      k8s-app: fluent-bit
-  template:
-    metadata:
-      annotations:
-        checksum/config: a54dc0c777b3caf8ea8c5e895f9e6054af9b06c72bed9d012c4414165bc85a41
-      labels:
-        k8s-app: fluent-bit
-        version: v1
-        kubernetes.io/cluster-service: "true"
-    spec:
-      securityContext:
-        windowsOptions:
-          hostProcess: true
-          runAsUserName: "NT AUTHORITY\\System"
-      hostNetwork: true
-      nodeSelector:
-        kubernetes.io/os: windows
-      containers:
-      - name: fluent-bit
-        image: public.ecr.aws/aws-observability/aws-for-fluent-bit:2.31.12-windowsservercore
-        imagePullPolicy: Always
-        command: ["powershell.exe", "-Command", "New-Item -ItemType Directory -Path C:\\var\\fluent-bit\\state -Force;", "%CONTAINER_SANDBOX_MOUNT_POINT%/fluent-bit/bin/fluent-bit.exe", "-e", "%CONTAINER_SANDBOX_MOUNT_POINT%/fluent-bit/kinesis.dll", "-e", "%CONTAINER_SANDBOX_MOUNT_POINT%/fluent-bit/firehose.dll", "-e", "%CONTAINER_SANDBOX_MOUNT_POINT%/fluent-bit/cloudwatch.dll", "-c", "%CONTAINER_SANDBOX_MOUNT_POINT%/fluent-bit/configuration/fluent-bit.conf"]
-        env:
-        - name: AWS_REGION
-          value: {{region_name}}
-        - name: CLUSTER_NAME
-          value: "{{cluster_name}}"
-        - name: READ_FROM_HEAD
-          value: "Off"
-        - name: HOST_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: HOSTNAME
-          valueFrom:
-            fieldRef:
-              apiVersion: v1
-              fieldPath: metadata.name
-        - name: CI_VERSION
-          value: "k8s/1.3.34"
-        resources:
-          limits:
-            cpu: 500m
-            memory: 600Mi
-          
-          requests:
-            cpu: 300m
-            memory: 300Mi
-        volumeMounts:
-          - name: fluent-bit-config
-            mountPath: fluent-bit\configuration\
-      volumes:
-        - name: fluent-bit-config
-          configMap:
-            name: fluent-bit-windows-config
-      terminationGracePeriodSeconds: 10
-      dnsPolicy: ClusterFirstWithHostNet
-      serviceAccountName: cloudwatch-agent
----
-
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: cert-manager.io/v1
+kind: Issuer
 metadata:
   labels:
     app.kubernetes.io/name: amazon-cloudwatch-observability
     app.kubernetes.io/instance: amazon-cloudwatch-observability
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
-    control-plane: controller-manager
-  name: amazon-cloudwatch-observability-controller-manager
+  name: "agent-ca"
   namespace: amazon-cloudwatch
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: amazon-cloudwatch-observability
-      control-plane: controller-manager
-  template:
-    metadata:
-      annotations:
-      labels:
-        app.kubernetes.io/name: amazon-cloudwatch-observability
-        control-plane: controller-manager
-        
-    spec:
-      containers:
-      - image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent-operator:1.3.0
-        args:
-        - "--auto-annotation-config={\"java\":{\"daemonsets\":[],\"deployments\":[],\"namespaces\":[],\"statefulsets\":[]},\"python\":{\"daemonsets\":[],\"deployments\":[],\"namespaces\":[],\"statefulsets\":[]}}"
-        - "--auto-instrumentation-java-image=public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v1.32.1"
-        - "--auto-instrumentation-python-image=public.ecr.aws/aws-observability/adot-autoinstrumentation-python:v0.1.0"
-        - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
-        command:
-        - /manager
-        name: manager
-        ports:
-        - containerPort: 9443
-          name: webhook-server
-          protocol: TCP
-        resources: 
-            requests:
-              cpu: 100m
-              memory: 64Mi
-        volumeMounts:
-        - mountPath: /tmp/k8s-webhook-server/serving-certs
-          name: cert
-          readOnly: true
-      serviceAccountName: amazon-cloudwatch-observability-controller-manager
-      terminationGracePeriodSeconds: 10
-      volumes:
-      - name: cert
-        secret:
-          defaultMode: 420
-          secretName: amazon-cloudwatch-observability-controller-manager-service-cert
-      nodeSelector:
-        kubernetes.io/os: linux
+  selfSigned: {}
 ---
-
-apiVersion: cloudwatch.aws.amazon.com/v1alpha1
-kind: AmazonCloudWatchAgent
-metadata:
-  name: cloudwatch-agent
-  namespace: amazon-cloudwatch
-spec:
-  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300056.0b1123
-  mode: daemonset
-  nodeSelector:
-    kubernetes.io/os: linux
-  serviceAccount: cloudwatch-agent
-  config: "{\"agent\":{\"region\":\"{{region_name}}\"},\"logs\":{\"metrics_collected\":{\"kubernetes\":{\"cluster_name\":\"{{cluster_name}}\",\"enhanced_container_insights\":true}}}}"
-  resources:
-    requests:
-      memory: "128Mi"
-      cpu: "250m"
-    limits:
-      memory: "512Mi"
-      cpu: "500m"
-  volumeMounts:
-  - mountPath: /rootfs
-    name: rootfs
-    readOnly: true
-  - mountPath: /var/run/docker.sock
-    name: dockersock
-    readOnly: true
-  - mountPath: /run/containerd/containerd.sock
-    name: containerdsock
-  - mountPath: /var/lib/docker
-    name: varlibdocker
-    readOnly: true
-  - mountPath: /sys
-    name: sys
-    readOnly: true
-  - mountPath: /dev/disk
-    name: devdisk
-    readOnly: true
-  - mountPath: /etc/amazon-cloudwatch-observability-agent-cert
-    name: agenttls
-    readOnly: true
-  - mountPath: /var/lib/kubelet/pod-resources
-    name: kubelet-podresources
-  volumes:
-  - name: kubelet-podresources
-    hostPath:
-      path: /var/lib/kubelet/pod-resources
-      type: Directory
-  - name: rootfs
-    hostPath:
-      path: /
-  - hostPath:
-      path: /var/run/docker.sock
-    name: dockersock
-  - hostPath:
-      path: /var/lib/docker
-    name: varlibdocker
-  - hostPath:
-      path: /run/containerd/containerd.sock
-    name: containerdsock
-  - hostPath:
-      path: /sys
-    name: sys
-  - hostPath:
-      path: /dev/disk/
-    name: devdisk
-  - name: agenttls
-    secret:
-      secretName: amazon-cloudwatch-observability-agent-cert
-      items:
-        - key: ca.crt
-          path: tls-ca.crt
-  env:
-  - name: K8S_NODE_NAME
-    valueFrom:
-      fieldRef:
-        fieldPath: spec.nodeName
-  - name: HOST_IP
-    valueFrom:
-      fieldRef:
-        fieldPath: status.hostIP
-  - name: HOST_NAME
-    valueFrom:
-      fieldRef:
-        fieldPath: spec.nodeName
-  - name: K8S_NAMESPACE
-    valueFrom:
-      fieldRef:
-        fieldPath: metadata.namespace
----
-
-apiVersion: cloudwatch.aws.amazon.com/v1alpha1
-kind: AmazonCloudWatchAgent
-metadata:
-  name: cloudwatch-agent-windows
-  namespace: amazon-cloudwatch
-spec:
-  podSecurityContext:
-    windowsOptions:
-      hostProcess: true
-      runAsUserName: "NT AUTHORITY\\System"
-  hostNetwork: true
-  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300056.0b1123
-  mode: daemonset
-  serviceAccount: cloudwatch-agent
-  nodeSelector:
-    kubernetes.io/os: windows
-  config: "{\"logs\":{\"metrics_collected\":{\"kubernetes\":{\"enhanced_container_insights\":true}}}}"
-  resources:
-    requests:
-      memory: "128Mi"
-      cpu: "250m"
-    limits:
-      memory: "512Mi"
-      cpu: "500m"
-  env:
-  - name: K8S_NODE_NAME
-    valueFrom:
-      fieldRef:
-        fieldPath: spec.nodeName
-  - name: HOST_IP
-    valueFrom:
-      fieldRef:
-        fieldPath: status.hostIP
-  - name: HOST_NAME
-    valueFrom:
-      fieldRef:
-        fieldPath: spec.nodeName
-  - name: K8S_NAMESPACE
-    valueFrom:
-      fieldRef:
-        fieldPath: metadata.namespace
-  - name: RUN_IN_CONTAINER
-    value: "True"
-  - name: RUN_AS_HOST_PROCESS_CONTAINER
-    value: "True"
----
-
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -996,7 +55,6 @@ spec:
     organizationalUnits:
       - amazon-cloudwatch-observability
 ---
-
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -1018,7 +76,1099 @@ spec:
     name: "agent-ca"
   secretName: "amazon-cloudwatch-observability-agent-cert"
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/name: amazon-cloudwatch-observability
+    app.kubernetes.io/instance: amazon-cloudwatch-observability
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
+  name: "amazon-cloudwatch-observability-agent-cert"
+  namespace: amazon-cloudwatch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloudwatch-agent
+  namespace: amazon-cloudwatch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: amazon-cloudwatch-observability
+    app.kubernetes.io/instance: amazon-cloudwatch-observability
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
+  name: amazon-cloudwatch-observability-controller-manager
+  namespace: amazon-cloudwatch
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/name: amazon-cloudwatch-observability
+    app.kubernetes.io/instance: amazon-cloudwatch-observability
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
+  name: "amazon-cloudwatch-observability-agent-cert"
+  namespace: amazon-cloudwatch
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-config
+  namespace: amazon-cloudwatch
+  labels:
+    k8s-app: fluent-bit
+data:
+  fluent-bit.conf: |
+    [SERVICE]
+      Flush                     5
+      Grace                     30
+      Log_Level                 error
+      Daemon                    off
+      Parsers_File              parsers.conf
+      storage.path              /var/fluent-bit/state/flb-storage/
+      storage.sync              normal
+      storage.checksum          off
+      storage.backlog.mem_limit 5M
 
+    @INCLUDE application-log.conf
+    @INCLUDE dataplane-log.conf
+    @INCLUDE host-log.conf
+  parsers.conf: |
+    [PARSER]
+      Name                syslog
+      Format              regex
+      Regex               ^(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
+      Time_Key            time
+      Time_Format         %b %d %H:%M:%S
+
+    [PARSER]
+      Name                container_firstline
+      Format              regex
+      Regex               (?<log>(?<="log":")\S(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
+      Time_Key            time
+      Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
+
+    [PARSER]
+      Name                cwagent_firstline
+      Format              regex
+      Regex               (?<log>(?<="log":")\d{4}[\/-]\d{1,2}[\/-]\d{1,2}[ T]\d{2}:\d{2}:\d{2}(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
+      Time_Key            time
+      Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
+  application-log.conf: |
+    [INPUT]
+      Name                tail
+      Tag                 application.*
+      Exclude_Path        /var/log/containers/cloudwatch-agent*, /var/log/containers/fluent-bit*, /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
+      Path                /var/log/containers/*.log
+      multiline.parser    docker, cri
+      DB                  /var/fluent-bit/state/flb_container.db
+      Mem_Buf_Limit       50MB
+      Skip_Long_Lines     On
+      Refresh_Interval    10
+      Rotate_Wait         30
+      storage.type        filesystem
+      Read_from_Head      ${READ_FROM_HEAD}
+
+    [INPUT]
+      Name                tail
+      Tag                 application.*
+      Path                /var/log/containers/fluent-bit*
+      multiline.parser    docker, cri
+      DB                  /var/fluent-bit/state/flb_log.db
+      Mem_Buf_Limit       5MB
+      Skip_Long_Lines     On
+      Refresh_Interval    10
+      Read_from_Head      ${READ_FROM_HEAD}
+
+    [INPUT]
+      Name                tail
+      Tag                 application.*
+      Path                /var/log/containers/cloudwatch-agent*
+      multiline.parser    docker, cri
+      DB                  /var/fluent-bit/state/flb_cwagent.db
+      Mem_Buf_Limit       5MB
+      Skip_Long_Lines     On
+      Refresh_Interval    10
+      Read_from_Head      ${READ_FROM_HEAD}
+
+    [FILTER]
+      Name                aws
+      Match               application.*
+      az                  false
+      ec2_instance_id     false
+      Enable_Entity       true
+
+    [FILTER]
+      Name                kubernetes
+      Match               application.*
+      Kube_URL            https://kubernetes.default.svc:443
+      Kube_Tag_Prefix     application.var.log.containers.
+      Merge_Log           On
+      Merge_Log_Key       log_processed
+      K8S-Logging.Parser  On
+      K8S-Logging.Exclude Off
+      Labels              Off
+      Annotations         Off
+      Use_Kubelet         On
+      Kubelet_Port        10250
+      Buffer_Size         0
+      Use_Pod_Association On
+
+    [OUTPUT]
+      Name                cloudwatch_logs
+      Match               application.*
+      region              ${AWS_REGION}
+      log_group_name      /aws/containerinsights/${CLUSTER_NAME}/application
+      log_stream_prefix   ${HOST_NAME}-
+      auto_create_group   true
+      extra_user_agent    container-insights
+      add_entity          true
+  dataplane-log.conf: |
+    [INPUT]
+      Name                systemd
+      Tag                 dataplane.systemd.*
+      Systemd_Filter      _SYSTEMD_UNIT=docker.service
+      Systemd_Filter      _SYSTEMD_UNIT=containerd.service
+      Systemd_Filter      _SYSTEMD_UNIT=kubelet.service
+      DB                  /var/fluent-bit/state/systemd.db
+      Path                /var/log/journal
+      Read_From_Tail      ${READ_FROM_TAIL}
+
+    [INPUT]
+      Name                tail
+      Tag                 dataplane.tail.*
+      Path                /var/log/containers/aws-node*, /var/log/containers/kube-proxy*
+      multiline.parser    docker, cri
+      DB                  /var/fluent-bit/state/flb_dataplane_tail.db
+      Mem_Buf_Limit       50MB
+      Skip_Long_Lines     On
+      Refresh_Interval    10
+      Rotate_Wait         30
+      storage.type        filesystem
+      Read_from_Head      ${READ_FROM_HEAD}
+
+    [FILTER]
+      Name                modify
+      Match               dataplane.systemd.*
+      Rename              _HOSTNAME                   hostname
+      Rename              _SYSTEMD_UNIT               systemd_unit
+      Rename              MESSAGE                     message
+      Remove_regex        ^((?!hostname|systemd_unit|message).)*$
+
+    [FILTER]
+      Name                aws
+      Match               dataplane.*
+      imds_version        v2
+
+    [OUTPUT]
+      Name                cloudwatch_logs
+      Match               dataplane.*
+      region              ${AWS_REGION}
+      log_group_name      /aws/containerinsights/${CLUSTER_NAME}/dataplane
+      log_stream_prefix   ${HOST_NAME}-
+      auto_create_group   true
+      extra_user_agent    container-insights
+  host-log.conf: |
+    [INPUT]
+      Name                tail
+      Tag                 host.dmesg
+      Path                /var/log/dmesg
+      Key                 message
+      DB                  /var/fluent-bit/state/flb_dmesg.db
+      Mem_Buf_Limit       5MB
+      Skip_Long_Lines     On
+      Refresh_Interval    10
+      Read_from_Head      ${READ_FROM_HEAD}
+
+    [INPUT]
+      Name                tail
+      Tag                 host.messages
+      Path                /var/log/messages
+      Parser              syslog
+      DB                  /var/fluent-bit/state/flb_messages.db
+      Mem_Buf_Limit       5MB
+      Skip_Long_Lines     On
+      Refresh_Interval    10
+      Read_from_Head      ${READ_FROM_HEAD}
+
+    [INPUT]
+      Name                tail
+      Tag                 host.secure
+      Path                /var/log/secure
+      Parser              syslog
+      DB                  /var/fluent-bit/state/flb_secure.db
+      Mem_Buf_Limit       5MB
+      Skip_Long_Lines     On
+      Refresh_Interval    10
+      Read_from_Head      ${READ_FROM_HEAD}
+
+    [FILTER]
+      Name                aws
+      Match               host.*
+      imds_version        v2
+
+    [OUTPUT]
+      Name                cloudwatch_logs
+      Match               host.*
+      region              ${AWS_REGION}
+      log_group_name      /aws/containerinsights/${CLUSTER_NAME}/host
+      log_stream_prefix   ${HOST_NAME}.
+      auto_create_group   true
+      extra_user_agent    container-insights
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fluent-bit-windows-config
+  namespace: amazon-cloudwatch
+  labels:
+    k8s-app: fluent-bit
+data:
+  fluent-bit.conf: |
+    [ SERVICE ]
+      Flush                       5
+      Log_Level                   error
+      Daemon                      off
+      net.dns.resolver            LEGACY
+      Parsers_File                parsers.conf
+
+      @INCLUDE application-log.conf
+      @INCLUDE dataplane-log.conf
+      @INCLUDE host-log.conf
+
+    @INCLUDE application-log.conf
+    @INCLUDE dataplane-log.conf
+    @INCLUDE host-log.conf
+  parsers.conf: |
+    [PARSER]
+      Name                docker
+      Format              json
+      Time_Key            time
+      Time_Format         %b %d %H:%M:%S
+
+    [PARSER]
+      Name                container_firstline
+      Format              regex
+      Regex               (?<log>(?<="log":")\S(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
+      Time_Key            time
+      Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
+
+    [PARSER]
+      Name                dataplane_firstline
+      Format              regex
+      Regex               (?<log>(?<="log":")\S(?!\.).*?)(?<!\\)".*(?<stream>(?<="stream":").*?)".*(?<time>\d{4}-\d{1,2}-\d{1,2}T\d{2}:\d{2}:\d{2}\.\w*).*(?=})
+      Time_Key            time
+      Time_Format         %Y-%m-%dT%H:%M:%S.%LZ
+  application-log.conf: |
+    [INPUT]
+      Name                tail
+      Tag                 application.*
+      Exclude_Path        C:\\var\\log\\containers\\fluent-bit*, C:\\var\\log\\containers\\cloudwatch-agent*
+      Path                C:\\var\\log\\containers\\*.log
+      Parser              docker
+      DB                  C:\\var\\fluent-bit\\state\\flb_container.db
+      Mem_Buf_Limit       50MB
+      Skip_Long_Lines     On
+      Rotate_Wait         30
+      Refresh_Interval    10
+      Read_from_Head      ${READ_FROM_HEAD}
+
+    [INPUT]
+      Name                tail
+      Tag                 application.*
+      Path                C:\\var\\log\\containers\\fluent-bit*
+      Parser              docker
+      DB                  C:\\var\\fluent-bit\\state\\flb_log.db
+      Mem_Buf_Limit       5MB
+      Skip_Long_Lines     On
+      Rotate_Wait         30
+      Refresh_Interval    10
+      Read_from_Head      ${READ_FROM_HEAD}
+
+    [INPUT]
+      Name                tail
+      Tag                 application.*
+      Path                C:\\var\\log\\containers\\cloudwatch-agent*
+      Parser              docker
+      DB                  C:\\var\\fluent-bit\\state\\flb_cwagent.db
+      Mem_Buf_Limit       5MB
+      Skip_Long_Lines     On
+      Rotate_Wait         30
+      Refresh_Interval    10
+      Read_from_Head      ${READ_FROM_HEAD}
+
+    [OUTPUT]
+      Name                cloudwatch_logs
+      Match               application.*
+      region              ${AWS_REGION}
+      log_group_name      /aws/containerinsights/${CLUSTER_NAME}/application
+      log_stream_prefix   ${HOST_NAME}-
+      auto_create_group   true
+      extra_user_agent    container-insights
+  dataplane-log.conf: |
+    [INPUT]
+      Name                tail
+      Tag                 dataplane.tail.*
+      Path                C:\\ProgramData\\containerd\\root\\*.log, C:\\ProgramData\\Amazon\\EKS\\logs\\*.log
+      Parser              dataplane_firstline
+      DB                  C:\\var\\fluent-bit\\state\\flb_dataplane_tail.db
+      Mem_Buf_Limit       5MB
+      Skip_Long_Lines     On
+      Rotate_Wait         30
+      Refresh_Interval    10
+      Read_from_Head      ${READ_FROM_HEAD}
+
+    [INPUT]
+      Name                tail
+      Tag                 dataplane.tail.C.ProgramData.Amazon.EKS.logs.vpc-bridge
+      Path                C:\\ProgramData\\Amazon\\EKS\\logs\\*.log.*
+      Path_Key            file_name
+      Parser              dataplane_firstline
+      DB                  C:\\var\\fluent-bit\\state\\flb_dataplane_cni_tail.db
+      Mem_Buf_Limit       5MB
+      Skip_Long_Lines     On
+      Rotate_Wait         30
+      Refresh_Interval    10
+      Read_from_Head      ${READ_FROM_HEAD}
+
+    [INPUT]
+      Name                winlog
+      Channels            EKS
+      DB                  C:\\var\\fluent-bit\\state\\flb_eks_winlog.db
+      Interval_Sec        60
+
+    [FILTER]
+      Name                aws
+      Match               dataplane.*
+      imds_version        v2
+
+    [FILTER]
+      Name                aws
+      Match               winlog.*
+      imds_version        v2
+
+    [OUTPUT]
+      Name                cloudwatch_logs
+      Match               dataplane.*
+      region              ${AWS_REGION}
+      log_group_name      /aws/containerinsights/${CLUSTER_NAME}/dataplane
+      log_stream_prefix   ${HOST_NAME}-
+      auto_create_group   true
+      extra_user_agent    container-insights
+
+    [OUTPUT]
+      Name                cloudwatch_logs
+      Match               winlog.*
+      region              ${AWS_REGION}
+      log_group_name      /aws/containerinsights/${CLUSTER_NAME}/dataplane
+      log_stream_name     ${HOST_NAME}.windows.kubelet.kubeproxy.service
+      auto_create_group   true
+      extra_user_agent    container-insights
+  host-log.conf: |
+    [INPUT]
+      Name                winlog
+      Channels            System
+      DB                  C:\\var\\fluent-bit\\state\\flb_system_winlog.db
+      Interval_Sec        60
+
+    [FILTER]
+      Name                aws
+      Match               winlog.*
+      imds_version        v2
+
+    [OUTPUT]
+      Name                cloudwatch_logs
+      Match               winlog.*
+      region              ${AWS_REGION}
+      log_group_name      /aws/containerinsights/${CLUSTER_NAME}/host
+      log_stream_name     ${HOST_NAME}.windows.system.events
+      auto_create_group   true
+      extra_user_agent    container-insights
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: amazon-cloudwatch-observability
+    app.kubernetes.io/instance: amazon-cloudwatch-observability
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
+  name: cloudwatch-agent-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "pods/logs", "nodes", "nodes/proxy", "namespaces", "endpoints"]
+    verbs: ["list", "watch", "get"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["list", "watch", "get"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets", "daemonsets", "deployments", "statefulsets"]
+    verbs: ["list", "watch", "get"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes/stats", "configmaps", "events"]
+    verbs: ["create", "get"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["update"]
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: amazon-cloudwatch-observability-manager-role
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "patch", "update", "watch"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["statefulsets"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["cloudwatch.aws.amazon.com"]
+    resources: ["amazoncloudwatchagents", "dcgmexporters", "neuronmonitors"]
+    verbs: ["get", "list", "patch", "update", "watch"]
+  - apiGroups: ["cloudwatch.aws.amazon.com"]
+    resources: ["amazoncloudwatchagents/finalizers", "dcgmexporters/finalizers", "neuronmonitors/finalizers"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: ["cloudwatch.aws.amazon.com"]
+    resources: ["amazoncloudwatchagents/status", "dcgmexporters/status", "neuronmonitors/status"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: ["cloudwatch.aws.amazon.com"]
+    resources: ["instrumentations"]
+    verbs: ["get", "list", "patch", "update", "watch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["create", "get", "list", "update"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes", "routes/custom-host"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cloudwatch-agent-role-binding
+roleRef:
+  kind: ClusterRole
+  name: cloudwatch-agent-role
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: cloudwatch-agent
+    namespace: amazon-cloudwatch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: amazon-cloudwatch-observability
+    app.kubernetes.io/instance: amazon-cloudwatch-observability
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
+  name: amazon-cloudwatch-observability-manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: amazon-cloudwatch-observability-manager-role
+subjects:
+  - kind: ServiceAccount
+    name: amazon-cloudwatch-observability-controller-manager
+    namespace: amazon-cloudwatch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "dcgm-exporter-role"
+  namespace: amazon-cloudwatch
+  labels:
+    app.kubernetes.io/name: amazon-cloudwatch-observability
+    app.kubernetes.io/instance: amazon-cloudwatch-observability
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["dcgm-exporter-config-map"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "neuron-monitor-role"
+  namespace: amazon-cloudwatch
+  labels:
+    app.kubernetes.io/name: amazon-cloudwatch-observability
+    app.kubernetes.io/instance: amazon-cloudwatch-observability
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    resourceNames: ["neuron-monitor-config-map"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: amazon-cloudwatch
+  name: dcgm-exporter-role-binding
+  labels:
+    app.kubernetes.io/name: amazon-cloudwatch-observability
+    app.kubernetes.io/instance: amazon-cloudwatch-observability
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
+roleRef:
+  kind: Role
+  name: "dcgm-exporter-role"
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: dcgm-exporter-service-acct
+    namespace: amazon-cloudwatch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: amazon-cloudwatch
+  name: neuron-monitor-role-binding
+  labels:
+    app.kubernetes.io/name: amazon-cloudwatch-observability
+    app.kubernetes.io/instance: amazon-cloudwatch-observability
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
+roleRef:
+  kind: Role
+  name: "neuron-monitor-role"
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: neuron-monitor-service-acct
+    namespace: amazon-cloudwatch
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: amazon-cloudwatch-observability
+    app.kubernetes.io/instance: amazon-cloudwatch-observability
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
+  name: amazon-cloudwatch-observability-webhook-service
+  namespace: amazon-cloudwatch
+spec:
+  ports:
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
+  selector:
+    app.kubernetes.io/name: amazon-cloudwatch-observability
+    control-plane: controller-manager
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluent-bit
+  namespace: amazon-cloudwatch
+  labels:
+    k8s-app: fluent-bit
+    version: v1
+    kubernetes.io/cluster-service: "true"
+spec:
+  selector:
+    matchLabels:
+      k8s-app: fluent-bit
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  template:
+    metadata:
+      annotations:
+        checksum/config: 343bfdc4f6cc519ad04fcf86e8ed75b5adb1dbbf7352093d37c3acbdc05bdd69
+      labels:
+        k8s-app: fluent-bit
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      containers:
+        - name: fluent-bit
+          image: public.ecr.aws/aws-observability/aws-for-fluent-bit:2.32.5.20250327
+          imagePullPolicy: Always
+          env:
+            - name: AWS_REGION
+              value: {? {region_name: ''} : ''}
+            - name: CLUSTER_NAME
+              value: "{{cluster_name}}"
+            - name: READ_FROM_HEAD
+              value: "Off"
+            - name: READ_FROM_TAIL
+              value: "On"
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: CI_VERSION
+              value: "k8s/1.3.35"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 250Mi
+            requests:
+              cpu: 50m
+              memory: 25Mi
+          volumeMounts:
+            # Please don't change below read-only permissions
+            - name: fluentbitstate
+              mountPath: /var/fluent-bit/state
+            - name: varlog
+              mountPath: /var/log
+              readOnly: true
+            - name: varlibdockercontainers
+              mountPath: /var/lib/docker/containers
+              readOnly: true
+            - name: fluent-bit-config
+              mountPath: /fluent-bit/etc/
+            - name: runlogjournal
+              mountPath: /run/log/journal
+              readOnly: true
+            - name: dmesg
+              mountPath: /var/log/dmesg
+              readOnly: true
+      terminationGracePeriodSeconds: 10
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      priorityClassName: system-node-critical
+      volumes:
+        - name: fluentbitstate
+          hostPath:
+            path: /var/fluent-bit/state
+        - name: varlog
+          hostPath:
+            path: /var/log
+        - name: varlibdockercontainers
+          hostPath:
+            path: /var/lib/docker/containers
+        - name: fluent-bit-config
+          configMap:
+            name: fluent-bit-config
+        - name: runlogjournal
+          hostPath:
+            path: /run/log/journal
+        - name: dmesg
+          hostPath:
+            path: /var/log/dmesg
+      serviceAccountName: cloudwatch-agent
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: eks.amazonaws.com/compute-type
+                    operator: NotIn
+                    values:
+                      - fargate
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        - operator: Exists
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fluent-bit-windows
+  namespace: amazon-cloudwatch
+  labels:
+    k8s-app: fluent-bit
+    version: v1
+    kubernetes.io/cluster-service: "true"
+spec:
+  selector:
+    matchLabels:
+      k8s-app: fluent-bit
+  template:
+    metadata:
+      annotations:
+        checksum/config: f878199d937d18566c364ffd6119fe4f9dd500a1b63080c1469fa0a3cf14ebe4
+      labels:
+        k8s-app: fluent-bit
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      securityContext:
+        windowsOptions:
+          hostProcess: true
+          runAsUserName: "NT AUTHORITY\\System"
+      hostNetwork: true
+      priorityClassName: system-node-critical
+      nodeSelector:
+        kubernetes.io/os: windows
+      containers:
+        - name: fluent-bit
+          image: public.ecr.aws/aws-observability/aws-for-fluent-bit:2.31.12-windowsservercore
+          imagePullPolicy: Always
+          command: ["powershell.exe", "-Command", "New-Item -ItemType Directory -Path C:\\var\\fluent-bit\\state -Force;", "%CONTAINER_SANDBOX_MOUNT_POINT%/fluent-bit/bin/fluent-bit.exe", "-e", "%CONTAINER_SANDBOX_MOUNT_POINT%/fluent-bit/kinesis.dll", "-e", "%CONTAINER_SANDBOX_MOUNT_POINT%/fluent-bit/firehose.dll", "-e", "%CONTAINER_SANDBOX_MOUNT_POINT%/fluent-bit/cloudwatch.dll", "-c", "%CONTAINER_SANDBOX_MOUNT_POINT%/fluent-bit/configuration/fluent-bit.conf"]
+          env:
+            - name: AWS_REGION
+              value: {? {region_name: ''} : ''}
+            - name: CLUSTER_NAME
+              value: "{{cluster_name}}"
+            - name: READ_FROM_HEAD
+              value: "Off"
+            - name: HOST_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOSTNAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: CI_VERSION
+              value: "k8s/1.3.35"
+          resources:
+            limits:
+              cpu: 500m
+              memory: 250Mi
+            requests:
+              cpu: 50m
+              memory: 25Mi
+          volumeMounts:
+            - name: fluent-bit-config
+              mountPath: fluent-bit\configuration\
+      volumes:
+        - name: fluent-bit-config
+          configMap:
+            name: fluent-bit-windows-config
+      terminationGracePeriodSeconds: 10
+      dnsPolicy: ClusterFirstWithHostNet
+      serviceAccountName: cloudwatch-agent
+      tolerations:
+        - operator: Exists
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: amazon-cloudwatch-observability
+    app.kubernetes.io/instance: amazon-cloudwatch-observability
+    app.kubernetes.io/version: "1.0.0"
+    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
+    control-plane: controller-manager
+  name: amazon-cloudwatch-observability-controller-manager
+  namespace: amazon-cloudwatch
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: amazon-cloudwatch-observability
+      control-plane: controller-manager
+  template:
+    metadata:
+      annotations:
+      labels:
+        app.kubernetes.io/name: amazon-cloudwatch-observability
+        control-plane: controller-manager
+    spec:
+      containers:
+        - image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent-operator:3.0.0
+          args:
+            - "--auto-instrumentation-config={\"dotnet\":{\"limits\":{\"cpu\":\"500m\",\"memory\":\"128Mi\"},\"requests\":{\"cpu\":\"50m\",\"memory\":\"128Mi\"},\"runtime_metrics\":{\"enabled\":\"true\"}},\"java\":{\"limits\":{\"cpu\":\"500m\",\"memory\":\"64Mi\"},\"requests\":{\"cpu\":\"50m\",\"memory\":\"64Mi\"},\"runtime_metrics\":{\"enabled\":\"true\"}},\"nodejs\":{\"limits\":{\"cpu\":\"500m\",\"memory\":\"128Mi\"},\"requests\":{\"cpu\":\"50m\",\"memory\":\"128Mi\"}},\"python\":{\"limits\":{\"cpu\":\"500m\",\"memory\":\"32Mi\"},\"requests\":{\"cpu\":\"50m\",\"memory\":\"32Mi\"},\"runtime_metrics\":{\"enabled\":\"true\"}}}"
+            - "--auto-annotation-config={\"dotnet\":{\"daemonsets\":[],\"deployments\":[],\"namespaces\":[],\"statefulsets\":[]},\"java\":{\"daemonsets\":[],\"deployments\":[],\"namespaces\":[],\"statefulsets\":[]},\"nodejs\":{\"daemonsets\":[],\"deployments\":[],\"namespaces\":[],\"statefulsets\":[]},\"python\":{\"daemonsets\":[],\"deployments\":[],\"namespaces\":[],\"statefulsets\":[]}}"
+            - "--auto-monitor-config={\"customSelector\":{\"dotnet\":{\"daemonsets\":[],\"deployments\":[],\"namespaces\":[],\"statefulsets\":[]},\"java\":{\"daemonsets\":[],\"deployments\":[],\"namespaces\":[],\"statefulsets\":[]},\"nodejs\":{\"daemonsets\":[],\"deployments\":[],\"namespaces\":[],\"statefulsets\":[]},\"python\":{\"daemonsets\":[],\"deployments\":[],\"namespaces\":[],\"statefulsets\":[]}},\"exclude\":{\"dotnet\":{\"daemonsets\":[],\"deployments\":[],\"namespaces\":[],\"statefulsets\":[]},\"java\":{\"daemonsets\":[],\"deployments\":[],\"namespaces\":[],\"statefulsets\":[]},\"nodejs\":{\"daemonsets\":[],\"deployments\":[],\"namespaces\":[],\"statefulsets\":[]},\"python\":{\"daemonsets\":[],\"deployments\":[],\"namespaces\":[],\"statefulsets\":[]}},\"languages\":[\"java\",\"python\",\"dotnet\",\"nodejs\"],\"monitorAllServices\":false,\"restartPods\":false}"
+            - "--auto-instrumentation-java-image=public.ecr.aws/aws-observability/adot-autoinstrumentation-java:v2.10.0"
+            - "--auto-instrumentation-python-image=public.ecr.aws/aws-observability/adot-autoinstrumentation-python:v0.9.0"
+            - "--auto-instrumentation-dotnet-image=public.ecr.aws/aws-observability/adot-autoinstrumentation-dotnet:v1.7.0"
+            - "--auto-instrumentation-nodejs-image=public.ecr.aws/aws-observability/adot-autoinstrumentation-node:v0.6.0"
+            - "--target-allocator-image=public.ecr.aws/cloudwatch-agent/cloudwatch-agent-target-allocator:1.0.0"
+            - "--feature-gates=operator.autoinstrumentation.multi-instrumentation,operator.autoinstrumentation.multi-instrumentation.skip-container-validation"
+          command:
+            - /manager
+          name: manager
+          ports:
+            - containerPort: 9443
+              name: webhook-server
+              protocol: TCP
+          resources:
+            requests:
+              cpu: 100m
+              memory: 64Mi
+          volumeMounts:
+            - mountPath: /tmp/k8s-webhook-server/serving-certs
+              name: cert
+              readOnly: true
+      serviceAccountName: amazon-cloudwatch-observability-controller-manager
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: cert
+          secret:
+            defaultMode: 420
+            secretName: amazon-cloudwatch-observability-controller-manager-service-cert
+      nodeSelector:
+        kubernetes.io/os: linux
+---
+apiVersion: cloudwatch.aws.amazon.com/v1alpha1
+kind: AmazonCloudWatchAgent
+metadata:
+  name: cloudwatch-agent
+  namespace: amazon-cloudwatch
+spec:
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
+  mode: daemonset
+  replicas: 1
+  nodeSelector:
+    kubernetes.io/os: linux
+  serviceAccount: cloudwatch-agent
+  priorityClassName: system-node-critical
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                  - fargate
+  hostNetwork: true
+  config: "{\"agent\":{\"region\":\"{{region_name}}\"},\"logs\":{\"metrics_collected\":{\"application_signals\":{\"hosted_in\":\"{{cluster_name}}\"},\"kubernetes\":{\"cluster_name\":\"{{cluster_name}}\",\"enhanced_container_insights\":true}}},\"traces\":{\"traces_collected\":{\"application_signals\":{}}}}"
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 128Mi
+  volumeMounts:
+    - mountPath: /rootfs
+      name: rootfs
+      readOnly: true
+    - mountPath: /var/run/docker.sock
+      name: dockersock
+      readOnly: true
+    - mountPath: /run/containerd/containerd.sock
+      name: containerdsock
+    - mountPath: /var/run/crio/crio.sock
+      name: criosock
+      readOnly: true
+    - mountPath: /var/lib/containers
+      name: criocontainer
+      readOnly: true
+    - mountPath: /var/log/pods
+      name: criologs
+      readOnly: true
+    - mountPath: /var/lib/docker
+      name: varlibdocker
+      readOnly: true
+    - mountPath: /sys
+      name: sys
+      readOnly: true
+    - mountPath: /dev/disk
+      name: devdisk
+      readOnly: true
+    - mountPath: /etc/amazon-cloudwatch-observability-agent-cert
+      name: agenttls
+      readOnly: true
+    - mountPath: /var/lib/kubelet/pod-resources
+      name: kubelet-podresources
+  volumes:
+    - name: kubelet-podresources
+      hostPath:
+        path: /var/lib/kubelet/pod-resources
+        type: Directory
+    - name: rootfs
+      hostPath:
+        path: /
+    - hostPath:
+        path: /var/run/docker.sock
+      name: dockersock
+    - hostPath:
+        path: /var/lib/docker
+      name: varlibdocker
+    - hostPath:
+        path: /run/containerd/containerd.sock
+      name: containerdsock
+    - hostPath:
+        path: /var/run/crio/crio.sock
+      name: criosock
+    - hostPath:
+        path: /var/lib/containers
+      name: criocontainer
+    - hostPath:
+        path: /var/log/pods
+      name: criologs
+    - hostPath:
+        path: /sys
+      name: sys
+    - hostPath:
+        path: /dev/disk/
+      name: devdisk
+    - name: agenttls
+      secret:
+        secretName: amazon-cloudwatch-observability-agent-cert
+        items:
+          - key: ca.crt
+            path: tls-ca.crt
+  env:
+    - name: K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: HOST_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: K8S_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: K8S_CLUSTER_NAME
+      value: "{{cluster_name}}"
+  tolerations:
+    - operator: Exists
+---
+apiVersion: cloudwatch.aws.amazon.com/v1alpha1
+kind: AmazonCloudWatchAgent
+metadata:
+  name: cloudwatch-agent-windows-container-insights
+  namespace: amazon-cloudwatch
+spec:
+  podSecurityContext:
+    windowsOptions:
+      hostProcess: true
+      runAsUserName: "NT AUTHORITY\\System"
+  hostNetwork: true
+  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
+  workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
+  mode: daemonset
+  serviceAccount: cloudwatch-agent
+  nodeSelector:
+    kubernetes.io/os: windows
+  config: "{\"agent\":{\"region\":\"{{region_name}}\"},\"logs\":{\"metrics_collected\":{\"kubernetes\":{\"cluster_name\":\"{{cluster_name}}\",\"enhanced_container_insights\":true}}}}"
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 128Mi
+  env:
+    - name: K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: HOST_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: K8S_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+    - name: RUN_IN_CONTAINER
+      value: "True"
+    - name: RUN_AS_HOST_PROCESS_CONTAINER
+      value: "True"
+  tolerations:
+    - operator: Exists
+---
+apiVersion: cloudwatch.aws.amazon.com/v1alpha1
+kind: AmazonCloudWatchAgent
+metadata:
+  name: cloudwatch-agent-windows
+  namespace: amazon-cloudwatch
+spec:
+  podSecurityContext:
+    windowsOptions:
+      runAsUserName: "NT AUTHORITY\\System"
+  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
+  mode: daemonset
+  serviceAccount: cloudwatch-agent
+  priorityClassName: system-node-critical
+  nodeSelector:
+    kubernetes.io/os: windows
+  config: "{\"agent\":{\"region\":\"{{region_name}}\"},\"logs\":{\"metrics_collected\":{\"application_signals\":{\"hosted_in\":\"{{cluster_name}}\"}}},\"traces\":{\"traces_collected\":{\"application_signals\":{}}}}"
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 250m
+      memory: 128Mi
+  env:
+    - name: K8S_NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: HOST_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: HOST_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: K8S_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
+  tolerations:
+    - operator: Exists
+---
 apiVersion: cloudwatch.aws.amazon.com/v1alpha1
 kind: DcgmExporter
 metadata:
@@ -1028,7 +1178,7 @@ metadata:
     k8s-app: dcgm-exporter
     version: v1
 spec:
-  image: nvcr.io/nvidia/k8s/dcgm-exporter:3.3.3-3.3.1-ubuntu22.04
+  image: nvcr.io/nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04
   nodeSelector:
     kubernetes.io/os: linux
   serviceAccount: dcgm-exporter-service-acct
@@ -1036,88 +1186,172 @@ spec:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
-        - matchExpressions:
-          - key: node.kubernetes.io/instance-type
-            operator: In
-            values: 
-                - p2.xlarge
-                - p2.8xlarge
-                - p2.16xlarge
-                - p3.2xlarge
-                - p3.8xlarge
-                - p3.16xlarge
-                - p3dn.24xlarge
-                - p4d.24xlarge
-                - p4de.24xlarge
-                - p5.48xlarge
-                - g3s.xlarge
-                - g3.4xlarge
-                - g3.8xlarge
-                - g3.16xlarge
-                - g4dn.xlarge
-                - g4dn.2xlarge
-                - g4dn.4xlarge
-                - g4dn.8xlarge
-                - g4dn.16xlarge
-                - g4dn.12xlarge
-                - g4dn.metal
-                - g4ad.xlarge
-                - g4ad.2xlarge
-                - g4ad.4xlarge
-                - g4ad.8xlarge
-                - g4ad.16xlarge
-                - g5.xlarge
-                - g5.2xlarge
-                - g5.4xlarge
-                - g5.8xlarge
-                - g5.16xlarge
-                - g5.12xlarge
-                - g5.24xlarge
-                - g5.48xlarge
-                - g5g.xlarge
-                - g5g.2xlarge
-                - g5g.4xlarge
-                - g5g.8xlarge
-                - g5g.16xlarge
-                - g5g.metal
+          - matchExpressions:
+              - key: node.kubernetes.io/instance-type
+                operator: In
+                values:
+                  - g3.4xlarge
+                  - g3.8xlarge
+                  - g3.16xlarge
+                  - g3s.xlarge
+                  - g4ad.2xlarge
+                  - g4ad.4xlarge
+                  - g4ad.8xlarge
+                  - g4ad.16xlarge
+                  - g4ad.xlarge
+                  - g4dn.2xlarge
+                  - g4dn.4xlarge
+                  - g4dn.8xlarge
+                  - g4dn.12xlarge
+                  - g4dn.16xlarge
+                  - g4dn.metal
+                  - g4dn.xlarge
+                  - g5.2xlarge
+                  - g5.4xlarge
+                  - g5.8xlarge
+                  - g5.12xlarge
+                  - g5.16xlarge
+                  - g5.24xlarge
+                  - g5.48xlarge
+                  - g5.xlarge
+                  - g5g.2xlarge
+                  - g5g.4xlarge
+                  - g5g.8xlarge
+                  - g5g.16xlarge
+                  - g5g.metal
+                  - g5g.xlarge
+                  - g6.2xlarge
+                  - g6.4xlarge
+                  - g6.8xlarge
+                  - g6.12xlarge
+                  - g6.16xlarge
+                  - g6.24xlarge
+                  - g6.48xlarge
+                  - g6.xlarge
+                  - g6e.2xlarge
+                  - g6e.4xlarge
+                  - g6e.8xlarge
+                  - g6e.12xlarge
+                  - g6e.16xlarge
+                  - g6e.24xlarge
+                  - g6e.48xlarge
+                  - g6e.xlarge
+                  - gr6.4xlarge
+                  - gr6.8xlarge
+                  - p2.8xlarge
+                  - p2.16xlarge
+                  - p2.xlarge
+                  - p3.2xlarge
+                  - p3.8xlarge
+                  - p3.16xlarge
+                  - p3dn.24xlarge
+                  - p4d.24xlarge
+                  - p4de.24xlarge
+                  - p5.48xlarge
+                  - p5e.48xlarge
+                  - p5en.48xlarge
+                  - ml.g3.4xlarge
+                  - ml.g3.8xlarge
+                  - ml.g3.16xlarge
+                  - ml.g3s.xlarge
+                  - ml.g4ad.2xlarge
+                  - ml.g4ad.4xlarge
+                  - ml.g4ad.8xlarge
+                  - ml.g4ad.16xlarge
+                  - ml.g4ad.xlarge
+                  - ml.g4dn.2xlarge
+                  - ml.g4dn.4xlarge
+                  - ml.g4dn.8xlarge
+                  - ml.g4dn.12xlarge
+                  - ml.g4dn.16xlarge
+                  - ml.g4dn.metal
+                  - ml.g4dn.xlarge
+                  - ml.g5.2xlarge
+                  - ml.g5.4xlarge
+                  - ml.g5.8xlarge
+                  - ml.g5.12xlarge
+                  - ml.g5.16xlarge
+                  - ml.g5.24xlarge
+                  - ml.g5.48xlarge
+                  - ml.g5.xlarge
+                  - ml.g5g.2xlarge
+                  - ml.g5g.4xlarge
+                  - ml.g5g.8xlarge
+                  - ml.g5g.16xlarge
+                  - ml.g5g.metal
+                  - ml.g5g.xlarge
+                  - ml.g6.2xlarge
+                  - ml.g6.4xlarge
+                  - ml.g6.8xlarge
+                  - ml.g6.12xlarge
+                  - ml.g6.16xlarge
+                  - ml.g6.24xlarge
+                  - ml.g6.48xlarge
+                  - ml.g6.xlarge
+                  - ml.g6e.2xlarge
+                  - ml.g6e.4xlarge
+                  - ml.g6e.8xlarge
+                  - ml.g6e.12xlarge
+                  - ml.g6e.16xlarge
+                  - ml.g6e.24xlarge
+                  - ml.g6e.48xlarge
+                  - ml.g6e.xlarge
+                  - ml.gr6.4xlarge
+                  - ml.gr6.8xlarge
+                  - ml.p2.8xlarge
+                  - ml.p2.16xlarge
+                  - ml.p2.xlarge
+                  - ml.p3.2xlarge
+                  - ml.p3.8xlarge
+                  - ml.p3.16xlarge
+                  - ml.p3dn.24xlarge
+                  - ml.p4d.24xlarge
+                  - ml.p4de.24xlarge
+                  - ml.p5.48xlarge
+                  - ml.p5e.48xlarge
+                  - ml.p5en.48xlarge
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                  - fargate
   resources:
+    limits:
+      cpu: 500m
+      memory: 500Mi
     requests:
       cpu: 250m
       memory: 128Mi
-    limits:
-      cpu: 500m
-      memory: 250Mi
   env:
-  - name: "DCGM_EXPORTER_KUBERNETES"
-    value: "true"
-  - name: "DCGM_EXPORTER_LISTEN"
-    value: ":9400"
-  - name: NODE_NAME
-    valueFrom:
-      fieldRef:
-        fieldPath: spec.nodeName
+    - name: "DCGM_EXPORTER_KUBERNETES"
+      value: "true"
+    - name: "DCGM_EXPORTER_LISTEN"
+      value: ":9400"
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
   ports:
-  - name: "metrics"
-    port: 9400
+    - name: "metrics"
+      port: 9400
   volumeMounts:
-  - name: "pod-gpu-resources"
-    readOnly: true
-    mountPath: "/var/lib/kubelet/pod-resources"
-  - mountPath: /etc/amazon-cloudwatch-observability-dcgm-cert
-    name: dcgmtls
-    readOnly: true
+    - name: "pod-gpu-resources"
+      readOnly: true
+      mountPath: "/var/lib/kubelet/pod-resources"
+    - mountPath: /etc/amazon-cloudwatch-observability-dcgm-cert
+      name: dcgmtls
+      readOnly: true
   volumes:
-  - name: dcgmtls
-    secret:
-      secretName: amazon-cloudwatch-observability-agent-cert
-      items:
-        - key: tls.crt
-          path: server.crt
-        - key:  tls.key
-          path: server.key
-  - name: "pod-gpu-resources"
-    hostPath:
-      path: /var/lib/kubelet/pod-resources
+    - name: dcgmtls
+      secret:
+        secretName: amazon-cloudwatch-observability-agent-cert
+        items:
+          - key: tls.crt
+            path: server.crt
+          - key: tls.key
+            path: server.key
+    - name: "pod-gpu-resources"
+      hostPath:
+        path: /var/lib/kubelet/pod-resources
   metricsConfig: |
     DCGM_FI_DEV_GPU_UTIL,      gauge, GPU utilization (in %).
     DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory utilization (in %).
@@ -1132,157 +1366,129 @@ spec:
     tls_server_config:
       cert_file: /etc/amazon-cloudwatch-observability-dcgm-cert/server.crt
       key_file: /etc/amazon-cloudwatch-observability-dcgm-cert/server.key
+  tolerations:
+    - operator: Exists
 ---
-
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  labels:
-    app.kubernetes.io/name: amazon-cloudwatch-observability
-    app.kubernetes.io/instance: amazon-cloudwatch-observability
-    app.kubernetes.io/version: "1.0.0"
-    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
-  name: amazon-cloudwatch-observability-selfsigned-issuer
-  namespace: amazon-cloudwatch
-spec:
-  selfSigned: { }
----
-
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  labels:
-    app.kubernetes.io/name: amazon-cloudwatch-observability
-    app.kubernetes.io/instance: amazon-cloudwatch-observability
-    app.kubernetes.io/version: "1.0.0"
-    app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
-  name: "agent-ca"
-  namespace: amazon-cloudwatch
-spec:
-  selfSigned: { }
----
-
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: amazon-cloudwatch/amazon-cloudwatch-observability-serving-cert
   labels:
     app.kubernetes.io/name: amazon-cloudwatch-observability
     app.kubernetes.io/instance: amazon-cloudwatch-observability
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
   name: amazon-cloudwatch-observability-mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: amazon-cloudwatch/amazon-cloudwatch-observability-serving-cert
 webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: amazon-cloudwatch-observability-webhook-service
-      namespace: amazon-cloudwatch
-      path: /mutate-cloudwatch-aws-amazon-com-v1alpha1-instrumentation
-  failurePolicy: Ignore
-  name: minstrumentation.kb.io
-  rules:
-  - apiGroups:
-    - cloudwatch.aws.amazon.com
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - instrumentations
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: amazon-cloudwatch-observability-webhook-service
-      namespace: amazon-cloudwatch
-      path: /mutate-cloudwatch-aws-amazon-com-v1alpha1-amazoncloudwatchagent
-  failurePolicy: Ignore
-  name: mamazoncloudwatchagent.kb.io
-  rules:
-  - apiGroups:
-    - cloudwatch.aws.amazon.com
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - amazoncloudwatchagents
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: amazon-cloudwatch-observability-webhook-service
-      namespace: amazon-cloudwatch
-      path: /mutate-v1-pod
-  failurePolicy: Ignore
-  name: mpod.kb.io
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - pods
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: amazon-cloudwatch-observability-webhook-service
-      namespace: amazon-cloudwatch
-      path: /mutate-v1-namespace
-  failurePolicy: Ignore
-  name: mnamespace.kb.io
-  rules:
-  - apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - namespaces
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: amazon-cloudwatch-observability-webhook-service
-      namespace: amazon-cloudwatch
-      path: /mutate-v1-workload
-  failurePolicy: Ignore
-  name: mworkload.kb.io
-  rules:
-  - apiGroups:
-    - apps
-    apiVersions:
-    - v1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - daemonsets
-    - deployments
-    - statefulsets
-  sideEffects: None
-  timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: amazon-cloudwatch-observability-webhook-service
+        namespace: amazon-cloudwatch
+        path: /mutate-cloudwatch-aws-amazon-com-v1alpha1-instrumentation
+    failurePolicy: Ignore
+    name: minstrumentation.kb.io
+    rules:
+      - apiGroups:
+          - cloudwatch.aws.amazon.com
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - instrumentations
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: amazon-cloudwatch-observability-webhook-service
+        namespace: amazon-cloudwatch
+        path: /mutate-cloudwatch-aws-amazon-com-v1alpha1-amazoncloudwatchagent
+    failurePolicy: Ignore
+    name: mamazoncloudwatchagent.kb.io
+    rules:
+      - apiGroups:
+          - cloudwatch.aws.amazon.com
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - amazoncloudwatchagents
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: amazon-cloudwatch-observability-webhook-service
+        namespace: amazon-cloudwatch
+        path: /mutate-v1-pod
+    failurePolicy: Ignore
+    name: mpod.kb.io
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - pods
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: amazon-cloudwatch-observability-webhook-service
+        namespace: amazon-cloudwatch
+        path: /mutate-v1-namespace
+    failurePolicy: Ignore
+    name: mnamespace.kb.io
+    rules:
+      - apiGroups:
+          - ""
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - namespaces
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: amazon-cloudwatch-observability-webhook-service
+        namespace: amazon-cloudwatch
+        path: /mutate-v1-workload
+    failurePolicy: Ignore
+    name: mworkload.kb.io
+    rules:
+      - apiGroups:
+          - apps
+        apiVersions:
+          - v1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - daemonsets
+          - deployments
+          - statefulsets
+    sideEffects: None
+    timeoutSeconds: 10
 ---
-
 apiVersion: cloudwatch.aws.amazon.com/v1alpha1
 kind: NeuronMonitor
 metadata:
@@ -1292,50 +1498,70 @@ metadata:
     k8s-app: neuron-monitor
     version: v1
 spec:
-  image: public.ecr.aws/neuron/neuron-monitor:1.0.0
+  image: public.ecr.aws/neuron/neuron-monitor:1.5.0
   serviceAccount: neuron-monitor-service-acct
+  nodeSelector:
+    kubernetes.io/os: linux
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
-            - key: kubernetes.io/os
-              operator: In
-              values:
-                - linux
-            - key: node.kubernetes.io/instance-type
-              operator: In
-              values: 
-                    - trn1.2xlarge
-                    - trn1.32xlarge
-                    - trn1n.32xlarge
-                    - inf1.xlarge
-                    - inf1.2xlarge
-                    - inf1.6xlarge
-                    - inf1.24xlarge
-                    - inf2.xlarge
-                    - inf2.8xlarge
-                    - inf2.24xlarge
-                    - inf2.48xlarge
+              - key: node.kubernetes.io/instance-type
+                operator: In
+                values:
+                  - trn1.2xlarge
+                  - trn1.32xlarge
+                  - trn1n.32xlarge
+                  - trn2.3xlarge
+                  - trn2.48xlarge
+                  - trn2a.48xlarge
+                  - trn2n.48xlarge
+                  - trn2u.48xlarge
+                  - inf1.xlarge
+                  - inf1.2xlarge
+                  - inf1.6xlarge
+                  - inf1.24xlarge
+                  - inf2.xlarge
+                  - inf2.8xlarge
+                  - inf2.24xlarge
+                  - inf2.48xlarge
+                  - ml.trn1.2xlarge
+                  - ml.trn1.32xlarge
+                  - ml.trn1n.32xlarge
+                  - ml.inf1.xlarge
+                  - ml.inf1.2xlarge
+                  - ml.inf1.6xlarge
+                  - ml.inf1.24xlarge
+                  - ml.inf2.xlarge
+                  - ml.inf2.8xlarge
+                  - ml.inf2.24xlarge
+                  - ml.inf2.48xlarge
+              - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                  - fargate
   resources:
     limits:
       cpu: 500m
-      memory: 256Mi
+      memory: 500Mi
     requests:
       cpu: 256m
       memory: 128Mi
   env:
-  - name: NODE_NAME
-    valueFrom:
-      fieldRef:
-        fieldPath: spec.nodeName
-  - name: PATH
-    value: /usr/local/bin:/usr/bin:/bin:/opt/aws/neuron/bin
+    - name: NODE_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: spec.nodeName
+    - name: PATH
+      value: /usr/local/bin:/usr/bin:/bin:/opt/aws/neuron/bin
+    - name: GOMEMLIMIT
+      value: 320MiB
   ports:
-  - name: "metrics"
-    port: 8000
+    - name: "metrics"
+      port: 8000
   command:
-  - "/opt/bin/entrypoint.sh"
+    - "/opt/bin/entrypoint.sh"
   args:
     port: "8000"
     cert-file: "/etc/amazon-cloudwatch-observability-neuron-cert/server.crt"
@@ -1343,18 +1569,24 @@ spec:
   securityContext:
     privileged: true
   volumeMounts:
-  - mountPath: /etc/amazon-cloudwatch-observability-neuron-cert/
-    name: neurontls
-    readOnly: true
+    - mountPath: /etc/amazon-cloudwatch-observability-neuron-cert/
+      name: neurontls
+      readOnly: true
+    - mountPath: /opt-aws
+      name: "aws-config"
+      readOnly: true
   volumes:
-  - name: neurontls
-    secret:
-      secretName: amazon-cloudwatch-observability-agent-cert
-      items:
-        - key: tls.crt
-          path: server.crt
-        - key: tls.key
-          path: server.key
+    - name: neurontls
+      secret:
+        secretName: amazon-cloudwatch-observability-agent-cert
+        items:
+          - key: tls.crt
+            path: server.crt
+          - key: tls.key
+            path: server.key
+    - name: "aws-config"
+      hostPath:
+        path: /opt/aws
   monitorConfig: |
     {
       "period": "5s",
@@ -1369,9 +1601,6 @@ spec:
               "type": "memory_used"
             },
             {
-              "type": "neuron_runtime_vcpu_usage"
-            },
-            {
               "type": "execution_stats"
             }
           ]
@@ -1379,107 +1608,105 @@ spec:
       ],
       "system_metrics": [
         {
-          "type": "memory_info"
-        },
-        {
           "period": "5s",
           "type": "neuron_hw_counters"
         }
       ]
     }
+  tolerations:
+    - operator: Exists
 ---
-
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: amazon-cloudwatch/amazon-cloudwatch-observability-serving-cert
   labels:
     app.kubernetes.io/name: amazon-cloudwatch-observability
     app.kubernetes.io/instance: amazon-cloudwatch-observability
     app.kubernetes.io/version: "1.0.0"
     app.kubernetes.io/managed-by: "amazon-cloudwatch-agent-operator"
   name: amazon-cloudwatch-observability-validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: amazon-cloudwatch/amazon-cloudwatch-observability-serving-cert
 webhooks:
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: amazon-cloudwatch-observability-webhook-service
-      namespace: amazon-cloudwatch
-      path: /validate-cloudwatch-aws-amazon-com-v1alpha1-instrumentation
-  failurePolicy: Ignore
-  name: vinstrumentationcreateupdate.kb.io
-  rules:
-  - apiGroups:
-    - cloudwatch.aws.amazon.com
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - instrumentations
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: amazon-cloudwatch-observability-webhook-service
-      namespace: amazon-cloudwatch
-      path: /validate-cloudwatch-aws-amazon-com-v1alpha1-instrumentation
-  failurePolicy: Ignore
-  name: vinstrumentationdelete.kb.io
-  rules:
-  - apiGroups:
-    - cloudwatch.aws.amazon.com
-    apiVersions:
-    - v1alpha1
-    operations:
-    - DELETE
-    resources:
-    - instrumentations
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: amazon-cloudwatch-observability-webhook-service
-      namespace: amazon-cloudwatch
-      path: /validate-cloudwatch-aws-amazon-com-v1alpha1-amazoncloudwatchagent
-  failurePolicy: Ignore
-  name: vamazoncloudwatchagentcreateupdate.kb.io
-  rules:
-  - apiGroups:
-    - cloudwatch.aws.amazon.com
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - amazoncloudwatchagents
-  sideEffects: None
-  timeoutSeconds: 10
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: amazon-cloudwatch-observability-webhook-service
-      namespace: amazon-cloudwatch
-      path: /validate-cloudwatch-aws-amazon-com-v1alpha1-amazoncloudwatchagent
-  failurePolicy: Ignore
-  name: vamazoncloudwatchagentdelete.kb.io
-  rules:
-  - apiGroups:
-    - cloudwatch.aws.amazon.com
-    apiVersions:
-    - v1alpha1
-    operations:
-    - DELETE
-    resources:
-    - amazoncloudwatchagents
-  sideEffects: None
-  timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: amazon-cloudwatch-observability-webhook-service
+        namespace: amazon-cloudwatch
+        path: /validate-cloudwatch-aws-amazon-com-v1alpha1-instrumentation
+    failurePolicy: Ignore
+    name: vinstrumentationcreateupdate.kb.io
+    rules:
+      - apiGroups:
+          - cloudwatch.aws.amazon.com
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - instrumentations
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: amazon-cloudwatch-observability-webhook-service
+        namespace: amazon-cloudwatch
+        path: /validate-cloudwatch-aws-amazon-com-v1alpha1-instrumentation
+    failurePolicy: Ignore
+    name: vinstrumentationdelete.kb.io
+    rules:
+      - apiGroups:
+          - cloudwatch.aws.amazon.com
+        apiVersions:
+          - v1alpha1
+        operations:
+          - DELETE
+        resources:
+          - instrumentations
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: amazon-cloudwatch-observability-webhook-service
+        namespace: amazon-cloudwatch
+        path: /validate-cloudwatch-aws-amazon-com-v1alpha1-amazoncloudwatchagent
+    failurePolicy: Ignore
+    name: vamazoncloudwatchagentcreateupdate.kb.io
+    rules:
+      - apiGroups:
+          - cloudwatch.aws.amazon.com
+        apiVersions:
+          - v1alpha1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - amazoncloudwatchagents
+    sideEffects: None
+    timeoutSeconds: 10
+  - admissionReviewVersions:
+      - v1
+    clientConfig:
+      service:
+        name: amazon-cloudwatch-observability-webhook-service
+        namespace: amazon-cloudwatch
+        path: /validate-cloudwatch-aws-amazon-com-v1alpha1-amazoncloudwatchagent
+    failurePolicy: Ignore
+    name: vamazoncloudwatchagentdelete.kb.io
+    rules:
+      - apiGroups:
+          - cloudwatch.aws.amazon.com
+        apiVersions:
+          - v1alpha1
+        operations:
+          - DELETE
+        resources:
+          - amazoncloudwatchagents
+    sideEffects: None
+    timeoutSeconds: 10

--- a/k8s-quickstart/cwagent-version.yaml
+++ b/k8s-quickstart/cwagent-version.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cloudwatch-agent
   namespace: amazon-cloudwatch
 spec:
-  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300056.0b1123
+  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
   mode: daemonset
   nodeSelector:
     kubernetes.io/os: linux

--- a/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-daemonset.yaml
+++ b/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-daemonset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -42,7 +42,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.0.1"
+              value: "k8s/1.3.35"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig

--- a/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-daemonset.yaml
+++ b/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-daemonset.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           imagePullPolicy: Always
           ports:
             # containerPort should be consistent with the listen port defined in configmap

--- a/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-deployment.yaml
+++ b/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-yaml-templates/fluentd/fluentd.yaml
+++ b/k8s-yaml-templates/fluentd/fluentd.yaml
@@ -378,7 +378,7 @@ spec:
           command: ['sh','-c','']
       containers:
         - name: fluentd-cloudwatch
-          image: fluent/fluentd-kubernetes-daemonset:v1.7.3-debian-cloudwatch-1.0
+          image: fluent/fluentd-kubernetes-daemonset:v1.10.3-debian-cloudwatch-1.0
           env:
             - name: REGION
               valueFrom:
@@ -391,7 +391,7 @@ spec:
                   name: cluster-info
                   key: cluster.name
             - name: CI_VERSION
-              value: "k8s/1.3.13"
+              value: "k8s/1.3.35"
           resources:
             limits:
               memory: 400Mi

--- a/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml
@@ -107,7 +107,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300032.3b392
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -134,7 +134,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.13"
+              value: "k8s/1.3.35"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig
@@ -583,7 +583,7 @@ spec:
                   name: cluster-info
                   key: cluster.name
             - name: CI_VERSION
-              value: "k8s/1.3.13"
+              value: "k8s/1.3.35"
           resources:
             limits:
               memory: 400Mi


### PR DESCRIPTION
# Description of the issue
Update the agent version to 1.300057.0b1161

`container-insights-manifest-update.sh` script, which is intended to update all sample files with the latest agent, Kubernetes, and Fluent (D/Bit) versions, is not updating all files as expected. After running the script, several files still reference an older version of the agent.

# Description of changes
- CWAgent was deployed with this version to ECR: https://gallery.ecr.aws/cloudwatch-agent/cloudwatch-agent.
- `container-insights-manifest-update.sh`: use `find` to look up files (`yaml` and `json`) rather then using directory prefixes. Also update stale files after updating the script. 
- Update `k8s-quickstart/cwagent-custom-resource-definitions.yaml` and `k8s-quickstart/cwagent-operator-rendered.yaml` to apply the latest changes to cloduwatch agent observability resources from https://github.com/aws-observability/helm-charts


# License
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._

# Tests
```
docker pull public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
1.300057.0b1161: Pulling from cloudwatch-agent/cloudwatch-agent
a4e9c760a1ee: Pull complete 
9b242823c4f3: Pull complete 
c78c05a45a46: Pull complete 
Digest: sha256:dd64abc867a303207ffc59403f01cc414c98a581fe3c23a5645ea074382a7f8d
Status: Downloaded newer image for public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.0b1161
```

```
## before the change
[11:34:48]➜  ~/works/workspace/other/amazon-cloudwatch-container-insights git:(main) ./container-insights-manifest-update.sh 
[11:35:26]➜  ~/works/workspace/other/amazon-cloudwatch-container-insights git:(main) ✗ gst | wc -l                            
      29

## after the change
[11:33:43]➜  ~/works/workspace/other/amazon-cloudwatch-container-insights git:(update-version-script) ./container-insights-manifest-update.sh 
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd-configmap.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cloudwatch-namespace.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-windows.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart-enhanced.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-enhanced.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-configmap-enhanced.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-serviceaccount.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset-windows.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-configmap.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-configmap.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-windows.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-fluentd-xray/cwagent-fluentd-xray-quickstart.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/combination/combination.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-statsd/cwagent-statsd.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/sidecar/combination/combination.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-windows-exporter.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-fargate.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_windows_exporter/sample-net-app.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_windows_exporter/windows-exporter.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/javajmx/cw_dashboard_javajmx.json
Processing ./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/redis/cw_dashboard_redis.json
Processing ./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/nginx-ingress/cw_dashboard_nginx_ingress_controller.json
Processing ./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/haproxy-ingress/cw_dashboard_haproxy_ingress.json
Processing ./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/appmesh/cw_dashboard_awsappmesh.json
Processing ./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/kubernetes_api_server/cw_dashboard_kubernetes_api_server.json
Processing ./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/memcached/cw_dashboard_memcached.json
Processing ./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_cloudwatch_dashboards/fluent-bit/cw_dashboard_fluent_bit.json
Processing ./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_traffic/redis/redis-traffic-sample.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_traffic/nginx-traffic/nginx-traffic-sample.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-k8s.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/service/combination/combination.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
Processing ./k8s-deployment-manifest-templates/deployment-mode/service/cwagent-statsd/cwagent-statsd.yaml
Processing ./k8s-yaml-templates/fluentd/fluentd-configmap.yaml
Processing ./k8s-yaml-templates/fluentd/fluentd.yaml
Processing ./k8s-yaml-templates/cloudwatch-namespace.yaml
Processing ./k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml
Processing ./k8s-yaml-templates/cwagent-statsd/cwagent-statsd-configmap.yaml
Processing ./k8s-yaml-templates/cwagent-statsd/cwagent-statsd-daemonset.yaml
Processing ./k8s-yaml-templates/cwagent-statsd/cwagent-statsd-deployment.yaml
Processing ./k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-daemonset.yaml
Processing ./k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-serviceaccount.yaml
Processing ./k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-configmap.yaml
Processing ./k8s-quickstart/cwagent-version.yaml
Processing ./k8s-quickstart/cwagent-custom-resource-definitions.yaml
Processing ./k8s-quickstart/cwagent-operator-rendered.yaml
Processing ./ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json
Processing ./ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cwagent-ecs-instance-metric.json
Processing ./ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-ec2.json
Processing ./ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-fargate.json
Processing ./ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-ec2.json
Processing ./ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-fargate.json
Processing ./ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-ec2.json
Processing ./ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-fargate.json
Processing ./ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-fargate.json
Processing ./ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-ec2.json
Processing ./ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_cloudwatch_dashboards/javajmx/cw_dashboard_javajmx.json
Processing ./ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_cloudwatch_dashboards/redis/cw_dashboard_redis.json
Processing ./ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_cloudwatch_dashboards/appmesh/cw_dashboard_awsappmesh.json
Processing ./ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_cloudwatch_dashboards/memcached/cw_dashboard_memcached.json
Processing ./ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_traffic/redis/redis-traffic-sample.yaml
Processing ./ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/sample_traffic/memcached/memcached-traffic-sample.yaml
Processing ./ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cwagent-prometheus-task-definition.json
Processing ./ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
Processing ./ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
Version and manifest updates completed successfully!

[11:34:02]➜  ~/works/workspace/other/amazon-cloudwatch-container-insights git:(update-version-script) ✗ gst | wc -l
      53

```

# Requirements
_Before committing the code, please verify the following:_

- If this commit includes changes to existing sample configurations, you acknowledge that you have confirmed this will not impact existing customer behavior.
- If not necessary, consider creating a new sample configuration for this change.

