### PR TITLE
Update ECS samples for the agent being essential container

### DIFF
--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
@@ -225,7 +225,7 @@ Resources:
       ContainerDefinitions:
         - Name: cloudwatch-agent-prometheus
           Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.1b1167
-          Essential: true
+          Essential: true # Set to false if you want the task to continue to run even when the agent fails
           MountPoints: []
           PortMappings: []
           Environment: []

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
@@ -220,7 +220,7 @@ Resources:
       ContainerDefinitions:
         - Name: cloudwatch-agent-prometheus
           Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.1b1167
-          Essential: true
+          Essential: true # Set to false if you want the task to continue to run even when the agent fails
           MountPoints: []
           PortMappings: []
           Environment: []

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cwagent-prometheus-task-definition.json
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cwagent-prometheus-task-definition.json
@@ -7,7 +7,6 @@
     {
       "name": "cloudwatch-agent-prometheus",
       "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300057.1b1167",
-      "essential": true,
       "mountPoints": [
       ],
       "portMappings": [


### PR DESCRIPTION
# Description of changes
- Add a comment explaining how to make the agent non-essential based on requirements
- Update JSON configuration file ([cwagent-prometheus-task-definition.json](https://github.com/aws-samples/amazon-cloudwatch-container-insights/pull/196/files#diff-a4a964bb26ab9e1a8b5d6aa02a5fee6006424506f12d382f1b2c927885d87553)) to remove the explicit `essential` field setting. This is to maintain consistency across JSON samples for ECS. The [public documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/deploy-container-insights-ECS-instancelevel.html) now includes a note about configuring the agent as a non-essential container when availability is a concern.

# License
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._

# Requirements
_Before committing the code, please verify the following:_

- If this commit includes changes to existing sample configurations, you acknowledge that you have confirmed this will not impact existing customer behavior.
- If not necessary, consider creating a new sample configuration for this change.

