### PR TITLE
Add permissions to list, watch & get PV, PVC and Ingresses

### DIFF
--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/combination/combination.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/combination/combination.yaml
@@ -47,6 +47,12 @@ rules:
   - apiGroups: [ "discovery.k8s.io" ]
     resources: [ "endpointslices" ]
     verbs: [ "list", "watch", "get" ]
+  - apiGroups: [ "networking.k8s.io" ]
+    resources: [ "ingresses" ]
+    verbs: [ "list", "watch", "get" ]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims", "persistentvolumes" ]
+    verbs: [ "get", "list", "watch" ]
 
 ---
 kind: ClusterRoleBinding

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-serviceaccount.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-serviceaccount.yaml
@@ -38,6 +38,12 @@ rules:
   - apiGroups: [ "discovery.k8s.io" ]
     resources: [ "endpointslices" ]
     verbs: [ "list", "watch", "get" ]
+  - apiGroups: [ "networking.k8s.io" ]
+    resources: [ "ingresses" ]
+    verbs: [ "list", "watch", "get" ]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims", "persistentvolumes" ]
+    verbs: [ "get", "list", "watch" ]
 
 ---
 kind: ClusterRoleBinding

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-enhanced.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-enhanced.yaml
@@ -47,6 +47,12 @@ rules:
   - apiGroups: [ "discovery.k8s.io" ]
     resources: [ "endpointslices" ]
     verbs: [ "list", "watch", "get" ]
+  - apiGroups: [ "networking.k8s.io" ]
+    resources: [ "ingresses" ]
+    verbs: [ "list", "watch", "get" ]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims", "persistentvolumes" ]
+    verbs: [ "get", "list", "watch" ]
 
 ---
 kind: ClusterRoleBinding

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
@@ -47,6 +47,12 @@ rules:
   - apiGroups: [ "discovery.k8s.io" ]
     resources: [ "endpointslices" ]
     verbs: [ "list", "watch", "get" ]
+  - apiGroups: [ "networking.k8s.io" ]
+    resources: [ "ingresses" ]
+    verbs: [ "list", "watch", "get" ]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims", "persistentvolumes" ]
+    verbs: [ "get", "list", "watch" ]
 
 ---
 kind: ClusterRoleBinding

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart-enhanced.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart-enhanced.yaml
@@ -47,6 +47,12 @@ rules:
   - apiGroups: [ "discovery.k8s.io" ]
     resources: [ "endpointslices" ]
     verbs: [ "list", "watch", "get" ]
+  - apiGroups: [ "networking.k8s.io" ]
+    resources: [ "ingresses" ]
+    verbs: [ "list", "watch", "get" ]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims", "persistentvolumes" ]
+    verbs: [ "get", "list", "watch" ]
 
 ---
 kind: ClusterRoleBinding

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
@@ -47,6 +47,12 @@ rules:
   - apiGroups: [ "discovery.k8s.io" ]
     resources: [ "endpointslices" ]
     verbs: [ "list", "watch", "get" ]
+  - apiGroups: [ "networking.k8s.io" ]
+    resources: [ "ingresses" ]
+    verbs: [ "list", "watch", "get" ]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims", "persistentvolumes" ]
+    verbs: [ "get", "list", "watch" ]
 
 ---
 kind: ClusterRoleBinding

--- a/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-serviceaccount.yaml
+++ b/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-serviceaccount.yaml
@@ -38,6 +38,12 @@ rules:
   - apiGroups: [ "discovery.k8s.io" ]
     resources: [ "endpointslices" ]
     verbs: [ "list", "watch", "get" ]
+  - apiGroups: [ "networking.k8s.io" ]
+    resources: [ "ingresses" ]
+    verbs: [ "list", "watch", "get" ]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims", "persistentvolumes" ]
+    verbs: [ "get", "list", "watch" ]
 
 ---
 kind: ClusterRoleBinding

--- a/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml
@@ -47,6 +47,12 @@ rules:
   - apiGroups: [ "discovery.k8s.io" ]
     resources: [ "endpointslices" ]
     verbs: [ "list", "watch", "get" ]
+  - apiGroups: [ "networking.k8s.io" ]
+    resources: [ "ingresses" ]
+    verbs: [ "list", "watch", "get" ]
+  - apiGroups: [ "" ]
+    resources: [ "persistentvolumeclaims", "persistentvolumes" ]
+    verbs: [ "get", "list", "watch" ]
 
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
This PR adds permission so the agent can pick up metrics implemented in these two PRs:
- https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/339
- https://github.com/amazon-contributing/opentelemetry-collector-contrib/pull/346

