### PR TITLE
Update K8s version to 1.3.41 and CWA version to 1.300064.1b1344

### DIFF
--- a/container-insights-manifest-update.sh
+++ b/container-insights-manifest-update.sh
@@ -3,8 +3,8 @@
 cd "$(dirname "$0")"
 
 # Version definitions
-newK8sVersion="k8s/1.3.40"
-agentVersion="public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337"
+newK8sVersion="k8s/1.3.41"
+agentVersion="public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344"
 fluentdVersion="fluent/fluentd-kubernetes-daemonset:v1.10.3-debian-cloudwatch-1.0"
 fluentBitVersion="public.ecr.aws/aws-observability/aws-for-fluent-bit:3.0.1"
 fluentBitWindowsVersion="public.ecr.aws/aws-observability/aws-for-fluent-bit:windowsservercore-stable"

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cloudformation-quickstart/cwagent-ecs-instance-metric-cfn.json
@@ -105,7 +105,7 @@
         "ContainerDefinitions": [
           {
             "Name": "cloudwatch-agent",
-            "Image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337",
+            "Image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344",
             "MountPoints": [
               {
                 "ReadOnly": true,

--- a/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cwagent-ecs-instance-metric.json
+++ b/ecs-task-definition-templates/deployment-mode/daemon-service/cwagent-ecs-instance-metric/cwagent-ecs-instance-metric.json
@@ -6,7 +6,7 @@
   "containerDefinitions": [
     {
       "name": "cloudwatch-agent",
-      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337",
+      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344",
       "mountPoints": [
         {
           "readOnly": true,

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-awsvpc.yaml
@@ -224,7 +224,7 @@ Resources:
       NetworkMode: awsvpc
       ContainerDefinitions:
         - Name: cloudwatch-agent-prometheus
-          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           Essential: true # Set to false if you want the task to continue to run even when the agent fails
           MountPoints: []
           PortMappings: []

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cloudformation-quickstart/cwagent-ecs-prometheus-metric-for-bridge-host.yaml
@@ -219,7 +219,7 @@ Resources:
       NetworkMode: !Ref ECSNetworkMode
       ContainerDefinitions:
         - Name: cloudwatch-agent-prometheus
-          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          Image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           Essential: true # Set to false if you want the task to continue to run even when the agent fails
           MountPoints: []
           PortMappings: []

--- a/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cwagent-prometheus-task-definition.json
+++ b/ecs-task-definition-templates/deployment-mode/replica-service/cwagent-prometheus/cwagent-prometheus-task-definition.json
@@ -6,7 +6,7 @@
   "containerDefinitions": [
     {
       "name": "cloudwatch-agent-prometheus",
-      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337",
+      "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344",
       "mountPoints": [
       ],
       "portMappings": [

--- a/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-ec2.json
@@ -22,7 +22,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/combination/combination-fargate.json
@@ -19,7 +19,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-ec2.json
@@ -22,7 +22,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf-fargate.json
@@ -19,7 +19,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-ec2.json
@@ -22,7 +22,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics-fargate.json
@@ -19,7 +19,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-ec2.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-ec2.json
@@ -27,7 +27,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-fargate.json
+++ b/ecs-task-definition-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd-fargate.json
@@ -24,7 +24,7 @@
         },
         {
             "name": "cloudwatch-agent",
-            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337",
+            "image": "public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344",
             "secrets": [
                 {
                     "name": "CW_CONFIG_CONTENT",

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/combination/combination.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/combination/combination.yaml
@@ -121,7 +121,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           ports:
             - containerPort: 8125
               hostPort: 8125

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset-windows.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset-windows.yaml
@@ -20,7 +20,7 @@ spec:
       hostNetwork: true
       containers:
       - name: cloudwatch-agent
-        image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+        image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
         workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
         volumeMounts:
         - name: cwagentconfig
@@ -47,7 +47,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: CI_VERSION
-            value: "k8s/1.3.40"
+            value: "k8s/1.3.41"
           - name: CWAGENT_LOG_LEVEL
             value: DEBUG
           - name: RUN_IN_CONTAINER

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/cwagent/cwagent-daemonset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -42,7 +42,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-compatible.yaml
@@ -331,7 +331,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
         resources:
             limits:
               memory: 200Mi

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-windows.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit-windows.yaml
@@ -205,7 +205,7 @@ spec:
               apiVersion: v1
               fieldPath: metadata.name
         - name: CI_VERSION
-          value: "k8s/1.3.40"
+          value: "k8s/1.3.41"
         resources:
             limits:
               cpu: 500m

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluent-bit/fluent-bit.yaml
@@ -315,7 +315,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.name
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
         resources:
             limits:
               memory: 200Mi

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/fluentd/fluentd.yaml
@@ -398,7 +398,7 @@ spec:
                   name: cluster-info
                   key: cluster.name
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
             - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
               value: /^(?<time>.+) (?<stream>stdout|stderr) (?<logtag>[FP]) (?<log>.*)$/
           resources:

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-enhanced.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-enhanced.yaml
@@ -107,7 +107,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -134,7 +134,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig
@@ -521,7 +521,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.name
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
         resources:
             limits:
               memory: 200Mi

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-windows.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart-windows.yaml
@@ -20,7 +20,7 @@ spec:
       hostNetwork: true
       containers:
       - name: cloudwatch-agent
-        image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+        image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
         workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
         volumeMounts:
         - name: cwagentconfig
@@ -47,7 +47,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: CI_VERSION
-            value: "k8s/1.3.40"
+            value: "k8s/1.3.41"
           - name: CWAGENT_LOG_LEVEL
             value: DEBUG
           - name: RUN_IN_CONTAINER
@@ -271,7 +271,7 @@ spec:
               apiVersion: v1
               fieldPath: metadata.name
         - name: CI_VERSION
-          value: "k8s/1.3.40"
+          value: "k8s/1.3.41"
         resources:
             limits:
               cpu: 500m

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluent-bit-quickstart.yaml
@@ -106,7 +106,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -133,7 +133,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig
@@ -520,7 +520,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.name
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
         resources:
             limits:
               memory: 200Mi

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart-enhanced.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart-enhanced.yaml
@@ -107,7 +107,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -134,7 +134,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig
@@ -598,7 +598,7 @@ spec:
                   name: cluster-info
                   key: cluster.name
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
             - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
               value: /^(?<time>.+) (?<stream>stdout|stderr) (?<logtag>[FP]) (?<log>.*)$/
           resources:

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/container-insights-monitoring/quickstart/cwagent-fluentd-quickstart.yaml
@@ -106,7 +106,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -133,7 +133,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig
@@ -597,7 +597,7 @@ spec:
                   name: cluster-info
                   key: cluster.name
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
             - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
               value: /^(?<time>.+) (?<stream>stdout|stderr) (?<logtag>[FP]) (?<log>.*)$/
           resources:

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-fluentd-xray/cwagent-fluentd-xray-quickstart.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-fluentd-xray/cwagent-fluentd-xray-quickstart.yaml
@@ -49,7 +49,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           ports:
             - containerPort: 25888
               hostPort: 25888

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
@@ -39,7 +39,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           imagePullPolicy: Always
           ports:
             - containerPort: 31000

--- a/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-statsd/cwagent-statsd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/daemonset/cwagent-statsd/cwagent-statsd.yaml
@@ -25,7 +25,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           imagePullPolicy: Always
           ports:
             # containerPort should be consistent with the listen port defined in configmap

--- a/k8s-deployment-manifest-templates/deployment-mode/service/combination/combination.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/combination/combination.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-fargate.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-fargate.yaml
@@ -398,7 +398,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           imagePullPolicy: Always
           resources:
             limits:
@@ -410,7 +410,7 @@ spec:
           # Please don't change below envs
           env:
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
             - name: RUN_IN_AWS
               value: "True"
           # Please don't change the mountPath

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-windows-exporter.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks-windows-exporter.yaml
@@ -145,7 +145,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           imagePullPolicy: Always
           resources:
             limits:
@@ -157,7 +157,7 @@ spec:
           # Please don't change below envs
           env:
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
           # Please don't change the mountPath
           volumeMounts:
             - name: prometheus-cwagentconfig

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-eks.yaml
@@ -449,7 +449,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           imagePullPolicy: Always
           resources:
             limits:
@@ -461,7 +461,7 @@ spec:
           # Please don't change below envs
           env:
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
           # Please don't change the mountPath
           volumeMounts:
             - name: prometheus-cwagentconfig

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-k8s.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/prometheus-k8s.yaml
@@ -396,7 +396,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           imagePullPolicy: Always
           resources:
             limits:
@@ -408,7 +408,7 @@ spec:
           # Please don't change below envs
           env:
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
           # Please don't change the mountPath
           volumeMounts:
             - name: prometheus-cwagentconfig

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
@@ -40,7 +40,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-statsd/cwagent-statsd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-statsd/cwagent-statsd.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/combination/combination.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/combination/combination.yaml
@@ -24,7 +24,7 @@ spec:
           - name: AWS_CSM_HOST
             value: "127.0.0.1"
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-emf/cwagent-emf.yaml
@@ -17,7 +17,7 @@ spec:
           image: <demo-app-docker-image> # this is the your demo app docker image
           imagePullPolicy: Always
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           imagePullPolicy: Always
           env:
             - name: POD_NAME

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-sdkmetrics/cwagent-sdkmetrics.yaml
@@ -42,7 +42,7 @@ spec:
     - name: AWS_CSM_HOST
       value: "127.0.0.1"
   - name: cloudwatch-agent
-    image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+    image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
     imagePullPolicy: Always
     resources:
       limits:

--- a/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd.yaml
+++ b/k8s-deployment-manifest-templates/deployment-mode/sidecar/cwagent-statsd/cwagent-statsd.yaml
@@ -19,7 +19,7 @@ spec:
           args: ["-c", "while true; do echo 'statsdTestMetric:1|c' | socat -v -t 0 - UDP:127.0.0.1:8125; sleep 1; done"]
           imagePullPolicy: Always
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-quickstart/cwagent-operator-rendered.yaml
+++ b/k8s-quickstart/cwagent-operator-rendered.yaml
@@ -762,7 +762,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.name
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
           resources:
             limits:
               cpu: 500m
@@ -878,7 +878,7 @@ spec:
                   apiVersion: v1
                   fieldPath: metadata.name
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
           resources:
             limits:
               cpu: 500m
@@ -971,7 +971,7 @@ spec:
     rollingUpdate:
       maxUnavailable: 1
       maxSurge: 0
-  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
   mode: daemonset
   replicas: 1
   nodeSelector:
@@ -1099,7 +1099,7 @@ spec:
       hostProcess: true
       runAsUserName: "NT AUTHORITY\\System"
   hostNetwork: true
-  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
   workingDir: "%CONTAINER_SANDBOX_MOUNT_POINT%\\Program Files\\Amazon\\AmazonCloudWatchAgent"
   mode: daemonset
   serviceAccount: cloudwatch-agent
@@ -1146,7 +1146,7 @@ spec:
   podSecurityContext:
     windowsOptions:
       runAsUserName: "NT AUTHORITY\\System"
-  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
   mode: daemonset
   serviceAccount: cloudwatch-agent
   priorityClassName: system-node-critical

--- a/k8s-quickstart/cwagent-version.yaml
+++ b/k8s-quickstart/cwagent-version.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cloudwatch-agent
   namespace: amazon-cloudwatch
 spec:
-  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+  image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
   mode: daemonset
   nodeSelector:
     kubernetes.io/os: linux

--- a/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-daemonset.yaml
+++ b/k8s-yaml-templates/cwagent-kubernetes-monitoring/cwagent-daemonset.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -42,7 +42,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig

--- a/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-daemonset.yaml
+++ b/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-daemonset.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           imagePullPolicy: Always
           ports:
             # containerPort should be consistent with the listen port defined in configmap

--- a/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-deployment.yaml
+++ b/k8s-yaml-templates/cwagent-statsd/cwagent-statsd-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           imagePullPolicy: Always
           resources:
             limits:

--- a/k8s-yaml-templates/fluentd/fluentd.yaml
+++ b/k8s-yaml-templates/fluentd/fluentd.yaml
@@ -391,7 +391,7 @@ spec:
                   name: cluster-info
                   key: cluster.name
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
           resources:
             limits:
               memory: 400Mi

--- a/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml
+++ b/k8s-yaml-templates/quickstart/cwagent-fluentd-quickstart.yaml
@@ -107,7 +107,7 @@ spec:
     spec:
       containers:
         - name: cloudwatch-agent
-          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.0b1337
+          image: public.ecr.aws/cloudwatch-agent/cloudwatch-agent:1.300064.1b1344
           #ports:
           #  - containerPort: 8125
           #    hostPort: 8125
@@ -134,7 +134,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
           # Please don't change the mountPath
           volumeMounts:
             - name: cwagentconfig
@@ -583,7 +583,7 @@ spec:
                   name: cluster-info
                   key: cluster.name
             - name: CI_VERSION
-              value: "k8s/1.3.40"
+              value: "k8s/1.3.41"
           resources:
             limits:
               memory: 400Mi


### PR DESCRIPTION
# Description of the issue
Update K8s version to 1.3.41 and CWA version to 1.300064.1b1344


# License
_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._


- If this commit includes changes to existing sample configurations, you acknowledge that you have confirmed this will not impact existing customer behavior.
- If not necessary, consider creating a new sample configuration for this change.

